### PR TITLE
No changes, just reformat to standard HTML formatting

### DIFF
--- a/templates/.html
+++ b/templates/.html
@@ -1,10 +1,18 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"/>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon" />
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -19,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png" />
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br />
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -38,14 +52,16 @@
     <hr />
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">undefined <small class="text-muted">[undefined] <a href="../pdfs/.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">undefined <small class="text-muted">[undefined] <a href="../pdfs/.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
@@ -55,31 +71,45 @@
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
     <ul id="conformance" class="list-group"></ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
+    </ul>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
 
-</body></html>
+</body>
+
+</html>

--- a/templates/1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html
+++ b/templates/1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,93 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Chief Complaint Section <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1, open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Chief Complaint Section <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1, open]
+        <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section records the patient's chief complaint (the patient's own description).</p></div>
+    <div id="description">
+      <p>This section records the patient's chief complaint (the patient's own description).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7832)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1"</b><b> (CONF:81-10453)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15451)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10154-3"</b> Chief Complaint<b> (CONF:81-15452)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26474)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7834)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7835)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7832)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1"</b><b>
+              (CONF:81-10453)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15451)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10154-3"</b> Chief Complaint<b>
+              (CONF:81-15452)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26474)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7834)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7835)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Chief%20Complaint%20Section_1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1/Chief%20Complaint%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Chief Complaint Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Chief%20Complaint%20Section_1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1/Chief%20Complaint%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Chief Complaint Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/1.3.6.1.4.1.19376.1.5.3.1.3.1.html
+++ b/templates/1.3.6.1.4.1.19376.1.5.3.1.3.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,101 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Reason for Referral Section (V2) <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.1, release 2014-06-09, open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Reason for Referral Section (V2) <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.1,
+        release 2014-06-09, open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.1.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section describes the clinical reason why a provider is sending a patient to another provider for care. The reason for referral may become the reason for visit documented by the receiving provider.</p></div>
+    <div id="description">
+      <p>This section describes the clinical reason why a provider is sending a patient to another provider for care.
+        The reason for referral may become the reason for visit documented by the receiving provider.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.140.html">Patient Referral Act</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.140.html">Patient Referral Act</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7844)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.1"</b><b> (CONF:1098-10468)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32571)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15427)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42349-1"</b> Reason for Referral<b> (CONF:1098-15428)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30867)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7846)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7847)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-30808)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Patient Referral Act<b> (identifier: 2.16.840.1.113883.10.20.22.4.140)</b><b> (CONF:1098-30897)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7844)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.1"</b><b>
+              (CONF:1098-10468)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32571)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15427)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42349-1"</b> Reason for Referral<b>
+              (CONF:1098-15428)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30867)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7846)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7847)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-30808)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Patient Referral Act<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.140)</b><b> (CONF:1098-30897)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Reason%20for%20Referral%20Section%20(V2)_1.3.6.1.4.1.19376.1.5.3.1.3.1/Reason%20for%20Referral%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Reason for Referral Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Reason%20for%20Referral%20Section%20(V2)_1.3.6.1.4.1.19376.1.5.3.1.3.1/Reason%20for%20Referral%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Reason for Referral Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/1.3.6.1.4.1.19376.1.5.3.1.3.18.html
+++ b/templates/1.3.6.1.4.1.19376.1.5.3.1.3.18.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,97 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Review of Systems Section <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.18, open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.18.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Review of Systems Section <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.18, open]
+        <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.18.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Review of Systems Section contains a relevant collection of symptoms and functions systematically gathered by a clinician. It includes symptoms the patient is currently experiencing, some of which were not elicited during the history of present illness, as well as a potentially large number of pertinent negatives, for example, symptoms that the patient denied experiencing.</p></div>
+    <div id="description">
+      <p>The Review of Systems Section contains a relevant collection of symptoms and functions systematically gathered
+        by a clinician. It includes symptoms the patient is currently experiencing, some of which were not elicited
+        during the history of present illness, as well as a potentially large number of pertinent negatives, for
+        example, symptoms that the patient denied experiencing.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7812)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.18"</b><b> (CONF:81-10469)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15435)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10187-3"</b> Review of Systems<b> (CONF:81-15436)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26495)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7814)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7815)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7812)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.18"</b><b>
+              (CONF:81-10469)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15435)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10187-3"</b> Review of Systems<b>
+              (CONF:81-15436)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26495)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7814)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7815)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Review%20of%20Systems%20Section_1.3.6.1.4.1.19376.1.5.3.1.3.18/Review%20of%20Systems%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Review of Systems Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Review%20of%20Systems%20Section_1.3.6.1.4.1.19376.1.5.3.1.3.18/Review%20of%20Systems%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Review of Systems Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/1.3.6.1.4.1.19376.1.5.3.1.3.26.html
+++ b/templates/1.3.6.1.4.1.19376.1.5.3.1.3.26.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,89 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Hospital Discharge Physical Section <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.26, open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.26.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Hospital Discharge Physical Section <small class="text-muted">[section,
+        1.3.6.1.4.1.19376.1.5.3.1.3.26, open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.26.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Hospital Discharge Physical Section records a narrative description of the patient's physical findings.</p></div>
+    <div id="description">
+      <p>The Hospital Discharge Physical Section records a narrative description of the patient's physical findings.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7971)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.26"</b><b> (CONF:81-10460)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15363)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10184-0"</b> Hospital Discharge Physical<b> (CONF:81-15364)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26482)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7973)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7974)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7971)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.26"</b><b>
+              (CONF:81-10460)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15363)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10184-0"</b> Hospital Discharge
+            Physical<b> (CONF:81-15364)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26482)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7973)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7974)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Discharge%20Physical%20Section_1.3.6.1.4.1.19376.1.5.3.1.3.26/Hospital%20Discharge%20Physical%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Hospital Discharge Physical Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Discharge%20Physical%20Section_1.3.6.1.4.1.19376.1.5.3.1.3.26/Hospital%20Discharge%20Physical%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Hospital Discharge Physical Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/1.3.6.1.4.1.19376.1.5.3.1.3.33.html
+++ b/templates/1.3.6.1.4.1.19376.1.5.3.1.3.33.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,95 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Discharge Diet Section (DEPRECATED) <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.33, release 2014-06-09, open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.33.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Discharge Diet Section (DEPRECATED) <small class="text-muted">[section,
+        1.3.6.1.4.1.19376.1.5.3.1.3.33, release 2014-06-09, open] <a
+          href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.33.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section records a narrative description of the expectations for diet and nutrition, including nutrition prescription, proposals, goals, and order requests for monitoring, tracking, or improving the nutritional status of the patient, used in a discharge from a facility such as an emergency department, hospital, or nursing home.</p><p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p><p><em>Reason for deprecation</em>: This template has been replaced by the Nutrition Section (2.16.840.1.113883.10.20.22.2.57).</p></div>
+    <div id="description">
+      <p>This section records a narrative description of the expectations for diet and nutrition, including nutrition
+        prescription, proposals, goals, and order requests for monitoring, tracking, or improving the nutritional status
+        of the patient, used in a discharge from a facility such as an emergency department, hospital, or nursing home.
+      </p>
+      <p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION
+        GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p>
+      <p><em>Reason for deprecation</em>: This template has been replaced by the Nutrition Section
+        (2.16.840.1.113883.10.20.22.2.57).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7975)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.33"</b><b> (CONF:1098-10455)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32593)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15459)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42344-2"</b> Discharge Diet<b> (CONF:1098-15460)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b><b> (CONF:1098-31140)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7977)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7978)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7975)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.33"</b><b>
+              (CONF:1098-10455)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32593)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15459)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42344-2"</b> Discharge Diet<b>
+              (CONF:1098-15460)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b><b> (CONF:1098-31140)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7977)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7978)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/1.3.6.1.4.1.19376.1.5.3.1.3.4.html
+++ b/templates/1.3.6.1.4.1.19376.1.5.3.1.3.4.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,96 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">History of Present Illness Section <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.4, open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.4.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">History of Present Illness Section <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.4,
+        open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.4.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The History of Present Illness section describes the history related to the reason for the encounter. It contains the historical details leading up to and pertaining to the patient's current complaint or reason for seeking medical care.</p></div>
+    <div id="description">
+      <p>The History of Present Illness section describes the history related to the reason for the encounter. It
+        contains the historical details leading up to and pertaining to the patient's current complaint or reason for
+        seeking medical care.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7848)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.4"</b><b> (CONF:81-10458)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15477)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10164-2"</b><b> (CONF:81-15478)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26478)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7850)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7851)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7848)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.4"</b><b>
+              (CONF:81-10458)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15477)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10164-2"</b><b> (CONF:81-15478)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26478)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7850)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7851)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/History%20of%20Present%20Illness%20Section_1.3.6.1.4.1.19376.1.5.3.1.3.4/History%20of%20Present%20Illness%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;History of Present Illness Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/History%20of%20Present%20Illness%20Section_1.3.6.1.4.1.19376.1.5.3.1.3.4/History%20of%20Present%20Illness%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;History of Present Illness Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/1.3.6.1.4.1.19376.1.5.3.1.3.5.html
+++ b/templates/1.3.6.1.4.1.19376.1.5.3.1.3.5.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,89 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Hospital Course Section <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.5, open] <a href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Hospital Course Section <small class="text-muted">[section, 1.3.6.1.4.1.19376.1.5.3.1.3.5, open] <a
+          href="../pdfs/1.3.6.1.4.1.19376.1.5.3.1.3.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Hospital Course Section describes the sequence of events from admission to discharge in a hospital facility.</p></div>
+    <div id="description">
+      <p>The Hospital Course Section describes the sequence of events from admission to discharge in a hospital
+        facility.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7852)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.5"</b><b> (CONF:81-10459)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15487)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8648-8"</b> Hospital Course<b> (CONF:81-15488)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26480)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7854)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7855)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7852)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"1.3.6.1.4.1.19376.1.5.3.1.3.5"</b><b>
+              (CONF:81-10459)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15487)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8648-8"</b> Hospital Course<b>
+              (CONF:81-15488)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26480)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7854)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7855)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Course%20Section_1.3.6.1.4.1.19376.1.5.3.1.3.5/Hospital%20Course%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Hospital Course Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Course%20Section_1.3.6.1.4.1.19376.1.5.3.1.3.5/Hospital%20Course%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Hospital Course Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.1.19.html
+++ b/templates/2.16.840.1.113883.10.20.1.19.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,111 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Authorization Activity <small class="text-muted">[act, 2.16.840.1.113883.10.20.1.19, open] <a href="../pdfs/2.16.840.1.113883.10.20.1.19.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Authorization Activity <small class="text-muted">[act, 2.16.840.1.113883.10.20.1.19, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.1.19.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>An Authorization Activity represents authorizations or pre-authorizations currently active for the patient for the particular payer.</p><p>Authorizations are represented using an act subordinate to the policy or program that provided it. The authorization refers to the policy or program. Authorized treatments can be grouped into an organizer class, where common properties, such as the reason for the authorization, can be expressed. Subordinate acts represent what was authorized.</p></div>
+    <div id="description">
+      <p>An Authorization Activity represents authorizations or pre-authorizations currently active for the patient for
+        the particular payer.</p>
+      <p>Authorizations are represented using an act subordinate to the policy or program that provided it. The
+        authorization refers to the policy or program. Authorized treatments can be grouped into an organizer class,
+        where common properties, such as the reason for the authorization, can be expressed. Subordinate acts represent
+        what was authorized.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-8944)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-8945)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8946)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.1.19"</b><b> (CONF:81-10529)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:81-8947)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:81-8948)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-8949)</b>.</li></ul><ul><li><p>The target of an authorization activity with act/entryRelationship/@typeCode="SUBJ" SHALL be a clinical statement with moodCode="PRMS" Promise (CONF:81-8951).</p></li></ul><ul><li><p>The target of an authorization activity MAY contain one or more performer, to indicate the providers that have been authorized to provide treatment (CONF:81-8952).</p></li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-8944)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-8945)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8946)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.1.19"</b><b>
+              (CONF:81-10529)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:81-8947)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:81-8948)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-8949)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>The target of an authorization activity with act/entryRelationship/@typeCode="SUBJ" SHALL be a clinical
+              statement with moodCode="PRMS" Promise (CONF:81-8951).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>The target of an authorization activity MAY contain one or more performer, to indicate the providers that
+              have been authorized to provide treatment (CONF:81-8952).</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Authorization%20Activity_2.16.840.1.113883.10.20.1.19/Authorization%20Activity%20Example.xml"><i class="fab fa-github"></i>&nbsp;Authorization Activity Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Authorization%20Activity_2.16.840.1.113883.10.20.1.19/Authorization%20Activity%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Authorization Activity Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.15.3.1.html
+++ b/templates/2.16.840.1.113883.10.20.15.3.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,104 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Estimated Date of Delivery <small class="text-muted">[observation, 2.16.840.1.113883.10.20.15.3.1, closed] <a href="../pdfs/2.16.840.1.113883.10.20.15.3.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Estimated Date of Delivery <small class="text-muted">[observation, 2.16.840.1.113883.10.20.15.3.1,
+        closed] <a href="../pdfs/2.16.840.1.113883.10.20.15.3.1.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement represents the anticipated date when a woman will give birth.</p></div>
+    <div id="description">
+      <p>This clinical statement represents the anticipated date when a woman will give birth.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.15.3.8.html">Pregnancy Observation</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.15.3.8.html">Pregnancy Observation</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-444)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-445)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-16762)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.15.3.1"</b><b> (CONF:81-16763)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19139)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11778-8"</b> Estimated date of delivery<b> (CONF:81-19140)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26503)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-448)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:81-19096)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="TS"<b> (CONF:81-450)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-444)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-445)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-16762)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.15.3.1"</b><b>
+              (CONF:81-16763)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19139)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11778-8"</b> Estimated date of
+            delivery<b> (CONF:81-19140)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26503)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-448)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:81-19096)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="TS"<b>
+          (CONF:81-450)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Estimated%20Date%20of%20Delivery_2.16.840.1.113883.10.20.15.3.1/Estimated%20Date%20of%20Delivery%20Example.xml"><i class="fab fa-github"></i>&nbsp;Estimated Date of Delivery Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Estimated%20Date%20of%20Delivery_2.16.840.1.113883.10.20.15.3.1/Estimated%20Date%20of%20Delivery%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Estimated Date of Delivery Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.15.3.8.html
+++ b/templates/2.16.840.1.113883.10.20.15.3.8.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,125 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Pregnancy Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.15.3.8, open] <a href="../pdfs/2.16.840.1.113883.10.20.15.3.8.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Pregnancy Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.15.3.8, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.15.3.8.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement represents current and/or prior pregnancy dates enabling investigators to determine if the subject of the case report was pregnant during the course of a condition.</p></div>
+    <div id="description">
+      <p>This clinical statement represents current and/or prior pregnancy dates enabling investigators to determine if
+        the subject of the case report was pregnant during the course of a condition.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.15.3.1.html">Estimated Date of Delivery</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.15.3.1.html">Estimated Date of Delivery</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-451)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-452)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-16768)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.15.3.8"</b><b> (CONF:81-16868)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19153)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b> (CONF:81-19154)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:81-26505)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-455)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:81-19110)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-2018)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Extended Pregnancy Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.24/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.24</a></b><b> DYNAMIC</b><b> (CONF:81-457)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:81-458)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-459)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Estimated Date of Delivery<b> (identifier: 2.16.840.1.113883.10.20.15.3.1)</b><b> (CONF:81-15584)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-451)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-452)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-16768)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.15.3.8"</b><b>
+              (CONF:81-16868)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19153)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b>
+              (CONF:81-19154)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:81-26505)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-455)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:81-19110)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-2018)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Extended Pregnancy Status<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.24/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.24</a></b><b> DYNAMIC</b><b>
+          (CONF:81-457)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:81-458)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-459)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Estimated Date of Delivery<b> (identifier:
+              2.16.840.1.113883.10.20.15.3.1)</b><b> (CONF:81-15584)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Pregnancy%20Observation_2.16.840.1.113883.10.20.15.3.8/Pregnancy%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Pregnancy Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Pregnancy%20Observation_2.16.840.1.113883.10.20.15.3.8/Pregnancy%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Pregnancy Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.18.2.12.html
+++ b/templates/2.16.840.1.113883.10.20.18.2.12.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,50 +52,92 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Disposition Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.18.2.12, open] <a href="../pdfs/2.16.840.1.113883.10.20.18.2.12.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Disposition Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.18.2.12,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.18.2.12.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Procedure Disposition Section records the status and condition of the patient at the completion of the procedure or surgery. It often also states where the patient was transferred to for the next level of care.</p></div>
+    <div id="description">
+      <p>The Procedure Disposition Section records the status and condition of the patient at the completion of the
+        procedure or surgery. It often also states where the patient was transferred to for the next level of care.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8070)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.18.2.12"</b><b> (CONF:81-10466)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15413)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59775-7"</b> Procedure Disposition<b> (CONF:81-15414)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26490)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8072)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8073)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8070)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.18.2.12"</b><b>
+              (CONF:81-10466)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15413)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59775-7"</b> Procedure Disposition<b>
+              (CONF:81-15414)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26490)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8072)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8073)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Disposition%20Section_2.16.840.1.113883.10.20.18.2.12/Procedure%20Disposition%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Disposition Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Disposition%20Section_2.16.840.1.113883.10.20.18.2.12/Procedure%20Disposition%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Disposition Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.18.2.9.html
+++ b/templates/2.16.840.1.113883.10.20.18.2.9.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,98 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Estimated Blood Loss Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.18.2.9, open] <a href="../pdfs/2.16.840.1.113883.10.20.18.2.9.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Estimated Blood Loss Section <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.18.2.9, open] <a href="../pdfs/2.16.840.1.113883.10.20.18.2.9.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Procedure Estimated Blood Loss Section may be a subsection of another section such as the Procedure Description Section. The Procedure Estimated Blood Loss Section records the approximate amount of blood that the patient lost during the procedure or surgery. It may be an accurate quantitative amount, e.g., 250 milliliters, or it may be descriptive, e.g., 'minimal' or 'none'.</p></div>
+    <div id="description">
+      <p>The Procedure Estimated Blood Loss Section may be a subsection of another section such as the Procedure
+        Description Section. The Procedure Estimated Blood Loss Section records the approximate amount of blood that the
+        patient lost during the procedure or surgery. It may be an accurate quantitative amount, e.g., 250 milliliters,
+        or it may be descriptive, e.g., 'minimal' or 'none'.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8074)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.18.2.9"</b><b> (CONF:81-10467)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15415)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59770-8"</b> Procedure Estimated Blood Loss<b> (CONF:81-15416)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26491)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8076)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8077)</b>.</li>
-<li class="list-group-item"> <p>The Estimated Blood Loss section SHALL include a statement providing an estimate of the amount of blood lost during the procedure, even if the estimate is text, such as "minimal" or "none" (CONF:81-8741).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8074)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.18.2.9"</b><b>
+              (CONF:81-10467)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15415)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59770-8"</b> Procedure Estimated Blood
+            Loss<b> (CONF:81-15416)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26491)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8076)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8077)</b>.</li>
+      <li class="list-group-item">
+        <p>The Estimated Blood Loss section SHALL include a statement providing an estimate of the amount of blood lost
+          during the procedure, even if the estimate is text, such as "minimal" or "none" (CONF:81-8741).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Estimated%20Blood%20Loss%20Section_2.16.840.1.113883.10.20.18.2.9/Procedure%20Estimated%20Blood%20Loss%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Estimated Blood Loss Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Estimated%20Blood%20Loss%20Section_2.16.840.1.113883.10.20.18.2.9/Procedure%20Estimated%20Blood%20Loss%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Estimated Blood Loss Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.2.10.html
+++ b/templates/2.16.840.1.113883.10.20.2.10.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,129 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Physical Exam Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.2.10, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.2.10.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Physical Exam Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.2.10, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.2.10.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The section includes direct observations made by a clinician. The examination may include the use of simple instruments and may also describe simple maneuvers performed directly on the patient's body.It also includes observations made by the examining clinician using only inspection, palpation, auscultation, and percussion. It does not include laboratory or imaging findings.The exam may be limited to pertinent body systems based on the patient's chief complaint or it may include a comprehensive examination. The examination may be reported as a collection of random clinical statements or it may be reported categorically.The Physical Exam Section may contain multiple nested subsections.</p></div>
+    <div id="description">
+      <p>The section includes direct observations made by a clinician. The examination may include the use of simple
+        instruments and may also describe simple maneuvers performed directly on the patient's body.It also includes
+        observations made by the examining clinician using only inspection, palpation, auscultation, and percussion. It
+        does not include laboratory or imaging findings.The exam may be limited to pertinent body systems based on the
+        patient's chief complaint or it may include a comprehensive examination. The examination may be reported as a
+        collection of random clinical statements or it may be reported categorically.The Physical Exam Section may
+        contain multiple nested subsections.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation
+              (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7806)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.2.10"</b><b> (CONF:1198-10465)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32587)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15397)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29545-1"</b> Physical Findings<b> (CONF:1198-15398)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30931)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7808)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7809)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31926)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Longitudinal Care Wound Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.114)</b><b> (CONF:1198-31927)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1198-32434)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>section</b><b> (CONF:1198-32435)</b>.</li><ul><li>This section <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Physical Exam Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.65/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.65</a></b><b> DYNAMIC</b><b> (CONF:1198-32436)</b>.</li></ul><ul><li>This section <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-32437)</b>.</li></ul><ul><li>This section <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-32438)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7806)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.2.10"</b><b>
+              (CONF:1198-10465)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32587)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15397)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29545-1"</b> Physical Findings<b>
+              (CONF:1198-15398)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30931)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7808)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7809)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31926)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Longitudinal Care Wound Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.114)</b><b> (CONF:1198-31927)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1198-32434)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>section</b><b> (CONF:1198-32435)</b>.</li>
+          <ul>
+            <li>This section <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from
+              ValueSet Physical Exam Type<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.65/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.65</a></b><b>
+                DYNAMIC</b><b> (CONF:1198-32436)</b>.</li>
+          </ul>
+          <ul>
+            <li>This section <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-32437)</b>.</li>
+          </ul>
+          <ul>
+            <li>This section <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-32438)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Physical%20Exam%20Section%20(V3)_2.16.840.1.113883.10.20.2.10/Physical%20Exam%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Physical Exam Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Physical%20Exam%20Section%20(V3)_2.16.840.1.113883.10.20.2.10/Physical%20Exam%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Physical Exam Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.2.5.html
+++ b/templates/2.16.840.1.113883.10.20.2.5.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,94 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">General Status Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.2.5, open] <a href="../pdfs/2.16.840.1.113883.10.20.2.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">General Status Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.2.5, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.2.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The General Status section describes general observations and readily observable attributes of the patient, including affect and demeanor, apparent age compared to actual age, gender, ethnicity, nutritional status based on appearance, body build and habitus (e.g., muscular, cachectic, obese), developmental or other deformities, gait and mobility, personal hygiene, evidence of distress, and voice quality and speech.</p></div>
+    <div id="description">
+      <p>The General Status section describes general observations and readily observable attributes of the patient,
+        including affect and demeanor, apparent age compared to actual age, gender, ethnicity, nutritional status based
+        on appearance, body build and habitus (e.g., muscular, cachectic, obese), developmental or other deformities,
+        gait and mobility, personal hygiene, evidence of distress, and voice quality and speech.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7985)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.2.5"</b><b> (CONF:81-10457)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15472)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10210-3"</b> General Status<b> (CONF:81-15473)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26477)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7987)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7988)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7985)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.2.5"</b><b>
+              (CONF:81-10457)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15472)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10210-3"</b> General Status<b>
+              (CONF:81-15473)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26477)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7987)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7988)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/General%20Status%20Section_2.16.840.1.113883.10.20.2.5/General%20Status%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;General Status Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/General%20Status%20Section_2.16.840.1.113883.10.20.2.5/General%20Status%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;General Status Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.21.2.1.html
+++ b/templates/2.16.840.1.113883.10.20.21.2.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,90 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Objective Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.21.2.1, open] <a href="../pdfs/2.16.840.1.113883.10.20.21.2.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Objective Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.21.2.1, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.21.2.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Objective Section contains data about the patient gathered through tests, measures, or observations that produce a quantified or categorized result. It includes important and relevant positive and negative test results, physical findings, review of systems, and other measurements and observations.</p></div>
+    <div id="description">
+      <p>The Objective Section contains data about the patient gathered through tests, measures, or observations that
+        produce a quantified or categorized result. It includes important and relevant positive and negative test
+        results, physical findings, review of systems, and other measurements and observations.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7869)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.21.2.1"</b><b> (CONF:81-10462)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15389)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"61149-1"</b> Objective<b> (CONF:81-15390)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26485)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7871)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7872)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7869)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.21.2.1"</b><b>
+              (CONF:81-10462)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15389)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"61149-1"</b> Objective<b>
+              (CONF:81-15390)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26485)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7871)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7872)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Objective%20Section_2.16.840.1.113883.10.20.21.2.1/Objective%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Objective Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Objective%20Section_2.16.840.1.113883.10.20.21.2.1/Objective%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Objective Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.21.2.2.html
+++ b/templates/2.16.840.1.113883.10.20.21.2.2.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,89 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Subjective Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.21.2.2, open] <a href="../pdfs/2.16.840.1.113883.10.20.21.2.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Subjective Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.21.2.2, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.21.2.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Subjective Section describes in a narrative format the patient's current condition and/or interval changes as reported by the patient or by the patient's guardian or another informant.</p></div>
+    <div id="description">
+      <p>The Subjective Section describes in a narrative format the patient's current condition and/or interval changes
+        as reported by the patient or by the patient's guardian or another informant.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7873)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.21.2.2"</b><b> (CONF:81-10470)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15437)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"61150-9"</b> Subjective<b> (CONF:81-15438)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26496)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7875)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7876)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7873)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.21.2.2"</b><b>
+              (CONF:81-10470)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15437)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"61150-9"</b> Subjective<b>
+              (CONF:81-15438)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26496)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7875)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7876)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Subjective%20Section_2.16.840.1.113883.10.20.21.2.2/Subjective%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Subjective Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Subjective%20Section_2.16.840.1.113883.10.20.21.2.2/Subjective%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Subjective Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.21.2.3.html
+++ b/templates/2.16.840.1.113883.10.20.21.2.3.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,126 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Interventions Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.21.2.3, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.21.2.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Interventions Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.21.2.3,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.21.2.3.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents Interventions. Interventions are actions taken to maximize the prospects of the goals of care for the patient, including the removal of barriers to success. Interventions can be planned, ordered, historical, etc.</p><p>Interventions include actions that may be ongoing (e.g., maintenance medications that the patient is taking, or monitoring the patient's health status or the status of an intervention).</p><p>Instructions are nested within interventions and may include self-care instructions. Instructions are information or directions to the patient and other providers including how to care for the individual's condition, what to do at home, when to call for help, any additional appointments, testing, and changes to the medication list or medication instructions, clinical guidelines and a summary of best practice.</p><p>Instructions are information or directions to the patient. Use the Instructions Section when instructions are included as part of a document that is not a Care Plan. Use the Interventions Section, containing the Intervention Act containing the Instruction entry, when instructions are part of a structured care plan.</p></div>
+    <div id="description">
+      <p>This template represents Interventions. Interventions are actions taken to maximize the prospects of the goals
+        of care for the patient, including the removal of barriers to success. Interventions can be planned, ordered,
+        historical, etc.</p>
+      <p>Interventions include actions that may be ongoing (e.g., maintenance medications that the patient is taking, or
+        monitoring the patient's health status or the status of an intervention).</p>
+      <p>Instructions are nested within interventions and may include self-care instructions. Instructions are
+        information or directions to the patient and other providers including how to care for the individual's
+        condition, what to do at home, when to call for help, any additional appointments, testing, and changes to the
+        medication list or medication instructions, clinical guidelines and a summary of best practice.</p>
+      <p>Instructions are information or directions to the patient. Use the Instructions Section when instructions are
+        included as part of a document that is not a Care Plan. Use the Interventions Section, containing the
+        Intervention Act containing the Instruction entry, when instructions are part of a structured care plan.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8680)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.21.2.3"</b><b> (CONF:1198-10461)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32559)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15377)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"62387-6"</b> Interventions Provided<b> (CONF:1198-15378)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30864)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8682)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8683)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-30996)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Intervention Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.131)</b><b> (CONF:1198-30997)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32730)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Intervention Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.146)</b><b> (CONF:1198-32731)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32402)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Handoff Communication Participants<b> (identifier: 2.16.840.1.113883.10.20.22.4.141)</b><b> (CONF:1198-32403)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8680)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.21.2.3"</b><b>
+              (CONF:1198-10461)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32559)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15377)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"62387-6"</b> Interventions Provided<b>
+              (CONF:1198-15378)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30864)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8682)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8683)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-30996)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Intervention Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.131)</b><b> (CONF:1198-30997)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32730)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Intervention Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.146)</b><b> (CONF:1198-32731)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32402)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Handoff Communication Participants<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.141)</b><b> (CONF:1198-32403)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Interventions%20Section%20(V3)_2.16.840.1.113883.10.20.21.2.3/Interventions%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Interventions Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Interventions%20Section%20(V3)_2.16.840.1.113883.10.20.21.2.3/Interventions%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Interventions Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Interventions"><i class="fas fa-external-link-alt"></i> Interventions</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Interventions"><i class="fas fa-external-link-alt"></i>
+          Interventions</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,71 +52,934 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">US Realm Header (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">US Realm Header (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.1,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.1.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template defines constraints that represent common administrative and demographic concepts for US Realm CDA documents. Further specification, such as ClinicalDocument/code, are provided in document templates that conform to this template.</p></div>
+    <div id="description">
+      <p>This template defines constraints that represent common administrative and demographic concepts for US Realm
+        CDA documents. Further specification, such as ClinicalDocument/code, are provided in document templates that
+        conform to this template.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.4.html">US Realm Date and Time (DTM.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address (AD.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.1.html">US Realm Patient Name (PTN.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.4.html">US Realm Date and Time
+              (DTM.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address
+              (AD.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.1.html">US Realm Patient Name
+              (PTN.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name
+              (PN.US.FIELDED)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>realmCode</b>=<b>"US"</b><b> (CONF:1198-16791)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>typeId</b><b> (CONF:1198-5361)</b>.<ul><li>This typeId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.1.3"</b><b> (CONF:1198-5250)</b>.</li></ul><ul><li>This typeId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"POCD_HD000040"</b><b> (CONF:1198-5251)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-5252)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.1"</b><b> (CONF:1198-10036)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32503)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1198-5363)</b>.<ul><li><p>This id <strong>SHALL</strong> be a globally unique identifier for the document (CONF:1198-9991).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-5253)</b>.<ul><li><p>This code <strong>SHALL</strong> specify the particular kind of document (e.g., History and Physical, Discharge Summary, Progress Note) (CONF:1198-9992).</p></li></ul><ul><li><p>This code <strong>SHALL</strong> be drawn from the LOINC document type ontology (LOINC codes where SCALE = DOC) (CONF:1198-32948).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-5254)</b>.<br>Note: The title can either be a locally defined name or the displayName corresponding to clinicalDocument/code</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DTM.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.4)</b><b> (CONF:1198-5256)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>confidentialityCode</b>, which <b>SHOULD</b> be selected from ValueSet HL7 BasicConfidentialityKind<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16926/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16926</a></b><b> DYNAMIC</b><b> (CONF:1198-5259)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>languageCode</b>, which <b>SHALL</b> be selected from ValueSet Language<b> <a href="https://terminology.hl7.org/3.1.0/ValueSet-v3-HumanLanguage.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.11526</a></b><b> DYNAMIC</b><b> (CONF:1198-5372)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>setId</b><b> (CONF:1198-5261)</b>.<ul><li><p>If  setId is present versionNumber <strong>SHALL</strong> be present (CONF:1198-6380).</p></li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>versionNumber</b><b> (CONF:1198-5264)</b>.<ul><li><p>If versionNumber is present setId <strong>SHALL</strong> be present (CONF:1198-6387).</p></li></ul></li>
-<li class="list-group-item"><p>Heading: recordTarget<br>The recordTarget records the administrative and demographic data of the patient whose health information is described by the clinical document; each recordTarget must contain at least one patientRole element<br></p> <b>SHALL</b> contain at least one [1..*] <b>recordTarget</b><b> (CONF:1198-5266)</b>.<ul><li>Such recordTargets <b>SHALL</b> contain exactly one [1..1] <b>patientRole</b><b> (CONF:1198-5267)</b>.</li><ul><li>This patientRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5268)</b>.</li></ul><ul><li>This patientRole <b>SHALL</b> contain at least one [1..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5271)</b>.</li></ul><ul><li>This patientRole <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5280)</b>.</li><ul><li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet Telecom Use (US Realm Header)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.20/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.20</a></b><b> DYNAMIC</b><b> (CONF:1198-5375)</b>.</li></ul></ul><ul><li>This patientRole <b>SHALL</b> contain exactly one [1..1] <b>patient</b><b> (CONF:1198-5283)</b>.</li><ul><li>This patient <b>SHALL</b> contain at least one [1..*]  US Realm Patient Name (PTN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1)</b><b> (CONF:1198-5284)</b>.</li></ul><ul><li>This patient <b>SHALL</b> contain exactly one [1..1] <b>administrativeGenderCode</b>, which <b>SHALL</b> be selected from ValueSet Administrative Gender (HL7 V3)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.1</a></b><b> DYNAMIC</b><b> (CONF:1198-6394)</b>.</li></ul><ul><li>This patient <b>SHALL</b> contain exactly one [1..1] <b>birthTime</b><b> (CONF:1198-5298)</b>.</li><ul><li><p><strong>SHALL</strong> be precise to year (CONF:1198-5299).</p></li></ul><ul><li><p><strong>SHOULD</strong> be precise to day (CONF:1198-5300).</p></li></ul><ul><li><p><strong>MAY</strong> be precise to the minute (CONF:1198-32418).</p></li></ul></ul><ul><li>This patient <b>SHOULD</b> contain zero or one [0..1] <b>maritalStatusCode</b>, which <b>SHALL</b> be selected from ValueSet Marital Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12212/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12212</a></b><b> DYNAMIC</b><b> (CONF:1198-5303)</b>.</li></ul><ul><li>This patient <b>MAY</b> contain zero or one [0..1] <b>religiousAffiliationCode</b>, which <b>SHALL</b> be selected from ValueSet Religious Affiliation<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.19185/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.19185</a></b><b> DYNAMIC</b><b> (CONF:1198-5317)</b>.</li></ul><ul><li>This patient <b>SHALL</b> contain exactly one [1..1] <b>raceCode</b>, which <b>SHALL</b> be selected from ValueSet Race Category Excluding Nulls<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.2074.1.1.3/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.2074.1.1.3</a></b><b> DYNAMIC</b><b> (CONF:1198-5322)</b>.</li></ul><ul><li>This patient <b>MAY</b> contain zero or more [0..*] <b>sdtc:raceCode</b>, which <b>SHALL</b> be selected from ValueSet Race Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.14914/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.14914</a></b><b> DYNAMIC</b><b> (CONF:1198-7263)</b>.<br>Note: The sdtc:raceCode is only used to record additional values when the patient has indicated multiple races or additional race detail beyond the five categories required for Meaningful Use Stage 2. The prefix sdtc: SHALL be bound to the namespace urn:hl7-org:sdtc. The use of the namespace provides a necessary extension to CDA R2 for the use of the additional raceCode elements.</li><ul><li><p>If sdtc:raceCode is present, then the patient <strong>SHALL</strong> contain [1..1] raceCode (CONF:1198-31347).</p></li></ul></ul><ul><li>This patient <b>SHALL</b> contain exactly one [1..1] <b>ethnicGroupCode</b>, which <b>SHALL</b> be selected from ValueSet Ethnicity<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.837/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.837</a></b><b> DYNAMIC</b><b> (CONF:1198-5323)</b>.</li></ul><ul><li>This patient <b>MAY</b> contain zero or more [0..*] <b>sdtc:ethnicGroupCode</b>, which <b>SHALL</b> be selected from ValueSet Detailed Ethnicity<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.877/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.877</a></b><b> DYNAMIC</b><b> (CONF:1198-32901)</b>.</li></ul><ul><li>This patient <b>MAY</b> contain zero or more [0..*] <b>guardian</b><b> (CONF:1198-5325)</b>.</li><ul><li>The guardian, if present, <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b> DYNAMIC</b><b> (CONF:1198-5326)</b>.</li></ul><ul><li>The guardian, if present, <b>SHOULD</b> contain zero or more [0..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5359)</b>.</li></ul><ul><li>The guardian, if present, <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1198-5382)</b>.</li><ul><li>The telecom, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b> (CONF:1198-7993)</b>.</li></ul></ul><ul><li>The guardian, if present, <b>SHALL</b> contain exactly one [1..1] <b>guardianPerson</b><b> (CONF:1198-5385)</b>.</li><ul><li>This guardianPerson <b>SHALL</b> contain at least one [1..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5386)</b>.</li></ul></ul></ul><ul><li>This patient <b>MAY</b> contain zero or one [0..1] <b>birthplace</b><b> (CONF:1198-5395)</b>.</li><ul><li>The birthplace, if present, <b>SHALL</b> contain exactly one [1..1] <b>place</b><b> (CONF:1198-5396)</b>.</li><ul><li>This place <b>SHALL</b> contain exactly one [1..1] <b>addr</b><b> (CONF:1198-5397)</b>.</li><ul><li>This addr <b>SHOULD</b> contain zero or one [0..1] <b>country</b>, which <b>SHALL</b> be selected from ValueSet Country<b> 2.16.840.1.113883.3.88.12.80.63</b><b> DYNAMIC</b><b> (CONF:1198-5404)</b>.</li></ul><ul><li><p>If country is US, this addr <strong>SHALL</strong> contain exactly one [1..1] state, which <strong>SHALL</strong> be selected from ValueSet StateValueSet 2.16.840.1.113883.3.88.12.80.1 <em>DYNAMIC</em> (CONF:1198-5402).</p><br>Note: A nullFlavor of 'UNK' may be used if the state is unknown.</li></ul><ul><li><p>If country is US, this addr <strong>MAY</strong> contain zero or one [0..1] postalCode, which <strong>SHALL</strong> be selected from ValueSet PostalCode 2.16.840.1.113883.3.88.12.80.2 <em>DYNAMIC</em> (CONF:1198-5403).</p></li></ul></ul></ul></ul><ul><li>This patient <b>SHOULD</b> contain zero or more [0..*] <b>languageCommunication</b><b> (CONF:1198-5406)</b>.</li><ul><li>The languageCommunication, if present, <b>SHALL</b> contain exactly one [1..1] <b>languageCode</b>, which <b>SHALL</b> be selected from ValueSet Language<b> <a href="https://terminology.hl7.org/3.1.0/ValueSet-v3-HumanLanguage.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.11526</a></b><b> DYNAMIC</b><b> (CONF:1198-5407)</b>.</li></ul><ul><li>The languageCommunication, if present, <b>MAY</b> contain zero or one [0..1] <b>modeCode</b>, which <b>SHALL</b> be selected from ValueSet LanguageAbilityMode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12249/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12249</a></b><b> DYNAMIC</b><b> (CONF:1198-5409)</b>.</li></ul><ul><li>The languageCommunication, if present, <b>SHOULD</b> contain zero or one [0..1] <b>proficiencyLevelCode</b>, which <b>SHALL</b> be selected from ValueSet LanguageAbilityProficiency<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12199/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12199</a></b><b> DYNAMIC</b><b> (CONF:1198-9965)</b>.</li></ul><ul><li>The languageCommunication, if present, <b>SHOULD</b> contain zero or one [0..1] <b>preferenceInd</b><b> (CONF:1198-5414)</b>.</li></ul></ul></ul><ul><li>This patientRole <b>MAY</b> contain zero or one [0..1] <b>providerOrganization</b><b> (CONF:1198-5416)</b>.</li><ul><li>The providerOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5417)</b>.</li><ul><li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider Identifier<b> (CONF:1198-16820)</b>.</li></ul></ul><ul><li>The providerOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-5419)</b>.</li></ul><ul><li>The providerOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5420)</b>.</li><ul><li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b> (CONF:1198-7994)</b>.</li></ul></ul><ul><li>The providerOrganization, if present, <b>SHALL</b> contain at least one [1..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5422)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: author<br>The author element represents the creator of the clinical document.  The author may be a device or a person. <br></p> <b>SHALL</b> contain at least one [1..*] <b>author</b><b> (CONF:1198-5444)</b>.<ul><li>Such authors <b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DTM.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.4)</b><b> (CONF:1198-5445)</b>.</li></ul><ul><li>Such authors <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b> (CONF:1198-5448)</b>.</li><ul><li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5449)</b>.</li></ul><ul><li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>id</b><b> (CONF:1198-32882)</b> such that it</li><ul><li><b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"UNK"</b> Unknown (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32883)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider Identifier<b> (CONF:1198-32884)</b>.</li></ul><ul><li><b>SHOULD</b> contain zero or one [0..1] <b>@extension</b><b> (CONF:1198-32885)</b>.</li></ul></ul><ul><li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-16787)</b>.</li><ul><li>The code, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1198-16788)</b>.</li></ul></ul><ul><li>This assignedAuthor <b>SHALL</b> contain at least one [1..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5452)</b>.</li></ul><ul><li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5428)</b>.</li><ul><li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b> (CONF:1198-7995)</b>.</li></ul></ul><ul><li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>assignedPerson</b><b> (CONF:1198-5430)</b>.</li><ul><li>The assignedPerson, if present, <b>SHALL</b> contain at least one [1..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-16789)</b>.</li></ul></ul><ul><li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>assignedAuthoringDevice</b><b> (CONF:1198-16783)</b>.</li><ul><li>The assignedAuthoringDevice, if present, <b>SHALL</b> contain exactly one [1..1] <b>manufacturerModelName</b><b> (CONF:1198-16784)</b>.</li></ul><ul><li>The assignedAuthoringDevice, if present, <b>SHALL</b> contain exactly one [1..1] <b>softwareName</b><b> (CONF:1198-16785)</b>.</li></ul></ul><ul><li><p>There <strong>SHALL</strong> be exactly one assignedAuthor/assignedPerson or exactly one assignedAuthor/assignedAuthoringDevice (CONF:1198-16790).</p></li></ul></ul></li>
-<li class="list-group-item"><p>Heading: dataEnterer<br>The dataEnterer element represents the person who transferred the content, written or dictated, into the clinical document. To clarify, an author provides the content found within the header or body of a document, subject to their own interpretation; a dataEnterer adds an author's information to the electronic system.<br></p> <b>MAY</b> contain zero or one [0..1] <b>dataEnterer</b><b> (CONF:1198-5441)</b>.<ul><li>The dataEnterer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-5442)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5443)</b>.</li><ul><li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider Identifier<b> (CONF:1198-16821)</b>.</li></ul></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b> (CONF:1198-32173)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5460)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5466)</b>.</li><ul><li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b> (CONF:1198-7996)</b>.</li></ul></ul><ul><li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b> (CONF:1198-5469)</b>.</li><ul><li>This assignedPerson <b>SHALL</b> contain at least one [1..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5470)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: informant<br>The informant element describes an information source for any content within the clinical document. This informant is constrained for use when the source of information is an assigned health care provider for the patient.<br><br></p> <b>MAY</b> contain zero or more [0..*] <b>informant</b><b> (CONF:1198-8001)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-8002)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-9945)</b>.</li><ul><li><p>If assignedEntity/id is a provider then this id, <strong>SHOULD</strong> include zero or one [0..1] id where id/@root ="2.16.840.1.113883.4.6" National Provider Identifier (CONF:1198-9946).</p></li></ul></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b> (CONF:1198-32174)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-8220)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b> (CONF:1198-8221)</b>.</li><ul><li>This assignedPerson <b>SHALL</b> contain at least one [1..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-8222)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: informant<br>The informant element describes an information source (who is not a provider) for any content within the clinical document. This informant would be used when the source of information has a personal relationship with the patient or is the patient.<br><br></p> <b>MAY</b> contain zero or more [0..*] <b>informant</b><b> (CONF:1198-31355)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>relatedEntity</b><b> (CONF:1198-31356)</b>.</li></ul></li>
-<li class="list-group-item"><p>Heading: custodian<br>The custodian element represents the organization that is in charge of maintaining and is entrusted with the care of the document.<br>There is only one custodian per CDA document. Allowing that a CDA document may not represent the original form of the authenticated document, the custodian represents the steward of the original source document. The custodian may be the document originator, a health information exchange, or other responsible party.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>custodian</b><b> (CONF:1198-5519)</b>.<ul><li>This custodian <b>SHALL</b> contain exactly one [1..1] <b>assignedCustodian</b><b> (CONF:1198-5520)</b>.</li><ul><li>This assignedCustodian <b>SHALL</b> contain exactly one [1..1] <b>representedCustodianOrganization</b><b> (CONF:1198-5521)</b>.</li><ul><li>This representedCustodianOrganization <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5522)</b>.</li><ul><li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider Identifier<b> (CONF:1198-16822)</b>.</li></ul></ul><ul><li>This representedCustodianOrganization <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:1198-5524)</b>.</li></ul><ul><li>This representedCustodianOrganization <b>SHALL</b> contain exactly one [1..1] <b>telecom</b><b> (CONF:1198-5525)</b>.</li><ul><li>This telecom <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b> (CONF:1198-7998)</b>.</li></ul></ul><ul><li>This representedCustodianOrganization <b>SHALL</b> contain exactly one [1..1]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5559)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: informationRecipient<br>The informationRecipient element records the intended recipient of the information at the time the document was created. In cases where the intended recipient of the document is the patient's health chart, set the receivedOrganization to the scoping organization for that chart.<br></p> <b>MAY</b> contain zero or more [0..*] <b>informationRecipient</b><b> (CONF:1198-5565)</b>.<ul><li>The informationRecipient, if present, <b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b> (CONF:1198-5566)</b>.</li><ul><li>This intendedRecipient <b>MAY</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-32399)</b>.</li></ul><ul><li>This intendedRecipient <b>MAY</b> contain zero or one [0..1] <b>informationRecipient</b><b> (CONF:1198-5567)</b>.</li><ul><li>The informationRecipient, if present, <b>SHALL</b> contain at least one [1..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5568)</b>.</li></ul></ul><ul><li>This intendedRecipient <b>MAY</b> contain zero or one [0..1] <b>receivedOrganization</b><b> (CONF:1198-5577)</b>.</li><ul><li>The receivedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:1198-5578)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: sdtc:signatureText<br>The sdtc:signatureText extension provides a location in CDA for a textual or multimedia depiction of the signature by which the participant endorses and accepts responsibility for his or her participation in the Act as specified in the Participation.typeCode. Details of what goes in the field are described in the HL7 CDA Digital Signature Standard balloted in Fall 2013.</p><p>Heading: legalAuthenticator<br>The legalAuthenticator identifies the single person legally responsible for the document and must be present if the document has been legally authenticated. A clinical document that does not contain this element has not been legally authenticated.<br>The act of legal authentication requires a certain privilege be granted to the legal authenticator depending upon local policy. Based on local practice, clinical documents may be released before legal authentication.  <br>All clinical documents have the potential for legal authentication, given the appropriate credentials.<br>Local policies MAY choose to delegate the function of legal authentication to a device or system that generates the clinical document. In these cases, the legal authenticator is a person accepting responsibility for the document, not the generating device or system.<br>Note that the legal authenticator, if present, must be a person.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>legalAuthenticator</b><b> (CONF:1198-5579)</b>.<ul><li>The legalAuthenticator, if present, <b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DTM.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.4)</b><b> (CONF:1198-5580)</b>.</li></ul><ul><li>The legalAuthenticator, if present, <b>SHALL</b> contain exactly one [1..1] <b>signatureCode</b><b> (CONF:1198-5583)</b>.</li><ul><li>This signatureCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"S"</b> (CodeSystem: <b>HL7ParticipationSignature <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationSignature.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.89</a></b><b> STATIC</b>)<b> (CONF:1198-5584)</b>.</li></ul></ul><ul><li>The legalAuthenticator, if present, <b>MAY</b> contain zero or one [0..1] <b>sdtc:signatureText</b><b> (CONF:1198-30810)</b>.<br>Note: The signature can be represented either inline or by reference according to the ED data type. Typical cases for CDA are:1) Electronic signature: this attribute can represent virtually any electronic signature scheme.2) Digital signature: this attribute can represent digital signatures by reference to a signature data block that is constructed in accordance to a digital signature standard, such as XML-DSIG, PKCS#7, PGP, etc.</li></ul><ul><li>The legalAuthenticator, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-5585)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5586)</b>.</li><ul><li>Such ids <b>MAY</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider Identifier<b> (CONF:1198-16823)</b>.</li></ul></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b> (CONF:1198-17000)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5589)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5595)</b>.</li><ul><li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b> (CONF:1198-7999)</b>.</li></ul></ul><ul><li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b> (CONF:1198-5597)</b>.</li><ul><li>This assignedPerson <b>SHALL</b> contain at least one [1..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5598)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>The sdtc:signatureText extension provides a location in CDA for a textual or multimedia depiction of the signature by which the participant endorses and accepts responsibility for his or her participation in the Act as specified in the Participation.typeCode. Details of what goes in the field are described in the HL7 CDA Digital Signature Standard balloted in Fall of 2013.<br></p><p>Heading: authenticator<br>The authenticator identifies a participant or participants who attest to the accuracy of the information in the document.<br></p> <b>MAY</b> contain zero or more [0..*] <b>authenticator</b><b> (CONF:1198-5607)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DTM.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.4)</b><b> (CONF:1198-5608)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>signatureCode</b><b> (CONF:1198-5610)</b>.</li><ul><li>This signatureCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"S"</b> (CodeSystem: <b>HL7ParticipationSignature <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationSignature.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.89</a></b><b> STATIC</b>)<b> (CONF:1198-5611)</b>.</li></ul></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>sdtc:signatureText</b><b> (CONF:1198-30811)</b>.<br>Note: The signature can be represented either inline or by reference according to the ED data type. Typical cases for CDA are:1) Electronic signature: this attribute can represent virtually any electronic signature scheme.2) Digital signature: this attribute can represent digital signatures by reference to a signature data block that is constructed in accordance to a digital signature standard, such as XML-DSIG, PKCS#7, PGP, etc.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-5612)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5613)</b>.</li><ul><li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider Identifier <b> (CONF:1198-16824)</b>.</li></ul></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-16825)</b>.</li><ul><li>The code, if present, <b>MAY</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b> (CONF:1198-16826)</b>.</li></ul></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5616)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5622)</b>.</li><ul><li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b> (CONF:1198-8000)</b>.</li></ul></ul><ul><li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b> (CONF:1198-5624)</b>.</li><ul><li>This assignedPerson <b>SHALL</b> contain at least one [1..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5625)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: participant<br>The participant element identifies supporting entities, including parents, relatives, caregivers, insurance policyholders, guarantors, and others related in some way to the patient. <br>A supporting person or organization is an individual or an organization with a relationship to the patient. A supporting person who is playing multiple roles would be recorded in multiple participants (e.g., emergency contact and next-of-kin).<br><br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-10003)</b> such that it<ul><li><b>MAY</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-10004)</b>.</li></ul><ul><li><p><strong>SHALL</strong> contain associatedEntity/associatedPerson <em>AND/OR</em> associatedEntity/scopingOrganization (CONF:1198-10006).</p></li></ul><ul><li><p>When participant/@typeCode is <em>IND</em>, associatedEntity/@classCode <strong>SHOULD</strong> be selected from ValueSet <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33 </a>INDRoleclassCodes <em>STATIC 2011-09-30</em> (CONF:1198-10007).</p></li></ul></li>
-<li class="list-group-item"><p>Heading: inFulfillmentOf<br>The inFulfillmentOf element represents orders that are fulfilled by this document such as a radiologists' report of an x-ray.<br></p> <b>MAY</b> contain zero or more [0..*] <b>inFulfillmentOf</b><b> (CONF:1198-9952)</b>.<ul><li>The inFulfillmentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>order</b><b> (CONF:1198-9953)</b>.</li><ul><li>This order <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-9954)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>A serviceEvent represents the main act being documented, such as a colonoscopy or a cardiac stress study. In a provision of healthcare serviceEvent, the care providers, PCP, or other longitudinal providers, are recorded within the serviceEvent. If the document is about a single encounter, the providers associated can be recorded in the componentOf/encompassingEncounter template.</p> <b>MAY</b> contain zero or more [0..*] <b>documentationOf</b><b> (CONF:1198-14835)</b>.<ul><li>The documentationOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-14836)</b>.</li><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-14837)</b>.</li><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-14838)</b>.</li></ul></ul><ul><li>This serviceEvent <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-14839)</b>.</li><ul><li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>, which <b>SHALL</b> be selected from ValueSet x_ServiceEventPerformer<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.19601/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.19601</a></b><b> STATIC</b><b> (CONF:1198-14840)</b>.</li></ul><ul><li>The performer, if present, <b>MAY</b> contain zero or one [0..1] <b>functionCode</b><b> (CONF:1198-16818)</b>.</li><ul><li>The functionCode, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Care Team Member Function<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.30</a></b><b> DYNAMIC</b><b> (CONF:1198-32889)</b>.</li></ul></ul><ul><li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-14841)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14846)</b>.</li><ul><li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider Identifier<b> (CONF:1198-14847)</b>.</li></ul></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b> (CONF:1198-14842)</b>.</li></ul></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: authorization<br>The authorization element represents information about the patient's consent.<br>The type of consent is conveyed in consent/code. Consents in the header have been finalized (consent/statusCode must equal Completed) and should be on file. This specification does not address how 'Privacy Consent' is represented, but does not preclude the inclusion of Privacy Consent.<br>The authorization consent is used for referring to consents that are documented elsewhere in the EHR or medical record for a health condition and/or treatment that is described in the CDA document.<br><br></p> <b>MAY</b> contain zero or more [0..*] <b>authorization</b><b> (CONF:1198-16792)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>consent</b><b> (CONF:1198-16793)</b>.</li><ul><li>This consent <b>MAY</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-16794)</b>.</li></ul><ul><li>This consent <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-16795)</b>.<br>Note: The type of consent (e.g., a consent to perform the related serviceEvent) is conveyed in consent/code. </li></ul><ul><li>This consent <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-16797)</b>.</li><ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-16798)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: componentOf<br>The encompassing encounter represents the setting of the clinical encounter during which the document act(s) or ServiceEvent(s) occurred. In order to represent providers associated with a specific encounter, they are recorded within the encompassingEncounter as participants. In a CCD, the encompassingEncounter may be used when documenting a specific encounter and its participants. All relevant encounters in a CCD may be listed in the encounters section.<br><br></p> <b>MAY</b> contain zero or one [0..1] <b>componentOf</b><b> (CONF:1198-9955)</b>.<ul><li>The componentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b> (CONF:1198-9956)</b>.</li><ul><li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-9959)</b>.</li></ul><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-9958)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>realmCode</b>=<b>"US"</b><b>
+          (CONF:1198-16791)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>typeId</b><b> (CONF:1198-5361)</b>.<ul>
+          <li>This typeId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.1.3"</b><b>
+              (CONF:1198-5250)</b>.</li>
+        </ul>
+        <ul>
+          <li>This typeId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"POCD_HD000040"</b><b>
+              (CONF:1198-5251)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-5252)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.1"</b><b>
+              (CONF:1198-10036)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32503)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1198-5363)</b>.<ul>
+          <li>
+            <p>This id <strong>SHALL</strong> be a globally unique identifier for the document (CONF:1198-9991).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-5253)</b>.<ul>
+          <li>
+            <p>This code <strong>SHALL</strong> specify the particular kind of document (e.g., History and Physical,
+              Discharge Summary, Progress Note) (CONF:1198-9992).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>This code <strong>SHALL</strong> be drawn from the LOINC document type ontology (LOINC codes where SCALE
+              = DOC) (CONF:1198-32948).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b>
+          (CONF:1198-5254)</b>.<br>Note: The title can either be a locally defined name or the displayName corresponding
+        to clinicalDocument/code</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] US Realm Date and Time (DTM.US.FIELDED)<b>
+          (identifier: 2.16.840.1.113883.10.20.22.5.4)</b><b> (CONF:1198-5256)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>confidentialityCode</b>, which
+        <b>SHOULD</b> be selected from ValueSet HL7 BasicConfidentialityKind<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16926/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16926</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-5259)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>languageCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Language<b> <a href="https://terminology.hl7.org/3.1.0/ValueSet-v3-HumanLanguage.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.11526</a></b><b>
+          DYNAMIC</b><b> (CONF:1198-5372)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>setId</b><b> (CONF:1198-5261)</b>.<ul>
+          <li>
+            <p>If setId is present versionNumber <strong>SHALL</strong> be present (CONF:1198-6380).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>versionNumber</b><b> (CONF:1198-5264)</b>.
+        <ul>
+          <li>
+            <p>If versionNumber is present setId <strong>SHALL</strong> be present (CONF:1198-6387).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: recordTarget<br>The recordTarget records the administrative and demographic data of the patient
+          whose health information is described by the clinical document; each recordTarget must contain at least one
+          patientRole element<br></p> <b>SHALL</b> contain at least one [1..*] <b>recordTarget</b><b>
+          (CONF:1198-5266)</b>.<ul>
+          <li>Such recordTargets <b>SHALL</b> contain exactly one [1..1] <b>patientRole</b><b> (CONF:1198-5267)</b>.
+          </li>
+          <ul>
+            <li>This patientRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5268)</b>.</li>
+          </ul>
+          <ul>
+            <li>This patientRole <b>SHALL</b> contain at least one [1..*] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5271)</b>.</li>
+          </ul>
+          <ul>
+            <li>This patientRole <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5280)</b>.</li>
+            <ul>
+              <li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected
+                from ValueSet Telecom Use (US Realm Header)<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.20/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.20</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-5375)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This patientRole <b>SHALL</b> contain exactly one [1..1] <b>patient</b><b> (CONF:1198-5283)</b>.</li>
+            <ul>
+              <li>This patient <b>SHALL</b> contain at least one [1..*] US Realm Patient Name (PTN.US.FIELDED)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.5.1)</b><b> (CONF:1198-5284)</b>.</li>
+            </ul>
+            <ul>
+              <li>This patient <b>SHALL</b> contain exactly one [1..1] <b>administrativeGenderCode</b>, which
+                <b>SHALL</b> be selected from ValueSet Administrative Gender (HL7 V3)<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.1/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.1</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-6394)</b>.</li>
+            </ul>
+            <ul>
+              <li>This patient <b>SHALL</b> contain exactly one [1..1] <b>birthTime</b><b> (CONF:1198-5298)</b>.</li>
+              <ul>
+                <li>
+                  <p><strong>SHALL</strong> be precise to year (CONF:1198-5299).</p>
+                </li>
+              </ul>
+              <ul>
+                <li>
+                  <p><strong>SHOULD</strong> be precise to day (CONF:1198-5300).</p>
+                </li>
+              </ul>
+              <ul>
+                <li>
+                  <p><strong>MAY</strong> be precise to the minute (CONF:1198-32418).</p>
+                </li>
+              </ul>
+            </ul>
+            <ul>
+              <li>This patient <b>SHOULD</b> contain zero or one [0..1] <b>maritalStatusCode</b>, which <b>SHALL</b> be
+                selected from ValueSet Marital Status<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12212/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12212</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-5303)</b>.</li>
+            </ul>
+            <ul>
+              <li>This patient <b>MAY</b> contain zero or one [0..1] <b>religiousAffiliationCode</b>, which <b>SHALL</b>
+                be selected from ValueSet Religious Affiliation<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.19185/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.19185</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-5317)</b>.</li>
+            </ul>
+            <ul>
+              <li>This patient <b>SHALL</b> contain exactly one [1..1] <b>raceCode</b>, which <b>SHALL</b> be selected
+                from ValueSet Race Category Excluding Nulls<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.2074.1.1.3/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.2074.1.1.3</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-5322)</b>.</li>
+            </ul>
+            <ul>
+              <li>This patient <b>MAY</b> contain zero or more [0..*] <b>sdtc:raceCode</b>, which <b>SHALL</b> be
+                selected from ValueSet Race Value Set<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.14914/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.14914</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-7263)</b>.<br>Note: The sdtc:raceCode is only used to record additional
+                values when the patient has indicated multiple races or additional race detail beyond the five
+                categories required for Meaningful Use Stage 2. The prefix sdtc: SHALL be bound to the namespace
+                urn:hl7-org:sdtc. The use of the namespace provides a necessary extension to CDA R2 for the use of the
+                additional raceCode elements.</li>
+              <ul>
+                <li>
+                  <p>If sdtc:raceCode is present, then the patient <strong>SHALL</strong> contain [1..1] raceCode
+                    (CONF:1198-31347).</p>
+                </li>
+              </ul>
+            </ul>
+            <ul>
+              <li>This patient <b>SHALL</b> contain exactly one [1..1] <b>ethnicGroupCode</b>, which <b>SHALL</b> be
+                selected from ValueSet Ethnicity<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.837/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.837</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-5323)</b>.</li>
+            </ul>
+            <ul>
+              <li>This patient <b>MAY</b> contain zero or more [0..*] <b>sdtc:ethnicGroupCode</b>, which <b>SHALL</b> be
+                selected from ValueSet Detailed Ethnicity<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.877/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.877</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-32901)</b>.</li>
+            </ul>
+            <ul>
+              <li>This patient <b>MAY</b> contain zero or more [0..*] <b>guardian</b><b> (CONF:1198-5325)</b>.</li>
+              <ul>
+                <li>The guardian, if present, <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b>
+                  be selected from ValueSet Personal And Legal Relationship Role Type<b> <a
+                      href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest"
+                      target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b>
+                    DYNAMIC</b><b> (CONF:1198-5326)</b>.</li>
+              </ul>
+              <ul>
+                <li>The guardian, if present, <b>SHOULD</b> contain zero or more [0..*] US Realm Address
+                  (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5359)</b>.</li>
+              </ul>
+              <ul>
+                <li>The guardian, if present, <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b>
+                    (CONF:1198-5382)</b>.</li>
+                <ul>
+                  <li>The telecom, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b>
+                    be selected from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b>
+                      DYNAMIC</b><b> (CONF:1198-7993)</b>.</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>The guardian, if present, <b>SHALL</b> contain exactly one [1..1] <b>guardianPerson</b><b>
+                    (CONF:1198-5385)</b>.</li>
+                <ul>
+                  <li>This guardianPerson <b>SHALL</b> contain at least one [1..*] US Realm Person Name
+                    (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5386)</b>.</li>
+                </ul>
+              </ul>
+            </ul>
+            <ul>
+              <li>This patient <b>MAY</b> contain zero or one [0..1] <b>birthplace</b><b> (CONF:1198-5395)</b>.</li>
+              <ul>
+                <li>The birthplace, if present, <b>SHALL</b> contain exactly one [1..1] <b>place</b><b>
+                    (CONF:1198-5396)</b>.</li>
+                <ul>
+                  <li>This place <b>SHALL</b> contain exactly one [1..1] <b>addr</b><b> (CONF:1198-5397)</b>.</li>
+                  <ul>
+                    <li>This addr <b>SHOULD</b> contain zero or one [0..1] <b>country</b>, which <b>SHALL</b> be
+                      selected from ValueSet Country<b> 2.16.840.1.113883.3.88.12.80.63</b><b> DYNAMIC</b><b>
+                        (CONF:1198-5404)</b>.</li>
+                  </ul>
+                  <ul>
+                    <li>
+                      <p>If country is US, this addr <strong>SHALL</strong> contain exactly one [1..1] state, which
+                        <strong>SHALL</strong> be selected from ValueSet StateValueSet 2.16.840.1.113883.3.88.12.80.1
+                        <em>DYNAMIC</em> (CONF:1198-5402).</p><br>Note: A nullFlavor of 'UNK' may be used if the state
+                      is unknown.
+                    </li>
+                  </ul>
+                  <ul>
+                    <li>
+                      <p>If country is US, this addr <strong>MAY</strong> contain zero or one [0..1] postalCode, which
+                        <strong>SHALL</strong> be selected from ValueSet PostalCode 2.16.840.1.113883.3.88.12.80.2
+                        <em>DYNAMIC</em> (CONF:1198-5403).</p>
+                    </li>
+                  </ul>
+                </ul>
+              </ul>
+            </ul>
+            <ul>
+              <li>This patient <b>SHOULD</b> contain zero or more [0..*] <b>languageCommunication</b><b>
+                  (CONF:1198-5406)</b>.</li>
+              <ul>
+                <li>The languageCommunication, if present, <b>SHALL</b> contain exactly one [1..1] <b>languageCode</b>,
+                  which <b>SHALL</b> be selected from ValueSet Language<b> <a
+                      href="https://terminology.hl7.org/3.1.0/ValueSet-v3-HumanLanguage.html" target="_blank"><i
+                        class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.11526</a></b><b> DYNAMIC</b><b>
+                    (CONF:1198-5407)</b>.</li>
+              </ul>
+              <ul>
+                <li>The languageCommunication, if present, <b>MAY</b> contain zero or one [0..1] <b>modeCode</b>, which
+                  <b>SHALL</b> be selected from ValueSet LanguageAbilityMode<b> <a
+                      href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12249/expansion/Latest"
+                      target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12249</a></b><b>
+                    DYNAMIC</b><b> (CONF:1198-5409)</b>.</li>
+              </ul>
+              <ul>
+                <li>The languageCommunication, if present, <b>SHOULD</b> contain zero or one [0..1]
+                  <b>proficiencyLevelCode</b>, which <b>SHALL</b> be selected from ValueSet
+                  LanguageAbilityProficiency<b> <a
+                      href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12199/expansion/Latest"
+                      target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12199</a></b><b>
+                    DYNAMIC</b><b> (CONF:1198-9965)</b>.</li>
+              </ul>
+              <ul>
+                <li>The languageCommunication, if present, <b>SHOULD</b> contain zero or one [0..1]
+                  <b>preferenceInd</b><b> (CONF:1198-5414)</b>.</li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>This patientRole <b>MAY</b> contain zero or one [0..1] <b>providerOrganization</b><b>
+                (CONF:1198-5416)</b>.</li>
+            <ul>
+              <li>The providerOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>id</b><b>
+                  (CONF:1198-5417)</b>.</li>
+              <ul>
+                <li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b>
+                  National Provider Identifier<b> (CONF:1198-16820)</b>.</li>
+              </ul>
+            </ul>
+            <ul>
+              <li>The providerOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b>
+                  (CONF:1198-5419)</b>.</li>
+            </ul>
+            <ul>
+              <li>The providerOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b>
+                  (CONF:1198-5420)</b>.</li>
+              <ul>
+                <li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected
+                  from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b>
+                    (CONF:1198-7994)</b>.</li>
+              </ul>
+            </ul>
+            <ul>
+              <li>The providerOrganization, if present, <b>SHALL</b> contain at least one [1..*] US Realm Address
+                (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5422)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: author<br>The author element represents the creator of the clinical document. The author may be a
+          device or a person. <br></p> <b>SHALL</b> contain at least one [1..*] <b>author</b><b> (CONF:1198-5444)</b>.
+        <ul>
+          <li>Such authors <b>SHALL</b> contain exactly one [1..1] US Realm Date and Time (DTM.US.FIELDED)<b>
+              (identifier: 2.16.840.1.113883.10.20.22.5.4)</b><b> (CONF:1198-5445)</b>.</li>
+        </ul>
+        <ul>
+          <li>Such authors <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b> (CONF:1198-5448)</b>.</li>
+          <ul>
+            <li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5449)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>id</b><b> (CONF:1198-32882)</b> such
+              that it</li>
+            <ul>
+              <li><b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"UNK"</b> Unknown (CodeSystem:
+                <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+                  (CONF:1198-32883)</b>.</li>
+            </ul>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider
+                Identifier<b> (CONF:1198-32884)</b>.</li>
+            </ul>
+            <ul>
+              <li><b>SHOULD</b> contain zero or one [0..1] <b>@extension</b><b> (CONF:1198-32885)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-16787)</b>.</li>
+            <ul>
+              <li>The code, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be
+                selected from ValueSet Healthcare Provider Taxonomy<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-16788)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5452)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5428)</b>.
+            </li>
+            <ul>
+              <li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected
+                from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b>
+                  (CONF:1198-7995)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>assignedPerson</b><b>
+                (CONF:1198-5430)</b>.</li>
+            <ul>
+              <li>The assignedPerson, if present, <b>SHALL</b> contain at least one [1..*] US Realm Person Name
+                (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-16789)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>assignedAuthoringDevice</b><b>
+                (CONF:1198-16783)</b>.</li>
+            <ul>
+              <li>The assignedAuthoringDevice, if present, <b>SHALL</b> contain exactly one [1..1]
+                <b>manufacturerModelName</b><b> (CONF:1198-16784)</b>.</li>
+            </ul>
+            <ul>
+              <li>The assignedAuthoringDevice, if present, <b>SHALL</b> contain exactly one [1..1]
+                <b>softwareName</b><b> (CONF:1198-16785)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>There <strong>SHALL</strong> be exactly one assignedAuthor/assignedPerson or exactly one
+                assignedAuthor/assignedAuthoringDevice (CONF:1198-16790).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: dataEnterer<br>The dataEnterer element represents the person who transferred the content, written or
+          dictated, into the clinical document. To clarify, an author provides the content found within the header or
+          body of a document, subject to their own interpretation; a dataEnterer adds an author's information to the
+          electronic system.<br></p> <b>MAY</b> contain zero or one [0..1] <b>dataEnterer</b><b> (CONF:1198-5441)</b>.
+        <ul>
+          <li>The dataEnterer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+              (CONF:1198-5442)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5443)</b>.</li>
+            <ul>
+              <li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National
+                Provider Identifier<b> (CONF:1198-16821)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected
+              from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b>
+                (CONF:1198-32173)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5460)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5466)</b>.
+            </li>
+            <ul>
+              <li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected
+                from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b>
+                  (CONF:1198-7996)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b>
+                (CONF:1198-5469)</b>.</li>
+            <ul>
+              <li>This assignedPerson <b>SHALL</b> contain at least one [1..*] US Realm Person Name (PN.US.FIELDED)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5470)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: informant<br>The informant element describes an information source for any content within the
+          clinical document. This informant is constrained for use when the source of information is an assigned health
+          care provider for the patient.<br><br></p> <b>MAY</b> contain zero or more [0..*] <b>informant</b><b>
+          (CONF:1198-8001)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-8002)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-9945)</b>.</li>
+            <ul>
+              <li>
+                <p>If assignedEntity/id is a provider then this id, <strong>SHOULD</strong> include zero or one [0..1]
+                  id where id/@root ="2.16.840.1.113883.4.6" National Provider Identifier (CONF:1198-9946).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected
+              from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b>
+                (CONF:1198-32174)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-8220)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b>
+                (CONF:1198-8221)</b>.</li>
+            <ul>
+              <li>This assignedPerson <b>SHALL</b> contain at least one [1..*] US Realm Person Name (PN.US.FIELDED)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-8222)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: informant<br>The informant element describes an information source (who is not a provider) for any
+          content within the clinical document. This informant would be used when the source of information has a
+          personal relationship with the patient or is the patient.<br><br></p> <b>MAY</b> contain zero or more [0..*]
+        <b>informant</b><b> (CONF:1198-31355)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>relatedEntity</b><b> (CONF:1198-31356)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: custodian<br>The custodian element represents the organization that is in charge of maintaining and
+          is entrusted with the care of the document.<br>There is only one custodian per CDA document. Allowing that a
+          CDA document may not represent the original form of the authenticated document, the custodian represents the
+          steward of the original source document. The custodian may be the document originator, a health information
+          exchange, or other responsible party.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>custodian</b><b>
+          (CONF:1198-5519)</b>.<ul>
+          <li>This custodian <b>SHALL</b> contain exactly one [1..1] <b>assignedCustodian</b><b> (CONF:1198-5520)</b>.
+          </li>
+          <ul>
+            <li>This assignedCustodian <b>SHALL</b> contain exactly one [1..1]
+              <b>representedCustodianOrganization</b><b> (CONF:1198-5521)</b>.</li>
+            <ul>
+              <li>This representedCustodianOrganization <b>SHALL</b> contain at least one [1..*] <b>id</b><b>
+                  (CONF:1198-5522)</b>.</li>
+              <ul>
+                <li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b>
+                  National Provider Identifier<b> (CONF:1198-16822)</b>.</li>
+              </ul>
+            </ul>
+            <ul>
+              <li>This representedCustodianOrganization <b>SHALL</b> contain exactly one [1..1] <b>name</b><b>
+                  (CONF:1198-5524)</b>.</li>
+            </ul>
+            <ul>
+              <li>This representedCustodianOrganization <b>SHALL</b> contain exactly one [1..1] <b>telecom</b><b>
+                  (CONF:1198-5525)</b>.</li>
+              <ul>
+                <li>This telecom <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected
+                  from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b>
+                    (CONF:1198-7998)</b>.</li>
+              </ul>
+            </ul>
+            <ul>
+              <li>This representedCustodianOrganization <b>SHALL</b> contain exactly one [1..1] US Realm Address
+                (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5559)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: informationRecipient<br>The informationRecipient element records the intended recipient of the
+          information at the time the document was created. In cases where the intended recipient of the document is the
+          patient's health chart, set the receivedOrganization to the scoping organization for that chart.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>informationRecipient</b><b> (CONF:1198-5565)</b>.<ul>
+          <li>The informationRecipient, if present, <b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b>
+              (CONF:1198-5566)</b>.</li>
+          <ul>
+            <li>This intendedRecipient <b>MAY</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-32399)</b>.</li>
+          </ul>
+          <ul>
+            <li>This intendedRecipient <b>MAY</b> contain zero or one [0..1] <b>informationRecipient</b><b>
+                (CONF:1198-5567)</b>.</li>
+            <ul>
+              <li>The informationRecipient, if present, <b>SHALL</b> contain at least one [1..*] US Realm Person Name
+                (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5568)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This intendedRecipient <b>MAY</b> contain zero or one [0..1] <b>receivedOrganization</b><b>
+                (CONF:1198-5577)</b>.</li>
+            <ul>
+              <li>The receivedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>name</b><b>
+                  (CONF:1198-5578)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: sdtc:signatureText<br>The sdtc:signatureText extension provides a location in CDA for a textual or
+          multimedia depiction of the signature by which the participant endorses and accepts responsibility for his or
+          her participation in the Act as specified in the Participation.typeCode. Details of what goes in the field are
+          described in the HL7 CDA Digital Signature Standard balloted in Fall 2013.</p>
+        <p>Heading: legalAuthenticator<br>The legalAuthenticator identifies the single person legally responsible for
+          the document and must be present if the document has been legally authenticated. A clinical document that does
+          not contain this element has not been legally authenticated.<br>The act of legal authentication requires a
+          certain privilege be granted to the legal authenticator depending upon local policy. Based on local practice,
+          clinical documents may be released before legal authentication. <br>All clinical documents have the potential
+          for legal authentication, given the appropriate credentials.<br>Local policies MAY choose to delegate the
+          function of legal authentication to a device or system that generates the clinical document. In these cases,
+          the legal authenticator is a person accepting responsibility for the document, not the generating device or
+          system.<br>Note that the legal authenticator, if present, must be a person.<br></p> <b>SHOULD</b> contain zero
+        or one [0..1] <b>legalAuthenticator</b><b> (CONF:1198-5579)</b>.<ul>
+          <li>The legalAuthenticator, if present, <b>SHALL</b> contain exactly one [1..1] US Realm Date and Time
+            (DTM.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.4)</b><b> (CONF:1198-5580)</b>.</li>
+        </ul>
+        <ul>
+          <li>The legalAuthenticator, if present, <b>SHALL</b> contain exactly one [1..1] <b>signatureCode</b><b>
+              (CONF:1198-5583)</b>.</li>
+          <ul>
+            <li>This signatureCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"S"</b> (CodeSystem:
+              <b>HL7ParticipationSignature <a
+                  href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationSignature.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.89</a></b><b> STATIC</b>)<b>
+                (CONF:1198-5584)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li>The legalAuthenticator, if present, <b>MAY</b> contain zero or one [0..1] <b>sdtc:signatureText</b><b>
+              (CONF:1198-30810)</b>.<br>Note: The signature can be represented either inline or by reference according
+            to the ED data type. Typical cases for CDA are:1) Electronic signature: this attribute can represent
+            virtually any electronic signature scheme.2) Digital signature: this attribute can represent digital
+            signatures by reference to a signature data block that is constructed in accordance to a digital signature
+            standard, such as XML-DSIG, PKCS#7, PGP, etc.</li>
+        </ul>
+        <ul>
+          <li>The legalAuthenticator, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+              (CONF:1198-5585)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5586)</b>.</li>
+            <ul>
+              <li>Such ids <b>MAY</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National
+                Provider Identifier<b> (CONF:1198-16823)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected
+              from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b>
+                (CONF:1198-17000)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5589)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5595)</b>.
+            </li>
+            <ul>
+              <li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected
+                from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b>
+                  (CONF:1198-7999)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b>
+                (CONF:1198-5597)</b>.</li>
+            <ul>
+              <li>This assignedPerson <b>SHALL</b> contain at least one [1..*] US Realm Person Name (PN.US.FIELDED)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5598)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The sdtc:signatureText extension provides a location in CDA for a textual or multimedia depiction of the
+          signature by which the participant endorses and accepts responsibility for his or her participation in the Act
+          as specified in the Participation.typeCode. Details of what goes in the field are described in the HL7 CDA
+          Digital Signature Standard balloted in Fall of 2013.<br></p>
+        <p>Heading: authenticator<br>The authenticator identifies a participant or participants who attest to the
+          accuracy of the information in the document.<br></p> <b>MAY</b> contain zero or more [0..*]
+        <b>authenticator</b><b> (CONF:1198-5607)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] US Realm Date and Time (DTM.US.FIELDED)<b> (identifier:
+              2.16.840.1.113883.10.20.22.5.4)</b><b> (CONF:1198-5608)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>signatureCode</b><b> (CONF:1198-5610)</b>.</li>
+          <ul>
+            <li>This signatureCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"S"</b> (CodeSystem:
+              <b>HL7ParticipationSignature <a
+                  href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationSignature.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.89</a></b><b> STATIC</b>)<b>
+                (CONF:1198-5611)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>sdtc:signatureText</b><b> (CONF:1198-30811)</b>.<br>Note: The
+            signature can be represented either inline or by reference according to the ED data type. Typical cases for
+            CDA are:1) Electronic signature: this attribute can represent virtually any electronic signature scheme.2)
+            Digital signature: this attribute can represent digital signatures by reference to a signature data block
+            that is constructed in accordance to a digital signature standard, such as XML-DSIG, PKCS#7, PGP, etc.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-5612)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-5613)</b>.</li>
+            <ul>
+              <li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National
+                Provider Identifier <b> (CONF:1198-16824)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-16825)</b>.</li>
+            <ul>
+              <li>The code, if present, <b>MAY</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be
+                selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b>
+                  (CONF:1198-16826)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-5616)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-5622)</b>.
+            </li>
+            <ul>
+              <li>Such telecoms <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected
+                from ValueSet Telecom Use (US Realm Header)<b> 2.16.840.1.113883.11.20.9.20</b><b> DYNAMIC</b><b>
+                  (CONF:1198-8000)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b>
+                (CONF:1198-5624)</b>.</li>
+            <ul>
+              <li>This assignedPerson <b>SHALL</b> contain at least one [1..*] US Realm Person Name (PN.US.FIELDED)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-5625)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: participant<br>The participant element identifies supporting entities, including parents, relatives,
+          caregivers, insurance policyholders, guarantors, and others related in some way to the patient. <br>A
+          supporting person or organization is an individual or an organization with a relationship to the patient. A
+          supporting person who is playing multiple roles would be recorded in multiple participants (e.g., emergency
+          contact and next-of-kin).<br><br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b>
+          (CONF:1198-10003)</b> such that it<ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-10004)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p><strong>SHALL</strong> contain associatedEntity/associatedPerson <em>AND/OR</em>
+              associatedEntity/scopingOrganization (CONF:1198-10006).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When participant/@typeCode is <em>IND</em>, associatedEntity/@classCode <strong>SHOULD</strong> be
+              selected from ValueSet <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33
+              </a>INDRoleclassCodes <em>STATIC 2011-09-30</em> (CONF:1198-10007).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: inFulfillmentOf<br>The inFulfillmentOf element represents orders that are fulfilled by this document
+          such as a radiologists' report of an x-ray.<br></p> <b>MAY</b> contain zero or more [0..*]
+        <b>inFulfillmentOf</b><b> (CONF:1198-9952)</b>.<ul>
+          <li>The inFulfillmentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>order</b><b>
+              (CONF:1198-9953)</b>.</li>
+          <ul>
+            <li>This order <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-9954)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>A serviceEvent represents the main act being documented, such as a colonoscopy or a cardiac stress study. In
+          a provision of healthcare serviceEvent, the care providers, PCP, or other longitudinal providers, are recorded
+          within the serviceEvent. If the document is about a single encounter, the providers associated can be recorded
+          in the componentOf/encompassingEncounter template.</p> <b>MAY</b> contain zero or more [0..*]
+        <b>documentationOf</b><b> (CONF:1198-14835)</b>.<ul>
+          <li>The documentationOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b>
+              (CONF:1198-14836)</b>.</li>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-14837)</b>.
+            </li>
+            <ul>
+              <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-14838)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-14839)</b>.
+            </li>
+            <ul>
+              <li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>, which
+                <b>SHALL</b> be selected from ValueSet x_ServiceEventPerformer<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.19601/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.19601</a></b><b>
+                  STATIC</b><b> (CONF:1198-14840)</b>.</li>
+            </ul>
+            <ul>
+              <li>The performer, if present, <b>MAY</b> contain zero or one [0..1] <b>functionCode</b><b>
+                  (CONF:1198-16818)</b>.</li>
+              <ul>
+                <li>The functionCode, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which
+                  <b>SHOULD</b> be selected from ValueSet Care Team Member Function<b> <a
+                      href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion/Latest"
+                      target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.30</a></b><b>
+                    DYNAMIC</b><b> (CONF:1198-32889)</b>.</li>
+              </ul>
+            </ul>
+            <ul>
+              <li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+                  (CONF:1198-14841)</b>.</li>
+              <ul>
+                <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14846)</b>.
+                </li>
+                <ul>
+                  <li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b>
+                    National Provider Identifier<b> (CONF:1198-14847)</b>.</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be
+                  selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b>
+                    DYNAMIC</b><b> (CONF:1198-14842)</b>.</li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: authorization<br>The authorization element represents information about the patient's
+          consent.<br>The type of consent is conveyed in consent/code. Consents in the header have been finalized
+          (consent/statusCode must equal Completed) and should be on file. This specification does not address how
+          'Privacy Consent' is represented, but does not preclude the inclusion of Privacy Consent.<br>The authorization
+          consent is used for referring to consents that are documented elsewhere in the EHR or medical record for a
+          health condition and/or treatment that is described in the CDA document.<br><br></p> <b>MAY</b> contain zero
+        or more [0..*] <b>authorization</b><b> (CONF:1198-16792)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>consent</b><b> (CONF:1198-16793)</b>.</li>
+          <ul>
+            <li>This consent <b>MAY</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-16794)</b>.</li>
+          </ul>
+          <ul>
+            <li>This consent <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-16795)</b>.<br>Note: The
+              type of consent (e.g., a consent to perform the related serviceEvent) is conveyed in consent/code. </li>
+          </ul>
+          <ul>
+            <li>This consent <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-16797)</b>.</li>
+            <ul>
+              <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+                (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+                  (CONF:1198-16798)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: componentOf<br>The encompassing encounter represents the setting of the clinical encounter during
+          which the document act(s) or ServiceEvent(s) occurred. In order to represent providers associated with a
+          specific encounter, they are recorded within the encompassingEncounter as participants. In a CCD, the
+          encompassingEncounter may be used when documenting a specific encounter and its participants. All relevant
+          encounters in a CCD may be listed in the encounters section.<br><br></p> <b>MAY</b> contain zero or one [0..1]
+        <b>componentOf</b><b> (CONF:1198-9955)</b>.<ul>
+          <li>The componentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b>
+              (CONF:1198-9956)</b>.</li>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-9959)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+                (CONF:1198-9958)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/Assigned%20Health%20Care%20Provider%20informant%20Example.xml"><i class="fab fa-github"></i>&nbsp;Assigned Health Care Provider informant Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/authenticator%20Example.xml"><i class="fab fa-github"></i>&nbsp;authenticator Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/author%20Example.xml"><i class="fab fa-github"></i>&nbsp;author Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/authorization%20Example.xml"><i class="fab fa-github"></i>&nbsp;authorization Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/custodian%20Example.xml"><i class="fab fa-github"></i>&nbsp;custodian Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/dateEnterer%20Example.xml"><i class="fab fa-github"></i>&nbsp;dateEnterer Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/Digital%20signature%20Example.xml"><i class="fab fa-github"></i>&nbsp;Digital signature Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/documentationOf%20Example.xml"><i class="fab fa-github"></i>&nbsp;documentationOf Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/informationRecipient%20Example.xml"><i class="fab fa-github"></i>&nbsp;informationRecipient Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/inFulfillmentOf%20Example.xml"><i class="fab fa-github"></i>&nbsp;inFulfillmentOf Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/legalAuthenticator%20Example.xml"><i class="fab fa-github"></i>&nbsp;legalAuthenticator Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/performer%20Example.xml"><i class="fab fa-github"></i>&nbsp;performer Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/Personal%20Relation%20informant%20Example.xml"><i class="fab fa-github"></i>&nbsp;Personal Relation informant Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/recordTarget%20Example.xml"><i class="fab fa-github"></i>&nbsp;recordTarget Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/Supporting%20Person%20participant%20Example.xml"><i class="fab fa-github"></i>&nbsp;Supporting Person participant Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/US%20Realm%20Header%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;US Realm Header (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/Assigned%20Health%20Care%20Provider%20informant%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Assigned Health Care Provider informant Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/authenticator%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;authenticator Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/author%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;author Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/authorization%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;authorization Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/custodian%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;custodian Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/dateEnterer%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;dateEnterer Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/Digital%20signature%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Digital signature Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/documentationOf%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;documentationOf Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/informationRecipient%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;informationRecipient Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/inFulfillmentOf%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;inFulfillmentOf Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/legalAuthenticator%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;legalAuthenticator Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/performer%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;performer Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/Personal%20Relation%20informant%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Personal Relation informant Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/recordTarget%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;recordTarget Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/Supporting%20Person%20participant%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Supporting Person participant Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20(V3)_2.16.840.1.113883.10.20.22.1.1/US%20Realm%20Header%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;US Realm Header (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.10.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.10.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,157 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Unstructured Document (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.10, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.10.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Unstructured Document (V3) <small class="text-muted">[ClinicalDocument,
+        2.16.840.1.113883.10.20.22.1.10, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.1.10.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>An Unstructured Document (UD) document type can (1) include unstructured content, such as a graphic, directly in a text element with a mediaType attribute, or (2) reference a single document file, such as a word-processing document using a text/reference element.For guidance on how to handle multiple files, on the selection of media types for this IG, and on the identification of external files, see the examples that follow the constraints below.IHE's XDS-SD (Cross-Transaction Specifications and Content Specifications, Scanned Documents Module) profile addresses a similar, more restricted use case, specifically for scanned documents or documents electronically created from existing text sources, and limits content to PDF-A or text. This Unstructured Documents template is applicable not only for scanned documents in non-PDF formats, but also for clinical documents produced through word processing applications, etc.For conformance with both specifications, implementers need to ensure that their documents at a minimum conform with the SHALL constraints from either specification.</p></div>
+    <div id="description">
+      <p>An Unstructured Document (UD) document type can (1) include unstructured content, such as a graphic, directly
+        in a text element with a mediaType attribute, or (2) reference a single document file, such as a word-processing
+        document using a text/reference element.For guidance on how to handle multiple files, on the selection of media
+        types for this IG, and on the identification of external files, see the examples that follow the constraints
+        below.IHE's XDS-SD (Cross-Transaction Specifications and Content Specifications, Scanned Documents Module)
+        profile addresses a similar, more restricted use case, specifically for scanned documents or documents
+        electronically created from existing text sources, and limits content to PDF-A or text. This Unstructured
+        Documents template is applicable not only for scanned documents in non-PDF formats, but also for clinical
+        documents produced through word processing applications, etc.For conformance with both specifications,
+        implementers need to ensure that their documents at a minimum conform with the SHALL constraints from either
+        specification.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7710)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.10"</b><b> (CONF:1198-10054)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32522)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32944).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>recordTarget</b><b> (CONF:1198-31089)</b>.<ul><li>Such recordTargets <b>SHALL</b> contain exactly one [1..1] <b>patientRole</b><b> (CONF:1198-31090)</b>.</li><ul><li>This patientRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31091)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>custodian</b><b> (CONF:1198-31096)</b>.<ul><li>This custodian <b>SHALL</b> contain exactly one [1..1] <b>assignedCustodian</b><b> (CONF:1198-31097)</b>.</li><ul><li>This assignedCustodian <b>SHALL</b> contain exactly one [1..1] <b>representedCustodianOrganization</b><b> (CONF:1198-31098)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>Heading: nonXMLBody<br>An Unstructured Document must include a nonXMLBody component with a single text element. The text element can reference an external file using a reference element, or include unstructured content directly with a mediaType attribute. The nonXMLBody/text element also has a "compression" attribute that can be used to indicate that the unstructured content was compressed before being Base64Encoded. At a minimum, a compression value of "DF" for the deflate compression algorithm (RFC 1951 [URL:http://www.ietf.org/rfc/rfc1951.txt]) must be supported although it is not required that content be compressed.</p> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-31085)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>nonXMLBody</b><b> (CONF:1198-31086)</b>.</li><ul><li>This nonXMLBody <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-31087)</b>.</li><ul><li><p>If the text element does not contain a reference element with a value attribute, then it <strong>SHALL</strong> contain exactly one [1..1] @representation="B64" and exactly one [1..1] @mediaType (CONF:1198-7624).</p></li></ul><ul><li><p>The value of @mediaType, if present, <strong>SHALL</strong> be drawn from the value set <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.7.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.7.1 </a>SupportedFileFormats STATIC 2010-05-12 (CONF:1198-7623).</p></li></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7710)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.10"</b><b>
+              (CONF:1198-10054)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32522)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32944).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>recordTarget</b><b>
+          (CONF:1198-31089)</b>.<ul>
+          <li>Such recordTargets <b>SHALL</b> contain exactly one [1..1] <b>patientRole</b><b> (CONF:1198-31090)</b>.
+          </li>
+          <ul>
+            <li>This patientRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31091)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>custodian</b><b> (CONF:1198-31096)</b>.
+        <ul>
+          <li>This custodian <b>SHALL</b> contain exactly one [1..1] <b>assignedCustodian</b><b> (CONF:1198-31097)</b>.
+          </li>
+          <ul>
+            <li>This assignedCustodian <b>SHALL</b> contain exactly one [1..1]
+              <b>representedCustodianOrganization</b><b> (CONF:1198-31098)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: nonXMLBody<br>An Unstructured Document must include a nonXMLBody component with a single text
+          element. The text element can reference an external file using a reference element, or include unstructured
+          content directly with a mediaType attribute. The nonXMLBody/text element also has a "compression" attribute
+          that can be used to indicate that the unstructured content was compressed before being Base64Encoded. At a
+          minimum, a compression value of "DF" for the deflate compression algorithm (RFC 1951
+          [URL:http://www.ietf.org/rfc/rfc1951.txt]) must be supported although it is not required that content be
+          compressed.</p> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-31085)</b>.<ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>nonXMLBody</b><b> (CONF:1198-31086)</b>.</li>
+          <ul>
+            <li>This nonXMLBody <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-31087)</b>.</li>
+            <ul>
+              <li>
+                <p>If the text element does not contain a reference element with a value attribute, then it
+                  <strong>SHALL</strong> contain exactly one [1..1] @representation="B64" and exactly one [1..1]
+                  @mediaType (CONF:1198-7624).</p>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <p>The value of @mediaType, if present, <strong>SHALL</strong> be drawn from the value set <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.7.1/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.7.1
+                  </a>SupportedFileFormats STATIC 2010-05-12 (CONF:1198-7623).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Unstructured%20Document%20(V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody%20Example%20with%20Compressed%20Content.xml"><i class="fab fa-github"></i>&nbsp;nonXMLBody Example with Compressed Content</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Unstructured%20Document%20(V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody%20Example%20with%20Embedded%20Content.xml"><i class="fab fa-github"></i>&nbsp;nonXMLBody Example with Embedded Content</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Unstructured%20Document%20(V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody%20Example%20with%20Referenced%20Content.xml"><i class="fab fa-github"></i>&nbsp;nonXMLBody Example with Referenced Content</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Unstructured%20Document%20(V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody%20Example%20with%20Compressed%20Content.xml"><i
+            class="fab fa-github"></i>&nbsp;nonXMLBody Example with Compressed Content</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Unstructured%20Document%20(V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody%20Example%20with%20Embedded%20Content.xml"><i
+            class="fab fa-github"></i>&nbsp;nonXMLBody Example with Embedded Content</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Unstructured%20Document%20(V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody%20Example%20with%20Referenced%20Content.xml"><i
+            class="fab fa-github"></i>&nbsp;nonXMLBody Example with Referenced Content</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Unstructured"><i class="fas fa-external-link-alt"></i> Unstructured</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Unstructured"><i class="fas fa-external-link-alt"></i>
+          Unstructured</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.13.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.13.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,500 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Transfer Summary (V2) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.13, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.13.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Transfer Summary (V2) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.13,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.13.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This document describes constraints on the Clinical Document Architecture (CDA) header and body elements for a Transfer Summary. The Transfer Summary standardizes critical information for exchange of information between providers of care when a patient moves between health care settings.Standardization of information used in this form will promote interoperability; create information suitable for reuse in quality measurement, public health, research, and for reimbursement.</p></div>
+    <div id="description">
+      <p>This document describes constraints on the Clinical Document Architecture (CDA) header and body elements for a
+        Transfer Summary. The Transfer Summary standardizes critical information for exchange of information between
+        providers of care when a patient moves between health care settings.Standardization of information used in this
+        form will promote interoperability; create information suitable for reuse in quality measurement, public health,
+        research, and for reimbursement.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.22.1.html">Encounters Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.24.html">Discharge Diagnosis Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries required) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.18.html">Payers Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.1.html">Procedures Section (entries required) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.2.5.html">General Status Section</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.1.html">Reason for Referral Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a href="2.16.840.1.113883.10.20.22.2.44.html">Admission Medications Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.43.html">Admission Diagnosis Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.64.html">Course of Care Section</a><br><a href="2.16.840.1.113883.10.20.22.2.21.1.html">Advance Directives Section (entries required) (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances Section (entries
+              required) (V3)</a><br><a href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.22.1.html">Encounters Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.24.html">Discharge Diagnosis Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries required) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.18.html">Payers Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.7.1.html">Procedures Section (entries required) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.2.5.html">General Status Section</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.1.html">Reason for Referral Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.44.html">Admission Medications Section (entries optional)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.43.html">Admission Diagnosis Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.64.html">Course of Care Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.21.1.html">Advance Directives Section (entries required) (V3)</a><br>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28239)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.13"</b><b> (CONF:1198-28240)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32907)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32946).</p></li></ul></li>
-<li class="list-group-item"><p>The Transfer Summary recommends use of the document type code 18761-7 "Provider Unspecified Transfer Summary", with further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any coded values describing the author or performer of the service act or the practice setting must be consistent with the LOINC document type. For example, an Obstetrics and Gynecology Transfer Summary note would not be authored by a Pediatric Cardiologist.<br>Pre-coordinated codes are those that indicate the specialty or service provided in the LOINC Long Common Name (Print Name in the TransferDocumentType valueSet table).<br>When using a generic type of code such as 18761-7 (Provider - Unspecified Transfer Summary), the types of services involved in the care are handled in documentationOf/serviceEvent with the use of serviceEvent/code (e.g., use a SNOMED CT procedure code such as 69031006 (Excision of breast tissue) while performers/providers involved in the care can be identified using the functionCode (bound to Healthcare Provider Taxonomy role codes).<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet TransferDocumentType<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.4/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.4</a></b><b> DYNAMIC</b><b> (CONF:1198-28243)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-29838)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31599)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> indirect (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1198-31872)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31600)</b>.</li><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>, which <b>SHALL</b> be selected from ValueSet INDRoleclassCodes<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33</a></b><b> DYNAMIC</b><b> (CONF:1198-31873)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b> (CONF:1198-31601)</b>.</li><ul><li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31602)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31626)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CALLBCK"</b> Call back contact (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1198-31627)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31628)</b>.</li><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b> assigned entity (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b>)<b> (CONF:1198-31641)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31629)</b>.</li></ul><ul><li>This associatedEntity <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31630)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-31631)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b> (CONF:1198-31632)</b>.</li><ul><li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31633)</b>.</li></ul></ul><ul><li>This associatedEntity <b>MAY</b> contain zero or one [0..1] <b>scopingOrganization</b><b> (CONF:1198-31634)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>The serviceEvent in a Transfer Note contains the representation of providers who are wholly or partially responsible for the safety and well-being of a subject of care.</p> <b>SHALL</b> contain exactly one [1..1] <b>documentationOf</b><b> (CONF:1198-31570)</b>.<ul><li>This documentationOf <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-31571)</b>.</li><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Care Provision (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-31572)</b>.</li></ul><ul><li>This serviceEvent <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-32650)</b>.</li></ul><ul><li>This serviceEvent <b>SHALL</b> contain at least one [1..*] <b>performer</b><b> (CONF:1198-31574)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRF"</b> Participation of Physical Performer (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> DYNAMIC</b>)<b> (CONF:1198-31575)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>functionCode</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1198-32651)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28251)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-28252)</b>.</li><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28253)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Advance Directives Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.21.1)</b><b> (CONF:1198-28254)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28255)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergies and Intolerances Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.6.1)</b><b> (CONF:1198-28256)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28257)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Physical Exam Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-28258)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28261)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Encounters Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.22.1)</b><b> (CONF:1198-28262)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28263)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-28264)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28265)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-28266)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28271)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Discharge Diagnosis Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.24)</b><b> (CONF:1198-28272)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28273)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Immunizations Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.2)</b><b> (CONF:1198-28274)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28275)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medical Equipment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.23)</b><b> (CONF:1198-28276)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28277)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medications Section (entries required) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.1.1)</b><b> (CONF:1198-28278)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28279)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Payers Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.18)</b><b> (CONF:1198-28280)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28281)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Plan of Treatment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-28282)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28283)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.5.1)</b><b> (CONF:1198-28284)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28285)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedures Section (entries required) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.7.1)</b><b> (CONF:1198-28286)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28287)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Results Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.3.1)</b><b> (CONF:1198-28288)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28289)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-28290)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28291)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Signs Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.4.1)</b><b> (CONF:1198-28292)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28327)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.56)</b><b> (CONF:1198-28328)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28838)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  General Status Section<b> (identifier: 2.16.840.1.113883.10.20.2.5)</b><b> (CONF:1198-28839)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30239)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Review of Systems Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30240)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30776)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-30777)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-31342)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Reason for Referral Section (V2)<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.1)</b><b> (CONF:1198-31343)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31561)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Past Medical History (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-31562)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31563)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  History of Present Illness Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-31564)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31565)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment and Plan Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-31566)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31567)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-31568)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32445)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Admission Medications Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.44)</b><b> (CONF:1198-32446)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32447)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Admission Diagnosis Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.43)</b><b> (CONF:1198-32448)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32648)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Course of Care Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.64)</b><b> (CONF:1198-32649)</b>.</li></ul></ul><ul><li><p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-31582).</p></li></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-31583).</p></li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28239)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.13"</b><b>
+              (CONF:1198-28240)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32907)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32946).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The Transfer Summary recommends use of the document type code 18761-7 "Provider Unspecified Transfer
+          Summary", with further specification provided by author or performer, setting, or specialty. When
+          pre-coordinated codes are used, any coded values describing the author or performer of the service act or the
+          practice setting must be consistent with the LOINC document type. For example, an Obstetrics and Gynecology
+          Transfer Summary note would not be authored by a Pediatric Cardiologist.<br>Pre-coordinated codes are those
+          that indicate the specialty or service provided in the LOINC Long Common Name (Print Name in the
+          TransferDocumentType valueSet table).<br>When using a generic type of code such as 18761-7 (Provider -
+          Unspecified Transfer Summary), the types of services involved in the care are handled in
+          documentationOf/serviceEvent with the use of serviceEvent/code (e.g., use a SNOMED CT procedure code such as
+          69031006 (Excision of breast tissue) while performers/providers involved in the care can be identified using
+          the functionCode (bound to Healthcare Provider Taxonomy role codes).<br></p> <b>SHALL</b> contain exactly one
+        [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet TransferDocumentType<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.4/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.4</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-28243)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-29838)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31599)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> indirect (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:1198-31872)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31600)</b>.</li>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>, which <b>SHALL</b> be
+              selected from ValueSet INDRoleclassCodes<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33</a></b><b>
+                DYNAMIC</b><b> (CONF:1198-31873)</b>.</li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b>
+                (CONF:1198-31601)</b>.</li>
+            <ul>
+              <li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31602)</b>.
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31626)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CALLBCK"</b> Call back contact (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:1198-31627)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31628)</b>.</li>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b>
+              assigned entity (CodeSystem: <b>HL7RoleClass <a
+                  href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b>)<b> (CONF:1198-31641)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31629)</b>.</li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31630)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-31631)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b>
+                (CONF:1198-31632)</b>.</li>
+            <ul>
+              <li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31633)</b>.
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>MAY</b> contain zero or one [0..1] <b>scopingOrganization</b><b>
+                (CONF:1198-31634)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The serviceEvent in a Transfer Note contains the representation of providers who are wholly or partially
+          responsible for the safety and well-being of a subject of care.</p> <b>SHALL</b> contain exactly one [1..1]
+        <b>documentationOf</b><b> (CONF:1198-31570)</b>.<ul>
+          <li>This documentationOf <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-31571)</b>.
+          </li>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Care Provision
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+                (CONF:1198-31572)</b>.</li>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-32650)</b>.</li>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain at least one [1..*] <b>performer</b><b> (CONF:1198-31574)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRF"</b> Participation of Physical
+                Performer (CodeSystem: <b>HL7ParticipationType <a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> DYNAMIC</b>)<b>
+                  (CONF:1198-31575)</b>.</li>
+            </ul>
+            <ul>
+              <li><b>MAY</b> contain zero or one [0..1] <b>functionCode</b>, which <b>SHOULD</b> be selected from
+                ValueSet Healthcare Provider Taxonomy<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-32651)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28251)</b>.
+        <ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-28252)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28253)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Advance Directives Section (entries required) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.21.1)</b><b> (CONF:1198-28254)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28255)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Allergies and Intolerances Section (entries required) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.6.1)</b><b> (CONF:1198-28256)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28257)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Physical Exam Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-28258)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28261)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Encounters Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.22.1)</b><b> (CONF:1198-28262)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28263)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Family History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-28264)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28265)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Functional Status Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-28266)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28271)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Discharge Diagnosis Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.24)</b><b> (CONF:1198-28272)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28273)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Immunizations Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.2)</b><b> (CONF:1198-28274)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28275)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medical Equipment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.23)</b><b> (CONF:1198-28276)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28277)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medications Section (entries required) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.1.1)</b><b> (CONF:1198-28278)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28279)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Payers Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.18)</b><b> (CONF:1198-28280)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28281)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Plan of Treatment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-28282)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28283)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Problem Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.5.1)</b><b> (CONF:1198-28284)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28285)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedures Section (entries required) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.7.1)</b><b> (CONF:1198-28286)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28287)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Results Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.3.1)</b><b> (CONF:1198-28288)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28289)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Social History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-28290)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28291)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Vital Signs Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.4.1)</b><b> (CONF:1198-28292)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28327)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Mental Status Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.56)</b><b> (CONF:1198-28328)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28838)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] General Status Section<b> (identifier:
+                  2.16.840.1.113883.10.20.2.5)</b><b> (CONF:1198-28839)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30239)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Review of Systems Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30240)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30776)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Nutrition Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-30777)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-31342)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Reason for Referral Section (V2)<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.1)</b><b> (CONF:1198-31343)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31561)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Past Medical History (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-31562)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31563)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] History of Present Illness Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-31564)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31565)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment and Plan Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-31566)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31567)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-31568)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32445)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Admission Medications Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.44)</b><b> (CONF:1198-32446)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32447)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Admission Diagnosis Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.43)</b><b> (CONF:1198-32448)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32648)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Course of Care Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.64)</b><b> (CONF:1198-32649)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan
+                of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-31582).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a
+                Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-31583).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Transfer%20Summary%20(V2)_2.16.840.1.113883.10.20.22.1.13/Transfer%20Summary%20Callback%20Contact%20Example.xml"><i class="fab fa-github"></i>&nbsp;Transfer Summary Callback Contact Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Transfer%20Summary%20(V2)_2.16.840.1.113883.10.20.22.1.13/Transfer%20Summary%20participant%20(Support)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Transfer Summary participant (Support) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Transfer%20Summary%20(V2)_2.16.840.1.113883.10.20.22.1.13/Transfer%20Summary%20Callback%20Contact%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Transfer Summary Callback Contact Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Transfer%20Summary%20(V2)_2.16.840.1.113883.10.20.22.1.13/Transfer%20Summary%20participant%20(Support)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Transfer Summary participant (Support) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.14.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.14.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,437 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Referral Note (V2) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.14, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.14.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Referral Note (V2) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.14,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.14.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Referral Note communicates pertinent information from a provider who is requesting services of another provider of clinical or non-clinical services. The information in this document includes the reason for the referral and additional information that would augment decision making and care delivery.Examples of referral situations are when a patient is referred from a family physician to a cardiologist for cardiac evaluation or when patient is sent by a cardiologist to an emergency department for angina or when a patient is referred by a nurse practitioner to an audiologist for hearing screening or when a patient is referred by a hospitalist to social services.</p></div>
+    <div id="description">
+      <p>A Referral Note communicates pertinent information from a provider who is requesting services of another
+        provider of clinical or non-clinical services. The information in this document includes the reason for the
+        referral and additional information that would augment decision making and care delivery.Examples of referral
+        situations are when a patient is referred from a family physician to a cardiologist for cardiac evaluation or
+        when patient is sent by a cardiologist to an emergency department for angina or when a patient is referred by a
+        nurse practitioner to an audiologist for hearing screening or when a patient is referred by a hospitalist to
+        social services.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.2.1.html">Immunizations Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required) (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a href="2.16.840.1.113883.10.20.2.5.html">General Status Section</a><br><a href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries required) (V2)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.1.html">Reason for Referral Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.1.html">US Realm Patient Name (PTN.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries optional) (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.2.1.html">Immunizations Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required) (V3)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances Section (entries required)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.2.5.html">General Status Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries required) (V2)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.1.html">Reason for Referral Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br><a
+              href="2.16.840.1.113883.10.20.22.5.1.html">US Realm Patient Name (PTN.US.FIELDED)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries optional) (V3)</a><br>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28947)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.14"</b><b> (CONF:1198-28948)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32911)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32943).</p></li></ul></li>
-<li class="list-group-item"><p>The Referral Note recommends use of the document type code 57133-1 "Referral Note", with further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any coded values describing the author or performer of the service act or the practice setting must be consistent with the LOINC document type. For example, an Obstetrics and Gynecology Referral note would not be authored by a Pediatric Cardiologist.  The type of referral and the target of the referral are specified via the participant (and not via the author).<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet ReferralDocumentType<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.3/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.3</a></b><b> DYNAMIC</b><b> (CONF:1198-28949)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>informationRecipient</b><b> (CONF:1198-31589)</b>.<ul><li>This informationRecipient <b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b> (CONF:1198-31590)</b>.</li><ul><li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31591)</b>.</li></ul><ul><li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1198-31592)</b>.</li></ul><ul><li>This intendedRecipient <b>SHALL</b> contain exactly one [1..1] <b>informationRecipient</b><b> (CONF:1198-31593)</b>.</li><ul><li>This informationRecipient <b>SHALL</b> contain at least one [1..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-31594)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31642)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> Indirect (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1198-31924)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31643)</b>.</li><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>, which <b>SHALL</b> be selected from ValueSet INDRoleclassCodes<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33</a></b><b> DYNAMIC</b><b> (CONF:1198-31925)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b> (CONF:1198-31644)</b>.</li><ul><li>This associatedPerson <b>SHALL</b> contain at least one [1..*]  US Realm Patient Name (PTN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1)</b><b> (CONF:1198-31645)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>This participant represents the clinician to contact for questions about the referral note.  This call back contact individual may be a different person than the individual(s) identified in the author or legalAuthenticator participant.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31647)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CALLBCK"</b> call back contact (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> DYNAMIC</b>)<b> (CONF:1198-31648)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31649)</b>.</li><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b> assigned entity (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b>)<b> (CONF:1198-32419)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31650)</b>.</li></ul><ul><li>This associatedEntity <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31651)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-31652)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b> (CONF:1198-31653)</b>.</li><ul><li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31654)</b>.</li></ul></ul><ul><li>This associatedEntity <b>MAY</b> contain zero or one [0..1] <b>scopingOrganization</b><b> (CONF:1198-31655)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-29062)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-29063)</b>.</li><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29066)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Plan of Treatment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-29067)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29068)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Advance Directives Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.21)</b><b> (CONF:1198-29069)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29074)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  History of Present Illness Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-29075)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29076)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-29077)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29082)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Immunizations Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.2.1)</b><b> (CONF:1198-29083)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-29086)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.5.1)</b><b> (CONF:1198-29087)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29088)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedures Section (entries optional) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-29089)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29090)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Results Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.3.1)</b><b> (CONF:1198-29091)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29092)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Review of Systems Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-29093)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29094)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-29095)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29096)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Signs Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.4.1)</b><b> (CONF:1198-29097)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29098)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-29099)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29100)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Physical Exam Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-29101)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30780)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-30781)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30796)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.56)</b><b> (CONF:1198-30926)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30798)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medical Equipment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.23)</b><b> (CONF:1198-30799)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30911)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergies and Intolerances Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.6.1)</b><b> (CONF:1198-30912)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30913)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-30914)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30915)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment and Plan Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-30916)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30917)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Past Medical History (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-30918)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30919)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  General Status Section<b> (identifier: 2.16.840.1.113883.10.20.2.5)</b><b> (CONF:1198-30920)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30922)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medications Section (entries required) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.1.1)</b><b> (CONF:1198-30923)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30924)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Reason for Referral Section (V2)<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.1)</b><b> (CONF:1198-30925)</b>.</li></ul></ul><ul><li><p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-29102).</p></li></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-29103).</p></li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28947)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.14"</b><b>
+              (CONF:1198-28948)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32911)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32943).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The Referral Note recommends use of the document type code 57133-1 "Referral Note", with further
+          specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any
+          coded values describing the author or performer of the service act or the practice setting must be consistent
+          with the LOINC document type. For example, an Obstetrics and Gynecology Referral note would not be authored by
+          a Pediatric Cardiologist. The type of referral and the target of the referral are specified via the
+          participant (and not via the author).<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which
+        <b>SHALL</b> be selected from ValueSet ReferralDocumentType<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.3/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.3</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-28949)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>informationRecipient</b><b>
+          (CONF:1198-31589)</b>.<ul>
+          <li>This informationRecipient <b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b>
+              (CONF:1198-31590)</b>.</li>
+          <ul>
+            <li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31591)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b>
+                (CONF:1198-31592)</b>.</li>
+          </ul>
+          <ul>
+            <li>This intendedRecipient <b>SHALL</b> contain exactly one [1..1] <b>informationRecipient</b><b>
+                (CONF:1198-31593)</b>.</li>
+            <ul>
+              <li>This informationRecipient <b>SHALL</b> contain at least one [1..*] US Realm Person Name
+                (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-31594)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31642)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> Indirect (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:1198-31924)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31643)</b>.</li>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>, which <b>SHALL</b> be
+              selected from ValueSet INDRoleclassCodes<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33</a></b><b>
+                DYNAMIC</b><b> (CONF:1198-31925)</b>.</li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b>
+                (CONF:1198-31644)</b>.</li>
+            <ul>
+              <li>This associatedPerson <b>SHALL</b> contain at least one [1..*] US Realm Patient Name
+                (PTN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1)</b><b> (CONF:1198-31645)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This participant represents the clinician to contact for questions about the referral note. This call back
+          contact individual may be a different person than the individual(s) identified in the author or
+          legalAuthenticator participant.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b>
+          (CONF:1198-31647)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CALLBCK"</b> call back contact (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              DYNAMIC</b>)<b> (CONF:1198-31648)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31649)</b>.</li>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b>
+              assigned entity (CodeSystem: <b>HL7RoleClass <a
+                  href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b>)<b> (CONF:1198-32419)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31650)</b>.</li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31651)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-31652)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b>
+                (CONF:1198-31653)</b>.</li>
+            <ul>
+              <li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31654)</b>.
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>MAY</b> contain zero or one [0..1] <b>scopingOrganization</b><b>
+                (CONF:1198-31655)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-29062)</b>.
+        <ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-29063)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29066)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Plan of Treatment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-29067)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29068)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Advance Directives Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.21)</b><b> (CONF:1198-29069)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29074)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] History of Present Illness Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-29075)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29076)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Family History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-29077)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29082)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Immunizations Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.2.1)</b><b> (CONF:1198-29083)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-29086)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Problem Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.5.1)</b><b> (CONF:1198-29087)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29088)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedures Section (entries optional) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-29089)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29090)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Results Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.3.1)</b><b> (CONF:1198-29091)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29092)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Review of Systems Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-29093)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29094)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Social History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-29095)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29096)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Vital Signs Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.4.1)</b><b> (CONF:1198-29097)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29098)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Functional Status Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-29099)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29100)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Physical Exam Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-29101)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30780)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Nutrition Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-30781)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30796)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Mental Status Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.56)</b><b> (CONF:1198-30926)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30798)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medical Equipment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.23)</b><b> (CONF:1198-30799)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30911)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Allergies and Intolerances Section (entries required) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.6.1)</b><b> (CONF:1198-30912)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30913)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-30914)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30915)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment and Plan Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-30916)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30917)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Past Medical History (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-30918)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30919)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] General Status Section<b> (identifier:
+                  2.16.840.1.113883.10.20.2.5)</b><b> (CONF:1198-30920)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30922)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medications Section (entries required) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.1.1)</b><b> (CONF:1198-30923)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30924)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Reason for Referral Section (V2)<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.1)</b><b> (CONF:1198-30925)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan
+                of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-29102).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a
+                Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-29103).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Referral%20Note%20(V2)_2.16.840.1.113883.10.20.22.1.14/Referral%20Note%20Callback%20Contact%20Example.xml"><i class="fab fa-github"></i>&nbsp;Referral Note Callback Contact Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Referral%20Note%20(V2)_2.16.840.1.113883.10.20.22.1.14/Referral%20Note%20Caregiver%20Example.xml"><i class="fab fa-github"></i>&nbsp;Referral Note Caregiver Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Referral%20Note%20(V2)_2.16.840.1.113883.10.20.22.1.14/Referral%20Note%20informationRecipient%20Example.xml"><i class="fab fa-github"></i>&nbsp;Referral Note informationRecipient Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Referral%20Note%20(V2)_2.16.840.1.113883.10.20.22.1.14/Referral%20Note%20Callback%20Contact%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Referral Note Callback Contact Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Referral%20Note%20(V2)_2.16.840.1.113883.10.20.22.1.14/Referral%20Note%20Caregiver%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Referral Note Caregiver Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Referral%20Note%20(V2)_2.16.840.1.113883.10.20.22.1.14/Referral%20Note%20informationRecipient%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Referral Note informationRecipient Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.15.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.15.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,61 +52,406 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Care Plan (V2) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.15, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.15.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Care Plan (V2) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.15, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.15.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>CARE PLAN FRAMEWORK</p><p>A Care Plan (including Home Health Plan of Care (HHPoC)) is a consensus-driven dynamic plan that represents a patient's and Care Team Members' prioritized concerns, goals, and planned interventions. It serves as a blueprint shared by all Care Team Members (including the patient, their caregivers and providers), to guide the patient's care. A Care Plan integrates multiple interventions proposed by multiple providers and disciplines for multiple conditions.</p><p>A Care Plan represents one or more Plan(s) of Care and serves to reconcile and resolve conflicts between the various Plans of Care developed for a specific patient by different providers. While both a plan of care and a care plan include the patient's life goals and require Care Team Members (including patients) to prioritize goals and interventions, the reconciliation process becomes more complex as the number of plans of care increases. The Care Plan also serves to enable longitudinal coordination of care.</p><p>The CDA Care Plan represents an instance of this dynamic Care Plan at a point in time. The CDA document itself is NOT dynamic.</p><p>Key differentiators between a Care Plan CDA and CCD (another 'snapshot in time' document):There are 2 required sections:o  Health Concernso  InterventionsThere are 2 optional sections:o  Goalso  Outcomes'	Provides the ability to identify patient and provider priorities with each act'	Provides a header participant to indicate occurrences of Care Plan reviewA care plan document can include entry references from the information in these sections to the information (entries) in other sections.</p><p>Please see Volume 1 of this guide to view a Care Plan Relationship diagram and story board.</p></div>
+    <div id="description">
+      <p>CARE PLAN FRAMEWORK</p>
+      <p>A Care Plan (including Home Health Plan of Care (HHPoC)) is a consensus-driven dynamic plan that represents a
+        patient's and Care Team Members' prioritized concerns, goals, and planned interventions. It serves as a
+        blueprint shared by all Care Team Members (including the patient, their caregivers and providers), to guide the
+        patient's care. A Care Plan integrates multiple interventions proposed by multiple providers and disciplines for
+        multiple conditions.</p>
+      <p>A Care Plan represents one or more Plan(s) of Care and serves to reconcile and resolve conflicts between the
+        various Plans of Care developed for a specific patient by different providers. While both a plan of care and a
+        care plan include the patient's life goals and require Care Team Members (including patients) to prioritize
+        goals and interventions, the reconciliation process becomes more complex as the number of plans of care
+        increases. The Care Plan also serves to enable longitudinal coordination of care.</p>
+      <p>The CDA Care Plan represents an instance of this dynamic Care Plan at a point in time. The CDA document itself
+        is NOT dynamic.</p>
+      <p>Key differentiators between a Care Plan CDA and CCD (another 'snapshot in time' document):There are 2 required
+        sections:o Health Concernso InterventionsThere are 2 optional sections:o Goalso Outcomes' Provides the ability
+        to identify patient and provider priorities with each act' Provides a header participant to indicate occurrences
+        of Care Plan reviewA care plan document can include entry references from the information in these sections to
+        the information (entries) in other sections.</p>
+      <p>Please see Volume 1 of this guide to view a Care Plan Relationship diagram and story board.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.58.html">Health Concerns Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.60.html">Goals Section</a><br><a href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.61.html">Health Status Evaluations and Outcomes Section</a><br><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.58.html">Health Concerns Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.60.html">Goals Section</a><br><a
+              href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.61.html">Health Status Evaluations and Outcomes Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28741)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.15"</b><b> (CONF:1198-28742)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32877)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32934).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-28745)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Care Plan Document Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.10/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.10</a></b><b> DYNAMIC</b><b> (CONF:1198-32959)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>setId</b><b> (CONF:1198-32321)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>versionNumber</b><b> (CONF:1198-32322)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>informationRecipient</b><b> (CONF:1198-31993)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b> (CONF:1198-31994)</b>.</li><ul><li>This intendedRecipient <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31996)</b>.</li></ul><ul><li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31997)</b>.</li></ul><ul><li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1198-31998)</b>.</li></ul><ul><li>This intendedRecipient <b>SHOULD</b> contain zero or one [0..1] <b>informationRecipient</b><b> (CONF:1198-31999)</b>.</li><ul><li>The informationRecipient, if present, <b>SHALL</b> contain exactly one [1..1]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-32320)</b>.</li></ul></ul><ul><li>This intendedRecipient <b>SHOULD</b> contain zero or one [0..1] <b>receivedOrganization</b><b> (CONF:1198-32000)</b>.</li><ul><li>The receivedOrganization, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-32001)</b>.</li></ul><ul><li>The receivedOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-32002)</b>.</li></ul><ul><li>The receivedOrganization, if present, <b>SHOULD</b> contain zero or one [0..1] <b>standardIndustryClassCode</b>, which <b>SHALL</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1198-32003)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>authenticator</b><b> (CONF:1198-31910)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:1198-31911)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>signatureCode</b><b> (CONF:1198-31912)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>sdtc:signatureText</b><b> (CONF:1198-31913)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-31914)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31915)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-31916)</b>.</li><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ONESELF"</b> Self<b> (CONF:1198-31917)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.111</a>"</b> (CodeSystem: <b>HL7RoleCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.111</a></b>)<b> (CONF:1198-31918)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31677)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"VRF"</b> Verifier (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1198-31678)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>functionCode</b><b> (CONF:1198-31679)</b>.</li><ul><li>This functionCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"425268008"</b> Review of Care Plan<b> (CONF:1198-31680)</b>.</li></ul><ul><li>This functionCode <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-31681)</b>.</li></ul></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:1198-31682)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31683)</b>.</li><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b> (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b>)<b> (CONF:1198-31686)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31684)</b>.</li></ul><ul><li>This associatedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-31685)</b>.</li><ul><li>The code, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b> DYNAMIC</b><b> (CONF:1198-32367)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31895)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> Indirect (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1198-31896)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31897)</b>.</li><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>, which <b>SHALL</b> be selected from ValueSet INDRoleclassCodes<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33</a></b><b> STATIC</b><b> (CONF:1198-31898)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b> (CONF:1198-31899)</b>.</li><ul><li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31900)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: documentationOf<br>The serviceEvent describes the provision of healthcare over a period of time. The duration over which care was provided is indicated in serviceEvent/effectiveTime. Additional data from outside this duration may also be included if it is relevant to care provided during that time range (e.g., reviewed during the stated time range).<br></p> <b>SHALL</b> contain exactly one [1..1] <b>documentationOf</b><b> (CONF:1198-31901)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-31902)</b>.</li><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Care Provision (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-31903)</b>.</li></ul><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-31904)</b>.</li><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-32330)</b>.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1198-32331)</b>.</li></ul></ul><ul><li>This serviceEvent <b>SHALL</b> contain at least one [1..*] <b>performer</b><b> (CONF:1198-31905)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-31907)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31908)</b>.</li></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-31909)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b> (CONF:1198-32328)</b>.</li><ul><li>This assignedPerson <b>SHALL</b> contain exactly one [1..1]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-32329)</b>.</li></ul></ul></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>relatedDocument</b><b> (CONF:1198-29893)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>, which <b>SHALL</b> be selected from ValueSet x_ActRelationshipDocument<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.11610/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.11610</a></b><b> STATIC</b><b> (CONF:1198-31889)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>parentDocument</b><b> (CONF:1198-29894)</b>.</li><ul><li>This parentDocument <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-32949)</b>.</li></ul><ul><li>This parentDocument <b>SHALL</b> contain exactly one [1..1] <b>setId</b><b> (CONF:1198-29895)</b>.</li></ul><ul><li>This parentDocument <b>SHALL</b> contain exactly one [1..1] <b>versionNumber</b><b> (CONF:1198-29896)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>componentOf</b><b> (CONF:1198-32004)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b> (CONF:1198-32005)</b>.</li><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-32007)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28753)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-28754)</b>.</li><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28755)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Health Concerns Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.58)</b><b> (CONF:1198-28756)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28761)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Goals Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.60)</b><b> (CONF:1198-28762)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28763)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Interventions Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.21.2.3)</b><b> (CONF:1198-28764)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29596)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Health Status Evaluations and Outcomes Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.61)</b><b> (CONF:1198-29597)</b>.</li></ul></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain a Plan of Treatment Section (V2) (identifier: 2.16.840.1.113883.10.20.22.2.10) (CONF:1198-31044).</p></li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28741)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.15"</b><b>
+              (CONF:1198-28742)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32877)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32934).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-28745)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet Care Plan Document Type<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.10/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.10</a></b><b>
+              DYNAMIC</b><b> (CONF:1198-32959)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>setId</b><b> (CONF:1198-32321)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>versionNumber</b><b>
+          (CONF:1198-32322)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>informationRecipient</b><b>
+          (CONF:1198-31993)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b> (CONF:1198-31994)</b>.</li>
+          <ul>
+            <li>This intendedRecipient <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31996)</b>.</li>
+          </ul>
+          <ul>
+            <li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31997)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b>
+                (CONF:1198-31998)</b>.</li>
+          </ul>
+          <ul>
+            <li>This intendedRecipient <b>SHOULD</b> contain zero or one [0..1] <b>informationRecipient</b><b>
+                (CONF:1198-31999)</b>.</li>
+            <ul>
+              <li>The informationRecipient, if present, <b>SHALL</b> contain exactly one [1..1] US Realm Person Name
+                (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-32320)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This intendedRecipient <b>SHOULD</b> contain zero or one [0..1] <b>receivedOrganization</b><b>
+                (CONF:1198-32000)</b>.</li>
+            <ul>
+              <li>The receivedOrganization, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b>
+                  (CONF:1198-32001)</b>.</li>
+            </ul>
+            <ul>
+              <li>The receivedOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b>
+                  (CONF:1198-32002)</b>.</li>
+            </ul>
+            <ul>
+              <li>The receivedOrganization, if present, <b>SHOULD</b> contain zero or one [0..1]
+                <b>standardIndustryClassCode</b>, which <b>SHALL</b> be selected from ValueSet Healthcare Provider
+                Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-32003)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>authenticator</b><b>
+          (CONF:1198-31910)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:1198-31911)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>signatureCode</b><b> (CONF:1198-31912)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>sdtc:signatureText</b><b> (CONF:1198-31913)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-31914)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31915)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-31916)</b>.</li>
+            <ul>
+              <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ONESELF"</b> Self<b>
+                  (CONF:1198-31917)</b>.</li>
+            </ul>
+            <ul>
+              <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleCode.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.111</a>"</b> (CodeSystem: <b>HL7RoleCode
+                  <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleCode.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.111</a></b>)<b> (CONF:1198-31918)</b>.
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31677)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"VRF"</b> Verifier (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:1198-31678)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>functionCode</b><b> (CONF:1198-31679)</b>.</li>
+          <ul>
+            <li>This functionCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"425268008"</b> Review of Care
+              Plan<b> (CONF:1198-31680)</b>.</li>
+          </ul>
+          <ul>
+            <li>This functionCode <b>SHALL</b> contain exactly one [1..1]
+              <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT
+                2.16.840.1.113883.6.96</b>)<b> (CONF:1198-31681)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:1198-31682)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31683)</b>.</li>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b>
+              (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b>)<b>
+                (CONF:1198-31686)</b>.</li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31684)</b>.</li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-31685)</b>.
+            </li>
+            <ul>
+              <li>The code, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be
+                selected from ValueSet Personal And Legal Relationship Role Type<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-32367)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31895)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> Indirect (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:1198-31896)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31897)</b>.</li>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>, which <b>SHALL</b> be
+              selected from ValueSet INDRoleclassCodes<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33</a></b><b>
+                STATIC</b><b> (CONF:1198-31898)</b>.</li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b>
+                (CONF:1198-31899)</b>.</li>
+            <ul>
+              <li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31900)</b>.
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: documentationOf<br>The serviceEvent describes the provision of healthcare over a period of time. The
+          duration over which care was provided is indicated in serviceEvent/effectiveTime. Additional data from outside
+          this duration may also be included if it is relevant to care provided during that time range (e.g., reviewed
+          during the stated time range).<br></p> <b>SHALL</b> contain exactly one [1..1] <b>documentationOf</b><b>
+          (CONF:1198-31901)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-31902)</b>.</li>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Care Provision
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+                (CONF:1198-31903)</b>.</li>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-31904)</b>.
+            </li>
+            <ul>
+              <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-32330)</b>.</li>
+            </ul>
+            <ul>
+              <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1198-32331)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain at least one [1..*] <b>performer</b><b> (CONF:1198-31905)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-31907)</b>.</li>
+              <ul>
+                <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31908)</b>.
+                </li>
+              </ul>
+              <ul>
+                <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-31909)</b>.</li>
+              </ul>
+              <ul>
+                <li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>assignedPerson</b><b>
+                    (CONF:1198-32328)</b>.</li>
+                <ul>
+                  <li>This assignedPerson <b>SHALL</b> contain exactly one [1..1] US Realm Person Name
+                    (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-32329)</b>.</li>
+                </ul>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>relatedDocument</b><b>
+          (CONF:1198-29893)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>, which <b>SHALL</b> be selected from ValueSet
+            x_ActRelationshipDocument<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.11610/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.11610</a></b><b>
+              STATIC</b><b> (CONF:1198-31889)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>parentDocument</b><b> (CONF:1198-29894)</b>.</li>
+          <ul>
+            <li>This parentDocument <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-32949)</b>.</li>
+          </ul>
+          <ul>
+            <li>This parentDocument <b>SHALL</b> contain exactly one [1..1] <b>setId</b><b> (CONF:1198-29895)</b>.</li>
+          </ul>
+          <ul>
+            <li>This parentDocument <b>SHALL</b> contain exactly one [1..1] <b>versionNumber</b><b>
+                (CONF:1198-29896)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>componentOf</b><b> (CONF:1198-32004)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b> (CONF:1198-32005)</b>.</li>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+                (CONF:1198-32007)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28753)</b>.
+        <ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-28754)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28755)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Health Concerns Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.58)</b><b> (CONF:1198-28756)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28761)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Goals Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.60)</b><b> (CONF:1198-28762)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28763)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Interventions Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.21.2.3)</b><b> (CONF:1198-28764)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-29596)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Health Status Evaluations and Outcomes Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.61)</b><b> (CONF:1198-29597)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain a Plan of Treatment Section (V2) (identifier:
+                2.16.840.1.113883.10.20.22.2.10) (CONF:1198-31044).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20Caregiver%20participant%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Plan Caregiver participant Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20Patient%20authenticator%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Plan Patient authenticator Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20performer%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Plan performer Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20relatedDocument%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Plan relatedDocument Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20Review%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Plan Review Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20Caregiver%20participant%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Plan Caregiver participant Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20Patient%20authenticator%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Plan Patient authenticator Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20performer%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Plan performer Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20relatedDocument%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Plan relatedDocument Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Plan%20(V2)_2.16.840.1.113883.10.20.22.1.15/Care%20Plan%20Review%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Plan Review Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.2.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.2.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,358 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Continuity of Care Document (CCD) (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.2, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Continuity of Care Document (CCD) (V3) <small class="text-muted">[ClinicalDocument,
+        2.16.840.1.113883.10.20.22.1.2, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.1.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This document type was originally based on the Continuity of Care Document (CCD) Release 1.1 which itself was derived from HITSP C32 and CCD Release 1.0.</p><p>The Continuity of Care Document (CCD) represents a core data set of the most relevant administrative, demographic, and clinical information facts about a patient's healthcare, covering one or more healthcare encounters. It provides a means for one healthcare practitioner, system, or setting to aggregate all of the pertinent data about a patient and forward it to another to support the continuity of care.</p><p>The primary use case for the CCD is to provide a snapshot in time containing the germane clinical, demographic, and administrative data for a specific patient. The key characteristic of a CCD is that the ServiceEvent is constrained to "PCPR". This means it does not function to report new ServiceEvents associated with performing care. It reports on care that has already been provided. The CCD provides a historical tally of the care over a range of time and is not a record of new services delivered.</p><p>More specific use cases, such as a Discharge Summary, Transfer Summary, Referral Note, Consultation Note, or Progress Note, are available as alternative documents in this guide.</p></div>
+    <div id="description">
+      <p>This document type was originally based on the Continuity of Care Document (CCD) Release 1.1 which itself was
+        derived from HITSP C32 and CCD Release 1.0.</p>
+      <p>The Continuity of Care Document (CCD) represents a core data set of the most relevant administrative,
+        demographic, and clinical information facts about a patient's healthcare, covering one or more healthcare
+        encounters. It provides a means for one healthcare practitioner, system, or setting to aggregate all of the
+        pertinent data about a patient and forward it to another to support the continuity of care.</p>
+      <p>The primary use case for the CCD is to provide a snapshot in time containing the germane clinical, demographic,
+        and administrative data for a specific patient. The key characteristic of a CCD is that the ServiceEvent is
+        constrained to "PCPR". This means it does not function to report new ServiceEvents associated with performing
+        care. It reports on care that has already been provided. The CCD provides a historical tally of the care over a
+        range of time and is not a record of new services delivered.</p>
+      <p>More specific use cases, such as a Discharge Summary, Transfer Summary, Referral Note, Consultation Note, or
+        Progress Note, are available as alternative documents in this guide.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries required) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.1.html">Procedures Section (entries required) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.22.html">Encounters Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.2.1.html">Immunizations Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.18.html">Payers Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries optional)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances Section (entries
+              required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries
+              required) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.1.html">Procedures Section (entries required)
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.22.html">Encounters Section (entries optional)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.2.1.html">Immunizations Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.18.html">Payers Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8450)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.2"</b><b> (CONF:1198-10038)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32516)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32936).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-17180)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"34133-9"</b> Summarization of Episode Note<b> (CONF:1198-17181)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32138)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>author</b><b> (CONF:1198-9442)</b>.<ul><li>Such authors <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b> (CONF:1198-9443)</b>.</li><ul><li><p>Such assignedAuthors <strong>SHALL</strong> contain (exactly one [1..1] assignedPerson) or (exactly one [1..1] assignedAuthoringDevice and exactly one [1..1] representedOrganization) (CONF:1198-8456).</p></li></ul><ul><li><p>If assignedAuthor has an associated representedOrganization with no assignedPerson or assignedAuthoringDevice, then the value for ClinicalDocument/author/assignedAuthor/id/@NullFlavor <strong>SHALL</strong> be "NA" Not applicable <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a> NullFlavor STATIC (CONF:1198-8457).</p></li></ul></ul></li>
-<li class="list-group-item"><p>The main activity being described by a CCD is the provision of healthcare over a period of time. This is shown by setting the value of serviceEvent/@classCode to "PCPR" (care provision) and indicating the duration over which care was provided in serviceEvent/effectiveTime. Additional data from outside this duration may also be included if it is relevant to care provided during that time range (e.g., reviewed during the stated time range). <br>NOTE: Implementations originating a CCD should take care to discover what the episode of care being summarized is. For example, when a patient fills out a form providing relevant health history, the episode of care being documented might be from birth to the present. </p><p>Heading: documentationOf<br>The documentationOf relationship in a Continuity Care Document contains the representation of providers who are wholly or partially responsible for the safety and well-being of a subject of care.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>documentationOf</b><b> (CONF:1198-8452)</b>.<ul><li>This documentationOf <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-8480)</b>.</li><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Care Provision (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-8453)</b>.</li></ul><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-8481)</b>.</li><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-8454)</b>.</li></ul><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1198-8455)</b>.</li></ul></ul><ul><li>This serviceEvent <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-8482)</b>.</li><ul><li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRF"</b> Participation physical performer (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8458)</b>.</li></ul><ul><li>The performer, if present, <b>MAY</b> contain zero or one [0..1] <b>assignedEntity</b><b> (CONF:1198-8459)</b>.</li><ul><li>The assignedEntity, if present, <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30882)</b> such that it</li><ul><li><p>If this assignedEntity is an assignedPerson, the assignedEntity/id <strong>SHOULD</strong> contain zero or one [0..1] @root="2.16.840.1.113883.4.6" National Provider Identifier (CONF:1198-32466).</p></li></ul></ul><ul><li>The assignedEntity, if present, <b>MAY</b> contain zero or one [0..1] <b>assignedPerson</b><b> (CONF:1198-32467)</b>.</li></ul></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30659)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30660)</b>.</li><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30661)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergies and Intolerances Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.6.1)</b><b> (CONF:1198-30662)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30663)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medications Section (entries required) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.1.1)</b><b> (CONF:1198-30664)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30665)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.5.1)</b><b> (CONF:1198-30666)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30667)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedures Section (entries required) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.7.1)</b><b> (CONF:1198-30668)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30669)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Results Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.3.1)</b><b> (CONF:1198-30670)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30671)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Advance Directives Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.21)</b><b> (CONF:1198-30672)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30673)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Encounters Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.22)</b><b> (CONF:1198-30674)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30675)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-30676)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30677)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-30678)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30679)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Immunizations Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.2.1)</b><b> (CONF:1198-30680)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30681)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medical Equipment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.23)</b><b> (CONF:1198-30682)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30683)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Payers Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.18)</b><b> (CONF:1198-30684)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30685)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Plan of Treatment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30686)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30687)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-30688)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30689)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Signs Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.4.1)</b><b> (CONF:1198-30690)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32143)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.56)</b><b> (CONF:1198-32144)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32624)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-32625)</b>.</li></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8450)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.2"</b><b>
+              (CONF:1198-10038)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32516)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32936).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-17180)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"34133-9"</b> Summarization of Episode
+            Note<b> (CONF:1198-17181)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32138)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>author</b><b> (CONF:1198-9442)</b>.<ul>
+          <li>Such authors <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b> (CONF:1198-9443)</b>.</li>
+          <ul>
+            <li>
+              <p>Such assignedAuthors <strong>SHALL</strong> contain (exactly one [1..1] assignedPerson) or (exactly one
+                [1..1] assignedAuthoringDevice and exactly one [1..1] representedOrganization) (CONF:1198-8456).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>If assignedAuthor has an associated representedOrganization with no assignedPerson or
+                assignedAuthoringDevice, then the value for ClinicalDocument/author/assignedAuthor/id/@NullFlavor
+                <strong>SHALL</strong> be "NA" Not applicable <a
+                  href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a> NullFlavor STATIC
+                (CONF:1198-8457).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The main activity being described by a CCD is the provision of healthcare over a period of time. This is
+          shown by setting the value of serviceEvent/@classCode to "PCPR" (care provision) and indicating the duration
+          over which care was provided in serviceEvent/effectiveTime. Additional data from outside this duration may
+          also be included if it is relevant to care provided during that time range (e.g., reviewed during the stated
+          time range). <br>NOTE: Implementations originating a CCD should take care to discover what the episode of care
+          being summarized is. For example, when a patient fills out a form providing relevant health history, the
+          episode of care being documented might be from birth to the present. </p>
+        <p>Heading: documentationOf<br>The documentationOf relationship in a Continuity Care Document contains the
+          representation of providers who are wholly or partially responsible for the safety and well-being of a subject
+          of care.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>documentationOf</b><b> (CONF:1198-8452)</b>.<ul>
+          <li>This documentationOf <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-8480)</b>.
+          </li>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Care Provision
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+                STATIC</b>)<b> (CONF:1198-8453)</b>.</li>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-8481)</b>.
+            </li>
+            <ul>
+              <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-8454)</b>.</li>
+            </ul>
+            <ul>
+              <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1198-8455)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-8482)</b>.
+            </li>
+            <ul>
+              <li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRF"</b>
+                Participation physical performer (CodeSystem: <b>HL7ParticipationType <a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b>
+                  (CONF:1198-8458)</b>.</li>
+            </ul>
+            <ul>
+              <li>The performer, if present, <b>MAY</b> contain zero or one [0..1] <b>assignedEntity</b><b>
+                  (CONF:1198-8459)</b>.</li>
+              <ul>
+                <li>The assignedEntity, if present, <b>SHALL</b> contain at least one [1..*] <b>id</b><b>
+                    (CONF:1198-30882)</b> such that it</li>
+                <ul>
+                  <li>
+                    <p>If this assignedEntity is an assignedPerson, the assignedEntity/id <strong>SHOULD</strong>
+                      contain zero or one [0..1] @root="2.16.840.1.113883.4.6" National Provider Identifier
+                      (CONF:1198-32466).</p>
+                  </li>
+                </ul>
+              </ul>
+              <ul>
+                <li>The assignedEntity, if present, <b>MAY</b> contain zero or one [0..1] <b>assignedPerson</b><b>
+                    (CONF:1198-32467)</b>.</li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30659)</b>.
+        <ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30660)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30661)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Allergies and Intolerances Section (entries required) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.6.1)</b><b> (CONF:1198-30662)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30663)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medications Section (entries required) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.1.1)</b><b> (CONF:1198-30664)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30665)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Problem Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.5.1)</b><b> (CONF:1198-30666)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30667)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedures Section (entries required) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.7.1)</b><b> (CONF:1198-30668)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30669)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Results Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.3.1)</b><b> (CONF:1198-30670)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30671)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Advance Directives Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.21)</b><b> (CONF:1198-30672)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30673)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Encounters Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.22)</b><b> (CONF:1198-30674)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30675)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Family History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-30676)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30677)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Functional Status Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-30678)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30679)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Immunizations Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.2.1)</b><b> (CONF:1198-30680)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30681)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medical Equipment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.23)</b><b> (CONF:1198-30682)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30683)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Payers Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.18)</b><b> (CONF:1198-30684)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30685)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Plan of Treatment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30686)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30687)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Social History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-30688)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30689)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Vital Signs Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.4.1)</b><b> (CONF:1198-30690)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32143)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Mental Status Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.56)</b><b> (CONF:1198-32144)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32624)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Nutrition Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-32625)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Continuity%20of%20Care%20Document%20(CCD)%20(V3)_2.16.840.1.113883.10.20.22.1.2/CCD%20(V2)%20author%20Example.xml"><i class="fab fa-github"></i>&nbsp;CCD (V2) author Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Continuity%20of%20Care%20Document%20(CCD)%20(V3)_2.16.840.1.113883.10.20.22.1.2/CCD%20(V2)%20Performer%20Example.xml"><i class="fab fa-github"></i>&nbsp;CCD (V2) Performer Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Continuity%20of%20Care%20Document%20(CCD)%20(V3)_2.16.840.1.113883.10.20.22.1.2/CCD%20(V2)%20serviceEvent%20Example.xml"><i class="fab fa-github"></i>&nbsp;CCD (V2) serviceEvent Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Continuity%20of%20Care%20Document%20(CCD)%20(V3)_2.16.840.1.113883.10.20.22.1.2/CCD%20(V2)%20author%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;CCD (V2) author Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Continuity%20of%20Care%20Document%20(CCD)%20(V3)_2.16.840.1.113883.10.20.22.1.2/CCD%20(V2)%20Performer%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;CCD (V2) Performer Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Continuity%20of%20Care%20Document%20(CCD)%20(V3)_2.16.840.1.113883.10.20.22.1.2/CCD%20(V2)%20serviceEvent%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;CCD (V2) serviceEvent Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.3.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.3.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,410 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">History and Physical (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.3, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">History and Physical (V3) <small class="text-muted">[ClinicalDocument,
+        2.16.840.1.113883.10.20.22.1.3, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.1.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A History and Physical (H&amp;P) note is a medical report that documents the current and past conditions of the patient. It contains essential information that helps determine an individual's health status.<br>The first portion of the report is a current collection of organized information unique to an individual. This is typically supplied by the patient or the caregiver, concerning the current medical problem or the reason for the patient encounter. This information is followed by a description of any past or ongoing medical issues, including current medications and allergies. Information is also obtained about the patient's lifestyle, habits, and diseases among family members.The next portion of the report contains information obtained by physically examining the patient and gathering diagnostic information in the form of laboratory tests, imaging, or other diagnostic procedures.The report ends with the clinician's assessment of the patient's situation and the intended plan to address those issues.A History and Physical Examination is required upon hospital admission as well as before operative procedures. An initial evaluation in an ambulatory setting is often documented in the form of an H&amp;P note.</p></div>
+    <div id="description">
+      <p>A History and Physical (H&amp;P) note is a medical report that documents the current and past conditions of the
+        patient. It contains essential information that helps determine an individual's health status.<br>The first
+        portion of the report is a current collection of organized information unique to an individual. This is
+        typically supplied by the patient or the caregiver, concerning the current medical problem or the reason for the
+        patient encounter. This information is followed by a description of any past or ongoing medical issues,
+        including current medications and allergies. Information is also obtained about the patient's lifestyle, habits,
+        and diseases among family members.The next portion of the report contains information obtained by physically
+        examining the patient and gathering diagnostic information in the form of laboratory tests, imaging, or other
+        diagnostic procedures.The report ends with the clinician's assessment of the patient's situation and the
+        intended plan to address those issues.A History and Physical Examination is required upon hospital admission as
+        well as before operative procedures. An initial evaluation in an ambulatory setting is often documented in the
+        form of an H&amp;P note.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a href="2.16.840.1.113883.10.20.22.2.13.html">Chief Complaint and Reason for Visit Section</a><br><a href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.2.5.html">General Status Section</a><br><a href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.45.html">Instructions Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.1.html">Medications Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.12.html">Reason for Visit Section</a><br><a href="2.16.840.1.113883.10.20.22.2.3.html">Results Section (entries optional) (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.4.html">Vital Signs Section (entries optional) (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time
+              (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section
+              (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.13.html">Chief Complaint and Reason for Visit Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.2.5.html">General Status Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.45.html">Instructions Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.1.html">Medications Section (entries optional) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.12.html">Reason for Visit Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.3.html">Results Section (entries optional) (V3)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.4.html">Vital Signs Section (entries optional) (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8283)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.3"</b><b> (CONF:1198-10046)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32518)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32939).</p></li></ul></li>
-<li class="list-group-item"><p>The H&amp;P Note recommends use of a single document type code, 34117-2 "History and physical note", with further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any coded values describing the author or performer of the service act or the practice setting must be consistent with the LOINC document type. <br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-17185)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet HPDocumentType<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.22/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.22</a></b><b> DYNAMIC</b><b> (CONF:1198-17186)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>informationRecipient</b><b> (CONF:1198-32482)</b>.<ul><li>The informationRecipient, if present, <b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b> (CONF:1198-32483)</b>.</li></ul></li>
-<li class="list-group-item"><p>A special class of participant is the supporting person or organization:  an individual or an organization that has a relationship to the patient, including  parents, relatives, caregivers, insurance policyholders, and guarantors. In the case of a supporting person who is also an emergency contact or next-of-kin, a participant element should be present for each role recorded.</p><p>Heading: participant<br>The participant element in the H&amp;P header follows the General Header Constraints for participants. H&amp;P Note does not specify any use for functionCode for participants. Local policies will determine how this element should be used in implementations.<br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8286)</b>.<ul><li><p>When participant/@typeCode is IND, associatedEntity/@classCode <strong>SHALL</strong> be selected from ValueSet <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33 </a>INDRoleclassCodes <em>STATIC</em> 2011-09-30 (CONF:1198-8333).</p></li></ul></li>
-<li class="list-group-item"><p>Heading: inFulfillmentOf<br>inFulfillmentOf elements describe the prior orders that are fulfilled (in whole or part) by the service events described in this document. For example, the prior order might be a referral and the H&amp;P Note may be in partial fulfillment of that referral.<br></p> <b>MAY</b> contain zero or more [0..*] <b>inFulfillmentOf</b><b> (CONF:1198-8336)</b>.</li>
-<li class="list-group-item"><p>Heading: componentOf<br>The H&amp;P Note is always associated with an encounter.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>componentOf</b><b> (CONF:1198-8338)</b>.<ul><li>This componentOf <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b> (CONF:1198-8339)</b>.</li><ul><li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8340)</b>.</li></ul><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-8341)</b>.</li></ul><ul><li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>responsibleParty</b><b> (CONF:1198-8345)</b>.</li><ul><li><p>The responsibleParty element, if present, <strong>SHALL</strong> contain an assignedEntity element, which <strong>SHALL</strong> contain an assignedPerson element, a representedOrganization element, or both (CONF:1198-8348).</p></li></ul></ul><ul><li>This encompassingEncounter <b>MAY</b> contain zero or more [0..*] <b>encounterParticipant</b><b> (CONF:1198-8342)</b>.</li><ul><li><p>An encounterParticipant element, if present, SHALL contain an assignedEntity element, which SHALL contain an assignedPerson element, a representedOrganization element, or both (CONF:1198-8343).</p></li></ul></ul><ul><li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>location</b><b> (CONF:1198-8344)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>In this template (templateId 2.16.840.1.113883.10.20.22.1.3.2), coded entries are optional.</p> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-8349)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30570)</b>.</li><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30571)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergies and Intolerances Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.6)</b><b> (CONF:1198-30572)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30573)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-30574)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30575)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Plan of Treatment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30576)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30577)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment and Plan Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-30578)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30579)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Chief Complaint Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-30580)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30581)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Chief Complaint and Reason for Visit Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.13)</b><b> (CONF:1198-30582)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30583)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-30584)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30585)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  General Status Section<b> (identifier: 2.16.840.1.113883.10.20.2.5)</b><b> (CONF:1198-30586)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30587)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Past Medical History (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-30588)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30589)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  History of Present Illness Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-30590)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30591)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Immunizations Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.2)</b><b> (CONF:1198-30592)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30593)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Instructions Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.45)</b><b> (CONF:1198-31385)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30595)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medications Section (entries optional) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.1)</b><b> (CONF:1198-30596)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30597)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Physical Exam Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-30598)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30599)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.5)</b><b> (CONF:1198-30600)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30601)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedures Section (entries optional) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-30602)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30603)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Reason for Visit Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.12)</b><b> (CONF:1198-30604)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30605)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Results Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.3)</b><b> (CONF:1198-30606)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30607)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Review of Systems Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30608)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30609)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-30610)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30611)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Signs Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.4)</b><b> (CONF:1198-30612)</b>.</li></ul></ul><ul><li><p>This structuredBody <strong>SHALL</strong> contain a Chief Complaint and Reason for Visit Section (2.16.840.1.113883.10.20.22.2.13) or a Chief Complaint Section (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) (CONF:1198-30613).</p></li></ul><ul><li><p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-30614).</p></li></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-30615).</p></li></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain a Chief Complaint and Reason for Visit Section (2.16.840.1.113883.10.20.22.2.13) when either a Chief Complaint Section (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) is present (CONF:1198-30616).</p></li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8283)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.3"</b><b>
+              (CONF:1198-10046)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32518)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32939).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The H&amp;P Note recommends use of a single document type code, 34117-2 "History and physical note", with
+          further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are
+          used, any coded values describing the author or performer of the service act or the practice setting must be
+          consistent with the LOINC document type. <br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b>
+          (CONF:1198-17185)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet HPDocumentType<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.22/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.22</a></b><b>
+              DYNAMIC</b><b> (CONF:1198-17186)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>informationRecipient</b><b>
+          (CONF:1198-32482)</b>.<ul>
+          <li>The informationRecipient, if present, <b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b>
+              (CONF:1198-32483)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>A special class of participant is the supporting person or organization: an individual or an organization
+          that has a relationship to the patient, including parents, relatives, caregivers, insurance policyholders, and
+          guarantors. In the case of a supporting person who is also an emergency contact or next-of-kin, a participant
+          element should be present for each role recorded.</p>
+        <p>Heading: participant<br>The participant element in the H&amp;P header follows the General Header Constraints
+          for participants. H&amp;P Note does not specify any use for functionCode for participants. Local policies will
+          determine how this element should be used in implementations.<br></p> <b>MAY</b> contain zero or more [0..*]
+        <b>participant</b><b> (CONF:1198-8286)</b>.<ul>
+          <li>
+            <p>When participant/@typeCode is IND, associatedEntity/@classCode <strong>SHALL</strong> be selected from
+              ValueSet <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33
+              </a>INDRoleclassCodes <em>STATIC</em> 2011-09-30 (CONF:1198-8333).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: inFulfillmentOf<br>inFulfillmentOf elements describe the prior orders that are fulfilled (in whole
+          or part) by the service events described in this document. For example, the prior order might be a referral
+          and the H&amp;P Note may be in partial fulfillment of that referral.<br></p> <b>MAY</b> contain zero or more
+        [0..*] <b>inFulfillmentOf</b><b> (CONF:1198-8336)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>Heading: componentOf<br>The H&amp;P Note is always associated with an encounter.<br></p> <b>SHALL</b> contain
+        exactly one [1..1] <b>componentOf</b><b> (CONF:1198-8338)</b>.<ul>
+          <li>This componentOf <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b>
+              (CONF:1198-8339)</b>.</li>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8340)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] US Realm Date and Time
+              (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-8341)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>responsibleParty</b><b>
+                (CONF:1198-8345)</b>.</li>
+            <ul>
+              <li>
+                <p>The responsibleParty element, if present, <strong>SHALL</strong> contain an assignedEntity element,
+                  which <strong>SHALL</strong> contain an assignedPerson element, a representedOrganization element, or
+                  both (CONF:1198-8348).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>MAY</b> contain zero or more [0..*] <b>encounterParticipant</b><b>
+                (CONF:1198-8342)</b>.</li>
+            <ul>
+              <li>
+                <p>An encounterParticipant element, if present, SHALL contain an assignedEntity element, which SHALL
+                  contain an assignedPerson element, a representedOrganization element, or both (CONF:1198-8343).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>location</b><b>
+                (CONF:1198-8344)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>In this template (templateId 2.16.840.1.113883.10.20.22.1.3.2), coded entries are optional.</p> <b>SHALL</b>
+        contain exactly one [1..1] <b>component</b><b> (CONF:1198-8349)</b>.<ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30570)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30571)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Allergies and Intolerances Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.6)</b><b> (CONF:1198-30572)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30573)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-30574)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30575)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Plan of Treatment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30576)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30577)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment and Plan Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-30578)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30579)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Chief Complaint Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-30580)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30581)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Chief Complaint and Reason for Visit Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.13)</b><b> (CONF:1198-30582)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30583)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Family History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-30584)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30585)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] General Status Section<b> (identifier:
+                  2.16.840.1.113883.10.20.2.5)</b><b> (CONF:1198-30586)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30587)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Past Medical History (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-30588)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30589)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] History of Present Illness Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-30590)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30591)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Immunizations Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.2)</b><b> (CONF:1198-30592)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30593)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Instructions Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.45)</b><b> (CONF:1198-31385)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30595)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medications Section (entries optional) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.1)</b><b> (CONF:1198-30596)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30597)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Physical Exam Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-30598)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30599)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Problem Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.5)</b><b> (CONF:1198-30600)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30601)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedures Section (entries optional) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-30602)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30603)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Reason for Visit Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.12)</b><b> (CONF:1198-30604)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30605)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Results Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.3)</b><b> (CONF:1198-30606)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30607)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Review of Systems Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30608)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30609)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Social History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-30610)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30611)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Vital Signs Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.4)</b><b> (CONF:1198-30612)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL</strong> contain a Chief Complaint and Reason for Visit Section
+                (2.16.840.1.113883.10.20.22.2.13) or a Chief Complaint Section (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a
+                Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) (CONF:1198-30613).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan
+                of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-30614).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a
+                Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-30615).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain a Chief Complaint and Reason for Visit Section
+                (2.16.840.1.113883.10.20.22.2.13) when either a Chief Complaint Section
+                (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) is
+                present (CONF:1198-30616).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/History%20and%20Physical%20(V3)_2.16.840.1.113883.10.20.22.1.3/H&amp;P%20encompassingEncounter%20Example.xml"><i class="fab fa-github"></i>&nbsp;H&amp;P encompassingEncounter Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/History%20and%20Physical%20(V3)_2.16.840.1.113883.10.20.22.1.3/H&amp;P%20encompassingEncounter%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;H&amp;P encompassingEncounter Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.4.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.4.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,470 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Consultation Note (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.4, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.4.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Consultation Note (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.4,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.4.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Consultation Note is generated by a request from a clinician for an opinion or advice from another clinician. Consultations may involve face-to-face time with the patient or may fall under the auspices of telemedicine visits. Consultations may occur while the patient is inpatient or ambulatory. The Consultation Note should also be used to summarize an Emergency Room or Urgent Care encounter.</p><p>A Consultation Note includes the reason for the referral, history of present illness, physical examination, and decision-making components (Assessment and Plan).</p></div>
+    <div id="description">
+      <p>The Consultation Note is generated by a request from a clinician for an opinion or advice from another
+        clinician. Consultations may involve face-to-face time with the patient or may fall under the auspices of
+        telemedicine visits. Consultations may occur while the patient is inpatient or ambulatory. The Consultation Note
+        should also be used to summarize an Emergency Room or Urgent Care encounter.</p>
+      <p>A Consultation Note includes the reason for the referral, history of present illness, physical examination, and
+        decision-making components (Assessment and Plan).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.12.html">Reason for Visit Section</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances Section (entries required) (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a href="2.16.840.1.113883.10.20.22.2.13.html">Chief Complaint and Reason for Visit Section</a><br><a href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.2.5.html">General Status Section</a><br><a href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries required) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries optional) (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time
+              (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.12.html">Reason for Visit Section</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a
+              href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances Section (entries required)
+              (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.13.html">Chief Complaint and Reason for Visit Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.2.5.html">General Status Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries required) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries optional) (V3)</a><br>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8375)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.4"</b><b> (CONF:1198-10040)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32502)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32935).</p></li></ul></li>
-<li class="list-group-item"><p>The Consultation Note recommends use of  the document type code 11488-4 "Consult Note", with further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any coded values describing the author or performer of the service act or the practice setting must be consistent with the LOINC document type.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet ConsultDocumentType<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.31/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.31</a></b><b> DYNAMIC</b><b> (CONF:1198-17176)</b>.</li>
-<li class="list-group-item"><p>Heading: participant (This participant represents the person to contact for questions about the consult summary. This call back contact individual may be a different person than the individual(s) identified in the author or legalAuthenticator participant.)<br>SHOULD contain zero or more [0..*] participant (CONF:1198-31656) such that it</p> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31656)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CALLBCK"</b> call back contact (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> DYNAMIC</b>)<b> (CONF:1198-31657)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31658)</b>.</li><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b> assigned entity (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> DYNAMIC</b>)<b> (CONF:1198-31659)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31660)</b>.</li></ul><ul><li>This associatedEntity <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31661)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-31662)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b> (CONF:1198-31663)</b>.</li><ul><li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31664)</b>.</li></ul></ul><ul><li>This associatedEntity <b>MAY</b> contain zero or one [0..1] <b>scopingOrganization</b><b> (CONF:1198-31665)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>Heading: inFulfillmentOf<br>The inFulfillmentOf element describes prior orders that are fulfilled (in whole or part) by the service events described in the Consultation Note. For example, a prior order might be the consultation that is being reported in the note.<br></p> <b>SHALL</b> contain at least one [1..*] <b>inFulfillmentOf</b><b> (CONF:1198-8382)</b>.<ul><li>Such inFulfillmentOfs <b>SHALL</b> contain exactly one [1..1] <b>order</b><b> (CONF:1198-29923)</b>.</li><ul><li>This order <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-29924)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>Heading: componentOf<br><br />A Consultation Note is always associated with an encounter; the id element of the encompassingEncounter is required to be present and represents the identifier for the encounter.<br /><br></p> <b>SHALL</b> contain exactly one [1..1] <b>componentOf</b><b> (CONF:1198-8386)</b>.<ul><li>This componentOf <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b> (CONF:1198-8387)</b>.</li><ul><li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8388)</b>.</li></ul><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-8389)</b>.</li></ul><ul><li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>responsibleParty</b><b> (CONF:1198-8391)</b>.</li><ul><li>The responsibleParty, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-32904)</b>.</li><ul><li><p>This assignedEntity SHALL contain an assignedPerson or a representedOrganization or both (CONF:1198-32905).</p></li></ul></ul></ul><ul><li>This encompassingEncounter <b>MAY</b> contain zero or more [0..*] <b>encounterParticipant</b><b> (CONF:1198-8392)</b>.</li><ul><li>The encounterParticipant, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-32902)</b>.</li><ul><li><p>This assignedEntity SHALL contain an assignedPerson or a representedOrganization or both (CONF:1198-32906).</p></li></ul></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-8397)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-28895)</b>.</li><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28896)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-28897)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28898)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment and Plan Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-28899)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28900)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Plan of Treatment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-28901)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28904)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Reason for Visit Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.12)</b><b> (CONF:1198-28905)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28906)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  History of Present Illness Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-28907)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28908)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Physical Exam Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-28909)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28910)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergies and Intolerances Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.6.1)</b><b> (CONF:1198-28911)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28912)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Chief Complaint Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-28913)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28915)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Chief Complaint and Reason for Visit Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.13)</b><b> (CONF:1198-28916)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28917)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-28918)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28919)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  General Status Section<b> (identifier: 2.16.840.1.113883.10.20.2.5)</b><b> (CONF:1198-28920)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28921)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Past Medical History (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-28922)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28923)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Immunizations Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.2)</b><b> (CONF:1198-28924)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28925)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medications Section (entries required) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.1.1)</b><b> (CONF:1198-28926)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28928)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.5.1)</b><b> (CONF:1198-28929)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28930)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedures Section (entries optional) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-28931)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28932)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Results Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.3.1)</b><b> (CONF:1198-28933)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28934)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-28935)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28936)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Signs Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.4.1)</b><b> (CONF:1198-28937)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28942)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Advance Directives Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.21)</b><b> (CONF:1198-28943)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28944)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-28945)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30237)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Review of Systems Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30238)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30904)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medical Equipment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.23)</b><b> (CONF:1198-30905)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30906)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.56)</b><b> (CONF:1198-30907)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30909)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-30910)</b>.</li></ul></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-28939).</p></li></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain a Chief Complaint and Reason for Visit Section (2.16.840.1.113883.10.20.22.2.13) when either a Chief Complaint Section (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) is present (CONF:1198-28940).</p></li></ul><ul><li><p><strong>SHALL</strong> include a Reason for Referral or Reason for Visit section (CONF:1198-9504).</p></li></ul><ul><li><p><strong>SHALL</strong> include an Assessment and Plan Section, or both an Assessment Section and a Plan of Treatment Section (CONF:1198-9501).</p></li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8375)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.4"</b><b>
+              (CONF:1198-10040)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32502)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32935).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The Consultation Note recommends use of the document type code 11488-4 "Consult Note", with further
+          specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any
+          coded values describing the author or performer of the service act or the practice setting must be consistent
+          with the LOINC document type.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b>
+        be selected from ValueSet ConsultDocumentType<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.31/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.31</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-17176)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>Heading: participant (This participant represents the person to contact for questions about the consult
+          summary. This call back contact individual may be a different person than the individual(s) identified in the
+          author or legalAuthenticator participant.)<br>SHOULD contain zero or more [0..*] participant (CONF:1198-31656)
+          such that it</p> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-31656)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CALLBCK"</b> call back contact (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              DYNAMIC</b>)<b> (CONF:1198-31657)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31658)</b>.</li>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b>
+              assigned entity (CodeSystem: <b>HL7RoleClass <a
+                  href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> DYNAMIC</b>)<b>
+                (CONF:1198-31659)</b>.</li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-31660)</b>.</li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1198-31661)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1198-31662)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b>
+                (CONF:1198-31663)</b>.</li>
+            <ul>
+              <li>This associatedPerson <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-31664)</b>.
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This associatedEntity <b>MAY</b> contain zero or one [0..1] <b>scopingOrganization</b><b>
+                (CONF:1198-31665)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: inFulfillmentOf<br>The inFulfillmentOf element describes prior orders that are fulfilled (in whole
+          or part) by the service events described in the Consultation Note. For example, a prior order might be the
+          consultation that is being reported in the note.<br></p> <b>SHALL</b> contain at least one [1..*]
+        <b>inFulfillmentOf</b><b> (CONF:1198-8382)</b>.<ul>
+          <li>Such inFulfillmentOfs <b>SHALL</b> contain exactly one [1..1] <b>order</b><b> (CONF:1198-29923)</b>.</li>
+          <ul>
+            <li>This order <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-29924)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: componentOf<br><br />A Consultation Note is always associated with an encounter; the id element of
+          the encompassingEncounter is required to be present and represents the identifier for the encounter.<br /><br>
+        </p> <b>SHALL</b> contain exactly one [1..1] <b>componentOf</b><b> (CONF:1198-8386)</b>.<ul>
+          <li>This componentOf <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b>
+              (CONF:1198-8387)</b>.</li>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8388)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] US Realm Date and Time
+              (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-8389)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>responsibleParty</b><b>
+                (CONF:1198-8391)</b>.</li>
+            <ul>
+              <li>The responsibleParty, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+                  (CONF:1198-32904)</b>.</li>
+              <ul>
+                <li>
+                  <p>This assignedEntity SHALL contain an assignedPerson or a representedOrganization or both
+                    (CONF:1198-32905).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>MAY</b> contain zero or more [0..*] <b>encounterParticipant</b><b>
+                (CONF:1198-8392)</b>.</li>
+            <ul>
+              <li>The encounterParticipant, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+                  (CONF:1198-32902)</b>.</li>
+              <ul>
+                <li>
+                  <p>This assignedEntity SHALL contain an assignedPerson or a representedOrganization or both
+                    (CONF:1198-32906).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-8397)</b>.<ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-28895)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28896)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-28897)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28898)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment and Plan Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-28899)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28900)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Plan of Treatment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-28901)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28904)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Reason for Visit Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.12)</b><b> (CONF:1198-28905)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28906)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] History of Present Illness Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-28907)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28908)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Physical Exam Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-28909)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28910)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Allergies and Intolerances Section (entries required) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.6.1)</b><b> (CONF:1198-28911)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28912)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Chief Complaint Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-28913)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28915)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Chief Complaint and Reason for Visit Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.13)</b><b> (CONF:1198-28916)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28917)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Family History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-28918)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28919)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] General Status Section<b> (identifier:
+                  2.16.840.1.113883.10.20.2.5)</b><b> (CONF:1198-28920)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28921)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Past Medical History (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-28922)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28923)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Immunizations Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.2)</b><b> (CONF:1198-28924)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28925)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medications Section (entries required) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.1.1)</b><b> (CONF:1198-28926)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-28928)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Problem Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.5.1)</b><b> (CONF:1198-28929)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28930)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedures Section (entries optional) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-28931)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28932)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Results Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.3.1)</b><b> (CONF:1198-28933)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28934)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Social History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-28935)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28936)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Vital Signs Section (entries required) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.4.1)</b><b> (CONF:1198-28937)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28942)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Advance Directives Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.21)</b><b> (CONF:1198-28943)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-28944)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Functional Status Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-28945)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30237)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Review of Systems Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30238)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30904)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medical Equipment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.23)</b><b> (CONF:1198-30905)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30906)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Mental Status Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.56)</b><b> (CONF:1198-30907)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30909)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Nutrition Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-30910)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a
+                Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-28939).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain a Chief Complaint and Reason for Visit Section
+                (2.16.840.1.113883.10.20.22.2.13) when either a Chief Complaint Section
+                (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) is
+                present (CONF:1198-28940).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p><strong>SHALL</strong> include a Reason for Referral or Reason for Visit section (CONF:1198-9504).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p><strong>SHALL</strong> include an Assessment and Plan Section, or both an Assessment Section and a Plan
+                of Treatment Section (CONF:1198-9501).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Consultation%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.4/Consultation%20Note%20(V2)%20inFulfillmentOf%20Example.xml"><i class="fab fa-github"></i>&nbsp;Consultation Note (V2) inFulfillmentOf Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Consultation%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.4/Consultation%20Note%20Callback%20participant%20Example.xml"><i class="fab fa-github"></i>&nbsp;Consultation Note Callback participant Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Consultation%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.4/Consultation%20Note%20structuredBody%20Example.xml"><i class="fab fa-github"></i>&nbsp;Consultation Note structuredBody Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Consultation%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.4/Consultation%20Note%20(V2)%20inFulfillmentOf%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Consultation Note (V2) inFulfillmentOf Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Consultation%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.4/Consultation%20Note%20Callback%20participant%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Consultation Note Callback participant Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Consultation%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.4/Consultation%20Note%20structuredBody%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Consultation Note structuredBody Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.5.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.5.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,60 +52,468 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Diagnostic Imaging Report (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.5, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Diagnostic Imaging Report (V3) <small class="text-muted">[ClinicalDocument,
+        2.16.840.1.113883.10.20.22.1.5, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.1.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Diagnostic Imaging Report (DIR) is a document that contains a consulting specialist's interpretation of image data. It conveys the interpretation to the referring (ordering) physician and becomes part of the patient's medical record. It is for use in Radiology, Endoscopy, Cardiology, and other imaging specialties.</p></div>
+    <div id="description">
+      <p>A Diagnostic Imaging Report (DIR) is a document that contains a consulting specialist's interpretation of image
+        data. It conveys the interpretation to the referring (ordering) physician and becomes part of the patient's
+        medical record. It is for use in Radiology, Endoscopy, Cardiology, and other imaging specialties.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.6.1.1.html">DICOM Object Catalog Section - DCM 121181</a><br><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.6.2.1.html">Physician Reading Study Performer (V2)</a><br><a href="2.16.840.1.113883.10.20.6.1.2.html">Findings Section (DIR)</a><br><a href="2.16.840.1.113883.10.20.6.2.5.html">Procedure Context</a><br><a href="2.16.840.1.113883.10.20.6.2.3.html">Fetus Subject Context</a><br><a href="2.16.840.1.113883.10.20.6.2.4.html">Observer Context</a><br><a href="2.16.840.1.113883.10.20.6.2.12.html">Text Observation</a><br><a href="2.16.840.1.113883.10.20.6.2.13.html">Code Observations</a><br><a href="2.16.840.1.113883.10.20.6.2.14.html">Quantity Measurement Observation</a><br><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.6.2.2.html">Physician of Record Participant (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.6.1.1.html">DICOM Object Catalog Section - DCM
+              121181</a><br><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name
+              (PN.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.6.2.1.html">Physician Reading Study Performer
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.6.1.2.html">Findings Section (DIR)</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.5.html">Procedure Context</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.3.html">Fetus Subject Context</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.4.html">Observer Context</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.12.html">Text Observation</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.13.html">Code Observations</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.14.html">Quantity Measurement Observation</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.2.html">Physician of Record Participant (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8404)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.5"</b><b> (CONF:1198-10042)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1198-32515)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32937).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1198-30932)</b>.<ul><li>This id <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:1198-30933)</b>.</li><ul><li><p>OIDs SHALL be represented in dotted decimal notation, where each decimal number is either 0 or starts with a nonzero digit. More formally, an OID SHALL be in the form of the regular expression: ([0-2])(.([1-9][0-9]*|0))+</p><p>The ClinicalDocument/id/@root attribute <b>SHALL</b> be a syntactically correct OID, and <b>SHALL NOT</b> be a UUID <b>(CONF:1198-30934)</b>.</p></li></ul><ul><li><p>OIDs <b>SHALL</b> be no more than 64 characters in length <b>(CONF:1198-30935)</b>.</p></li></ul></ul></li>
-<li class="list-group-item"><p>Preferred code is 18748-4 LOINC Diagnostic Imaging Report<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14833)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet LOINC Imaging Document Codes<b> <a href="https://vsac.nlm.nih.gov/valueset/1.3.6.1.4.1.12009.10.2.5/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 1.3.6.1.4.1.12009.10.2.5</a></b><b> DYNAMIC</b><b> (CONF:1198-14834)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL NOT</b> contain [0..0] <b>informant</b><b> (CONF:1198-8410)</b>.</li>
-<li class="list-group-item"><p>Heading: informationRecipient</p> <b>MAY</b> contain zero or more [0..*] <b>informationRecipient</b><b> (CONF:1198-8411)</b>.<ul><li><p>The physician requesting the imaging procedure (ClinicalDocument/participant[@typeCode=REF]/associatedEntity), if present, <strong>SHOULD</strong> also be recorded as an informationRecipient, unless in the local setting another physician (such as the attending physician for an inpatient) is known to be the appropriate recipient of the report (CONF:1198-8412).</p></li></ul><ul><li><p>When no referring physician is present, as in the case of self-referred screening examinations allowed by law, the intendedRecipient <strong>MAY</strong> be absent. The intendedRecipient <strong>MAY</strong> also be the health chart of the patient, in which case the receivedOrganization <strong>SHALL</strong> be the scoping organization of that chart (CONF:1198-8413).</p></li></ul></li>
-<li class="list-group-item"><p>Heading: participant<br>If participant is present, the associatedEntity/associatedPerson element SHALL be present and SHALL represent the physician requesting the imaging procedure (the referring physician AssociatedEntity that is the target of ClincalDocument/participant@typeCode=REF).<br></p> <b>MAY</b> contain zero or one [0..1] <b>participant</b><b> (CONF:1198-8414)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31198)</b>.</li><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b> (CONF:1198-31199)</b>.</li><ul><li>This associatedPerson <b>SHALL</b> contain exactly one [1..1]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-31200)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: inFulfillmentOf<br>An inFulfillmentOf element represents the Placer Order that is either a group of orders (modeled as PlacerGroup in the Placer Order RMIM of the Orders &amp; Observations domain) or a single order item (modeled as ObservationRequest in the same RMIM). This optionality reflects two major approaches to the grouping of procedures as implemented in the installed base of imaging information systems. These approaches differ in their handling of grouped procedures and how they are mapped to identifiers in the Digital Imaging and Communications in Medicine (DICOM) image and structured reporting data. The example of a CT examination covering chest, abdomen, and pelvis will be used in the discussion below. In the IHE Scheduled Workflow model, the Chest CT, Abdomen CT, and Pelvis CT each represent a Requested Procedure, and all three procedures are grouped under a single Filler Order. The Filler Order number maps directly to the DICOM Accession Number in the DICOM imaging and report data. A widely deployed alternative approach maps the requested procedure identifiers directly to the DICOM Accession Number. The Requested Procedure ID in such implementations may or may not be different from the Accession Number, but is of little identifying importance because there is only one Requested Procedure per Accession Number. There is no identifier that formally connects the requested procedures ordered in this group.<br></p> <b>MAY</b> contain zero or more [0..*] <b>inFulfillmentOf</b><b> (CONF:1198-30936)</b>.<ul><li>The inFulfillmentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>order</b><b> (CONF:1198-30937)</b>.</li><ul><li>This order <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30938)</b>.<br>Note: DICOM Accession Number in the DICOM imaging and report data</li></ul></ul></li>
-<li class="list-group-item"><p>Heading: documentationOf<br>Each serviceEvent indicates an imaging procedure that the provider describes and interprets in the content of the DIR. The main activity being described by this document is the interpretation of the imaging procedure. This is shown by setting the value of the @classCode attribute of the serviceEvent element to ACT, and indicating the duration over which care was provided in the effectiveTime element. Within each documentationOf element, there is one serviceEvent element. This event is the unit imaging procedure corresponding to a billable item. The type of imaging procedure may be further described in the serviceEvent/code element. This guide makes no specific recommendations about the vocabulary to use for describing this event. In IHE Scheduled Workflow environments, one serviceEvent/id element contains the DICOM Study Instance UID from the Modality Worklist, and the second serviceEvent/id element contains the DICOM Requested Procedure ID from the Modality Worklist. These two ids are in a single serviceEvent. The effectiveTime for the serviceEvent covers the duration of the imaging procedure being reported. This event should have one or more performers, which may participate at the same or different periods of time. Service events map to DICOM Requested Procedures. That is, serviceEvent/id is the ID of the Requested Procedure.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>documentationOf</b><b> (CONF:1198-8416)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-8431)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-8430)</b>.</li></ul><ul><li><b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-8418)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-8419)</b>.</li><ul><li><p>The value of serviceEvent/code <strong>SHALL NOT</strong> conflict with the ClininicalDocument/code. When transforming from DICOM SR documents that do not contain a procedure code, an appropriate nullFlavor <strong>SHALL</strong> be used on serviceEvent/code (CONF:1198-8420).</p></li></ul></ul><ul><li>The performer is the Physician Reading Study Performer defined in serviceEvent and is usually different from the attending physician. The reading physician interprets the images and evidence of the study (DICOM Definition).<br><b>SHOULD</b> contain zero or more [0..*]  Physician Reading Study Performer (V2)<b> (identifier: 2.16.840.1.113883.10.20.6.2.1)</b><b> (CONF:1198-8422)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>Heading: relatedDocument<br>A DIR may have three types of parent document:  A superseded version that the present document wholly replaces (typeCode = RPLC). DIRs may go through stages of revision prior to being legally authenticated. Such early stages may be drafts from transcription, those created by residents, or other preliminary versions. Policies not covered by this specification may govern requirements for retention of such earlier versions. Except for forensic purposes, the latest version in a chain of revisions represents the complete and current report. An original version that the present document appends (typeCode = APND). When a DIR is legally authenticated, it can be amended by a separate addendum document that references the original.  A source document from which the present document is transformed (typeCode = XFRM). A DIR may be created by transformation from a DICOM Structured Report (SR) document or from another DIR. An example of the latter case is the creation of a derived document for inclusion of imaging results in a clinical document.<br></p> <b>MAY</b> contain zero or one [0..1] <b>relatedDocument</b><b> (CONF:1198-8432)</b>.<ul><li>The relatedDocument, if present, <b>SHALL</b> contain exactly one [1..1] <b>parentDocument</b><b> (CONF:1198-32089)</b>.</li><ul><li>This parentDocument <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1198-32090)</b>.</li><ul><li><p>OIDs <strong>SHALL</strong> be represented in dotted decimal notation, where each decimal number is either 0 or starts with a nonzero digit. More formally, an OID <strong>SHALL</strong> be in the form of the regular expression: ([0-2])(.([1-9][0-9][*]|0))+ <b>(CONF:1198-10031)</b></p></li><li>OIDs <b>SHALL</b> be no more than 64 characters in length <b>(CONF:1198-10032)</b></li></ul></ul><li>When a Diagnostic Imaging Report has been transformed from a DICOM SR document, relatedDocument/@typeCode <b>SHALL</b> be XFRM, and relatedDocument/parentDocument/id <b>SHALL</b> contain the SOP Instance UID of the original DICOM SR document <b>(CONF:1198-8433)</b>.</li></ul>
-</li><li class="list-group-item"><p>Heading: componentOf<br>The id element of the encompassingEncounter represents the identifier for the encounter. When the diagnostic imaging procedure is performed in the context of a hospital stay or an outpatient visit for which there is an Encounter Number, that number should be present as the ID of the encompassingEncounter.<br>The effectiveTime represents the time interval or point in time in which the encounter took place. The encompassing encounter might be that of the hospital or office visit in which the diagnostic imaging procedure was performed. If the effective time is unknown, a nullFlavor attribute can be used.</p> <b>MAY</b> contain zero or one [0..1] <b>componentOf</b><b> (CONF:1198-30939)</b>.<ul><li>The componentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b> (CONF:1198-30940)</b>.</li><ul><li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30941)</b>.</li><ul><li><p>In the case of transformed DICOM SR documents, an appropriate null flavor <strong>MAY</strong> be used if the id is unavailable (CONF:1198-30942).</p></li></ul></ul><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-30943)</b>.</li></ul><ul><li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>responsibleParty</b><b> (CONF:1198-30945)</b>.</li><ul><li>The responsibleParty, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-30946)</b>.</li><ul><li><p><strong>SHOULD</strong> contain zero or one [0..1] assignedPerson <em>OR</em> contain zero or one [0..1] representedOrganization (CONF:1198-30947).</p></li></ul></ul></ul><ul><li>This encompassingEncounter <b>SHOULD</b> contain zero or one [0..1]  Physician of Record Participant (V2)<b> (identifier: 2.16.840.1.113883.10.20.6.2.2)</b><b> (CONF:1198-30948)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>Heading: component</p><b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-14907)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30695)</b>.</li><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30696)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Findings Section (DIR)<b> (identifier: 2.16.840.1.113883.10.20.6.1.2)</b><b> (CONF:1198-30697)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30698)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  DICOM Object Catalog Section - DCM 121181<b> (identifier: 2.16.840.1.113883.10.20.6.1.1)</b><b> (CONF:1198-30699)</b>.</li><ul><li><p>The DICOM Object Catalog section (templateId 2.16.840.1.113883.10.20.6.1.1), if present, <strong>SHALL</strong> be the first section in the document Body (CONF:1198-31206).</p></li></ul></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1198-31055)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>section</b><b> (CONF:1198-31056)</b>.</li><ul><li>This section <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-31057)</b>.</li><ul><li>For sections listed in the DIR Section Type Codes table, the code element must contain a LOINC code or DCM code for sections that have no LOINC equivalent<br>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet DIRSectionTypeCodes<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.59/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.59</a></b><b> DYNAMIC</b><b> (CONF:1198-31207)</b>.<br>Note: The section/code SHOULD be selected from LOINC or DICOM for sections not listed in the DIR Section Type Codes table</li></ul></ul><ul><li>There is no equivalent to section/title in DICOM SR, so for a CDA to SR transformation, the section/code will be transferred and the title element will be dropped.<br>This section <b>SHOULD</b> contain zero or one [0..1] <b>title</b><b> (CONF:1198-31058)</b>.</li></ul><ul><li>This section <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:1198-31059)</b>.</li><ul><li><p>If clinical statements are present, the section/text <strong>SHALL</strong> represent faithfully all such statements and <strong>MAY</strong> contain additional text (CONF:1198-31060).</p></li></ul><ul><li><p>All text elements <strong>SHALL</strong> contain content. Text elements <strong>SHALL</strong> contain PCDATA or child elements (CONF:1198-31061).</p></li></ul><ul><li><p>The text elements (and their children) <strong>MAY</strong> contain Web Access to DICOM Persistent Object (WADO) references to DICOM objects by including a linkHtml element where @href is a valid WADO URL and the text content of linkHtml is the visible text of the hyperlink (CONF:1198-31062).</p></li></ul></ul><ul><li>This section <b>MAY</b> contain zero or more [0..*] <b>subject</b><b> (CONF:1198-31215)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Fetus Subject Context<b> (identifier: 2.16.840.1.113883.10.20.6.2.3)</b><b> (CONF:1198-31216)</b>.</li></ul></ul><ul><li>This author element is used when the author of a section is different from the author(s) listed in the Header. <br>This section <b>MAY</b> contain zero or more [0..*] <b>author</b><b> (CONF:1198-31217)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Observer Context<b> (identifier: 2.16.840.1.113883.10.20.6.2.4)</b><b> (CONF:1198-31218)</b>.</li></ul></ul><ul><li>If the service context of a section is different from the value specified in documentationOf/serviceEvent, then the section SHALL contain one or more entries containing Procedure Context (templateId 2.16.840.1.113883.10.20.6.2.5), which will reset the context for any clinical statements nested within those elements.<br>This section <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31213)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Context<b> (identifier: 2.16.840.1.113883.10.20.6.2.5)</b><b> (CONF:1198-31214)</b>.</li></ul></ul><ul><li>This section <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31357)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Text Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.12)</b><b> (CONF:1198-31358)</b>.</li></ul></ul><ul><li>This section <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31359)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Code Observations<b> (identifier: 2.16.840.1.113883.10.20.6.2.13)</b><b> (CONF:1198-31360)</b>.</li></ul></ul><ul><li>This section <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31361)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Quantity Measurement Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.14)</b><b> (CONF:1198-31362)</b>.</li></ul></ul><ul><li>This section <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31363)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  SOP Instance Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:1198-31364)</b>.</li></ul></ul><ul><li>This section <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1198-31208)</b>.</li><ul><li><p><strong>SHALL</strong> contain child elements (CONF:1198-31210).</p></li></ul></ul><ul><li><p>All sections defined in the DIR Section Type Codes table <strong>SHALL</strong> be top-level sections (CONF:1198-31211).</p></li></ul><ul><li><p><strong>SHALL</strong> contain at least one text element or one or more component elements (CONF:1198-31212).</p></li></ul></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8404)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.5"</b><b>
+              (CONF:1198-10042)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1198-32515)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32937).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1198-30932)</b>.<ul>
+          <li>This id <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:1198-30933)</b>.</li>
+          <ul>
+            <li>
+              <p>OIDs SHALL be represented in dotted decimal notation, where each decimal number is either 0 or starts
+                with a nonzero digit. More formally, an OID SHALL be in the form of the regular expression:
+                ([0-2])(.([1-9][0-9]*|0))+</p>
+              <p>The ClinicalDocument/id/@root attribute <b>SHALL</b> be a syntactically correct OID, and <b>SHALL
+                  NOT</b> be a UUID <b>(CONF:1198-30934)</b>.</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>OIDs <b>SHALL</b> be no more than 64 characters in length <b>(CONF:1198-30935)</b>.</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Preferred code is 18748-4 LOINC Diagnostic Imaging Report<br></p> <b>SHALL</b> contain exactly one [1..1]
+        <b>code</b><b> (CONF:1198-14833)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from
+            ValueSet LOINC Imaging Document Codes<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/1.3.6.1.4.1.12009.10.2.5/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 1.3.6.1.4.1.12009.10.2.5</a></b><b> DYNAMIC</b><b>
+              (CONF:1198-14834)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL NOT</b> contain [0..0] <b>informant</b><b> (CONF:1198-8410)</b>.</li>
+      <li class="list-group-item">
+        <p>Heading: informationRecipient</p> <b>MAY</b> contain zero or more [0..*] <b>informationRecipient</b><b>
+          (CONF:1198-8411)</b>.<ul>
+          <li>
+            <p>The physician requesting the imaging procedure
+              (ClinicalDocument/participant[@typeCode=REF]/associatedEntity), if present, <strong>SHOULD</strong> also
+              be recorded as an informationRecipient, unless in the local setting another physician (such as the
+              attending physician for an inpatient) is known to be the appropriate recipient of the report
+              (CONF:1198-8412).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When no referring physician is present, as in the case of self-referred screening examinations allowed by
+              law, the intendedRecipient <strong>MAY</strong> be absent. The intendedRecipient <strong>MAY</strong> also
+              be the health chart of the patient, in which case the receivedOrganization <strong>SHALL</strong> be the
+              scoping organization of that chart (CONF:1198-8413).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: participant<br>If participant is present, the associatedEntity/associatedPerson element SHALL be
+          present and SHALL represent the physician requesting the imaging procedure (the referring physician
+          AssociatedEntity that is the target of ClincalDocument/participant@typeCode=REF).<br></p> <b>MAY</b> contain
+        zero or one [0..1] <b>participant</b><b> (CONF:1198-8414)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-31198)</b>.</li>
+          <ul>
+            <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b>
+                (CONF:1198-31199)</b>.</li>
+            <ul>
+              <li>This associatedPerson <b>SHALL</b> contain exactly one [1..1] US Realm Person Name (PN.US.FIELDED)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-31200)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: inFulfillmentOf<br>An inFulfillmentOf element represents the Placer Order that is either a group of
+          orders (modeled as PlacerGroup in the Placer Order RMIM of the Orders &amp; Observations domain) or a single
+          order item (modeled as ObservationRequest in the same RMIM). This optionality reflects two major approaches to
+          the grouping of procedures as implemented in the installed base of imaging information systems. These
+          approaches differ in their handling of grouped procedures and how they are mapped to identifiers in the
+          Digital Imaging and Communications in Medicine (DICOM) image and structured reporting data. The example of a
+          CT examination covering chest, abdomen, and pelvis will be used in the discussion below. In the IHE Scheduled
+          Workflow model, the Chest CT, Abdomen CT, and Pelvis CT each represent a Requested Procedure, and all three
+          procedures are grouped under a single Filler Order. The Filler Order number maps directly to the DICOM
+          Accession Number in the DICOM imaging and report data. A widely deployed alternative approach maps the
+          requested procedure identifiers directly to the DICOM Accession Number. The Requested Procedure ID in such
+          implementations may or may not be different from the Accession Number, but is of little identifying importance
+          because there is only one Requested Procedure per Accession Number. There is no identifier that formally
+          connects the requested procedures ordered in this group.<br></p> <b>MAY</b> contain zero or more [0..*]
+        <b>inFulfillmentOf</b><b> (CONF:1198-30936)</b>.<ul>
+          <li>The inFulfillmentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>order</b><b>
+              (CONF:1198-30937)</b>.</li>
+          <ul>
+            <li>This order <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30938)</b>.<br>Note: DICOM
+              Accession Number in the DICOM imaging and report data</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: documentationOf<br>Each serviceEvent indicates an imaging procedure that the provider describes and
+          interprets in the content of the DIR. The main activity being described by this document is the interpretation
+          of the imaging procedure. This is shown by setting the value of the @classCode attribute of the serviceEvent
+          element to ACT, and indicating the duration over which care was provided in the effectiveTime element. Within
+          each documentationOf element, there is one serviceEvent element. This event is the unit imaging procedure
+          corresponding to a billable item. The type of imaging procedure may be further described in the
+          serviceEvent/code element. This guide makes no specific recommendations about the vocabulary to use for
+          describing this event. In IHE Scheduled Workflow environments, one serviceEvent/id element contains the DICOM
+          Study Instance UID from the Modality Worklist, and the second serviceEvent/id element contains the DICOM
+          Requested Procedure ID from the Modality Worklist. These two ids are in a single serviceEvent. The
+          effectiveTime for the serviceEvent covers the duration of the imaging procedure being reported. This event
+          should have one or more performers, which may participate at the same or different periods of time. Service
+          events map to DICOM Requested Procedures. That is, serviceEvent/id is the ID of the Requested Procedure.<br>
+        </p> <b>SHALL</b> contain exactly one [1..1] <b>documentationOf</b><b> (CONF:1198-8416)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-8431)</b> such that it</li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a
+                  href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+                (CONF:1198-8430)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-8418)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-8419)</b>.</li>
+            <ul>
+              <li>
+                <p>The value of serviceEvent/code <strong>SHALL NOT</strong> conflict with the ClininicalDocument/code.
+                  When transforming from DICOM SR documents that do not contain a procedure code, an appropriate
+                  nullFlavor <strong>SHALL</strong> be used on serviceEvent/code (CONF:1198-8420).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>The performer is the Physician Reading Study Performer defined in serviceEvent and is usually different
+              from the attending physician. The reading physician interprets the images and evidence of the study (DICOM
+              Definition).<br><b>SHOULD</b> contain zero or more [0..*] Physician Reading Study Performer (V2)<b>
+                (identifier: 2.16.840.1.113883.10.20.6.2.1)</b><b> (CONF:1198-8422)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: relatedDocument<br>A DIR may have three types of parent document: A superseded version that the
+          present document wholly replaces (typeCode = RPLC). DIRs may go through stages of revision prior to being
+          legally authenticated. Such early stages may be drafts from transcription, those created by residents, or
+          other preliminary versions. Policies not covered by this specification may govern requirements for retention
+          of such earlier versions. Except for forensic purposes, the latest version in a chain of revisions represents
+          the complete and current report. An original version that the present document appends (typeCode = APND). When
+          a DIR is legally authenticated, it can be amended by a separate addendum document that references the
+          original. A source document from which the present document is transformed (typeCode = XFRM). A DIR may be
+          created by transformation from a DICOM Structured Report (SR) document or from another DIR. An example of the
+          latter case is the creation of a derived document for inclusion of imaging results in a clinical document.<br>
+        </p> <b>MAY</b> contain zero or one [0..1] <b>relatedDocument</b><b> (CONF:1198-8432)</b>.<ul>
+          <li>The relatedDocument, if present, <b>SHALL</b> contain exactly one [1..1] <b>parentDocument</b><b>
+              (CONF:1198-32089)</b>.</li>
+          <ul>
+            <li>This parentDocument <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1198-32090)</b>.</li>
+            <ul>
+              <li>
+                <p>OIDs <strong>SHALL</strong> be represented in dotted decimal notation, where each decimal number is
+                  either 0 or starts with a nonzero digit. More formally, an OID <strong>SHALL</strong> be in the form
+                  of the regular expression: ([0-2])(.([1-9][0-9][*]|0))+ <b>(CONF:1198-10031)</b></p>
+              </li>
+              <li>OIDs <b>SHALL</b> be no more than 64 characters in length <b>(CONF:1198-10032)</b></li>
+            </ul>
+          </ul>
+          <li>When a Diagnostic Imaging Report has been transformed from a DICOM SR document, relatedDocument/@typeCode
+            <b>SHALL</b> be XFRM, and relatedDocument/parentDocument/id <b>SHALL</b> contain the SOP Instance UID of the
+            original DICOM SR document <b>(CONF:1198-8433)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: componentOf<br>The id element of the encompassingEncounter represents the identifier for the
+          encounter. When the diagnostic imaging procedure is performed in the context of a hospital stay or an
+          outpatient visit for which there is an Encounter Number, that number should be present as the ID of the
+          encompassingEncounter.<br>The effectiveTime represents the time interval or point in time in which the
+          encounter took place. The encompassing encounter might be that of the hospital or office visit in which the
+          diagnostic imaging procedure was performed. If the effective time is unknown, a nullFlavor attribute can be
+          used.</p> <b>MAY</b> contain zero or one [0..1] <b>componentOf</b><b> (CONF:1198-30939)</b>.<ul>
+          <li>The componentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b>
+              (CONF:1198-30940)</b>.</li>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30941)</b>.
+            </li>
+            <ul>
+              <li>
+                <p>In the case of transformed DICOM SR documents, an appropriate null flavor <strong>MAY</strong> be
+                  used if the id is unavailable (CONF:1198-30942).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] US Realm Date and Time
+              (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-30943)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>responsibleParty</b><b>
+                (CONF:1198-30945)</b>.</li>
+            <ul>
+              <li>The responsibleParty, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+                  (CONF:1198-30946)</b>.</li>
+              <ul>
+                <li>
+                  <p><strong>SHOULD</strong> contain zero or one [0..1] assignedPerson <em>OR</em> contain zero or one
+                    [0..1] representedOrganization (CONF:1198-30947).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHOULD</b> contain zero or one [0..1] Physician of Record Participant
+              (V2)<b> (identifier: 2.16.840.1.113883.10.20.6.2.2)</b><b> (CONF:1198-30948)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: component</p><b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-14907)</b>.<ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30695)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30696)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Findings Section (DIR)<b> (identifier:
+                  2.16.840.1.113883.10.20.6.1.2)</b><b> (CONF:1198-30697)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30698)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] DICOM Object Catalog Section - DCM 121181<b> (identifier:
+                  2.16.840.1.113883.10.20.6.1.1)</b><b> (CONF:1198-30699)</b>.</li>
+              <ul>
+                <li>
+                  <p>The DICOM Object Catalog section (templateId 2.16.840.1.113883.10.20.6.1.1), if present,
+                    <strong>SHALL</strong> be the first section in the document Body (CONF:1198-31206).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1198-31055)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>section</b><b> (CONF:1198-31056)</b>.</li>
+              <ul>
+                <li>This section <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-31057)</b>.</li>
+                <ul>
+                  <li>For sections listed in the DIR Section Type Codes table, the code element must contain a LOINC
+                    code or DCM code for sections that have no LOINC equivalent<br>This code <b>SHALL</b> contain
+                    exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet
+                    DIRSectionTypeCodes<b> <a
+                        href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.59/expansion/Latest"
+                        target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.59</a></b><b>
+                      DYNAMIC</b><b> (CONF:1198-31207)</b>.<br>Note: The section/code SHOULD be selected from LOINC or
+                    DICOM for sections not listed in the DIR Section Type Codes table</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>There is no equivalent to section/title in DICOM SR, so for a CDA to SR transformation, the
+                  section/code will be transferred and the title element will be dropped.<br>This section <b>SHOULD</b>
+                  contain zero or one [0..1] <b>title</b><b> (CONF:1198-31058)</b>.</li>
+              </ul>
+              <ul>
+                <li>This section <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:1198-31059)</b>.</li>
+                <ul>
+                  <li>
+                    <p>If clinical statements are present, the section/text <strong>SHALL</strong> represent faithfully
+                      all such statements and <strong>MAY</strong> contain additional text (CONF:1198-31060).</p>
+                  </li>
+                </ul>
+                <ul>
+                  <li>
+                    <p>All text elements <strong>SHALL</strong> contain content. Text elements <strong>SHALL</strong>
+                      contain PCDATA or child elements (CONF:1198-31061).</p>
+                  </li>
+                </ul>
+                <ul>
+                  <li>
+                    <p>The text elements (and their children) <strong>MAY</strong> contain Web Access to DICOM
+                      Persistent Object (WADO) references to DICOM objects by including a linkHtml element where @href
+                      is a valid WADO URL and the text content of linkHtml is the visible text of the hyperlink
+                      (CONF:1198-31062).</p>
+                  </li>
+                </ul>
+              </ul>
+              <ul>
+                <li>This section <b>MAY</b> contain zero or more [0..*] <b>subject</b><b> (CONF:1198-31215)</b> such
+                  that it</li>
+                <ul>
+                  <li><b>SHALL</b> contain exactly one [1..1] Fetus Subject Context<b> (identifier:
+                      2.16.840.1.113883.10.20.6.2.3)</b><b> (CONF:1198-31216)</b>.</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>This author element is used when the author of a section is different from the author(s) listed in
+                  the Header. <br>This section <b>MAY</b> contain zero or more [0..*] <b>author</b><b>
+                    (CONF:1198-31217)</b> such that it</li>
+                <ul>
+                  <li><b>SHALL</b> contain exactly one [1..1] Observer Context<b> (identifier:
+                      2.16.840.1.113883.10.20.6.2.4)</b><b> (CONF:1198-31218)</b>.</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>If the service context of a section is different from the value specified in
+                  documentationOf/serviceEvent, then the section SHALL contain one or more entries containing Procedure
+                  Context (templateId 2.16.840.1.113883.10.20.6.2.5), which will reset the context for any clinical
+                  statements nested within those elements.<br>This section <b>MAY</b> contain zero or more [0..*]
+                  <b>entry</b><b> (CONF:1198-31213)</b> such that it</li>
+                <ul>
+                  <li><b>SHALL</b> contain exactly one [1..1] Procedure Context<b> (identifier:
+                      2.16.840.1.113883.10.20.6.2.5)</b><b> (CONF:1198-31214)</b>.</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>This section <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31357)</b> such that
+                  it</li>
+                <ul>
+                  <li><b>SHALL</b> contain exactly one [1..1] Text Observation<b> (identifier:
+                      2.16.840.1.113883.10.20.6.2.12)</b><b> (CONF:1198-31358)</b>.</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>This section <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31359)</b> such that
+                  it</li>
+                <ul>
+                  <li><b>SHALL</b> contain exactly one [1..1] Code Observations<b> (identifier:
+                      2.16.840.1.113883.10.20.6.2.13)</b><b> (CONF:1198-31360)</b>.</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>This section <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31361)</b> such that
+                  it</li>
+                <ul>
+                  <li><b>SHALL</b> contain exactly one [1..1] Quantity Measurement Observation<b> (identifier:
+                      2.16.840.1.113883.10.20.6.2.14)</b><b> (CONF:1198-31362)</b>.</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>This section <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-31363)</b> such that
+                  it</li>
+                <ul>
+                  <li><b>SHALL</b> contain exactly one [1..1] SOP Instance Observation<b> (identifier:
+                      2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:1198-31364)</b>.</li>
+                </ul>
+              </ul>
+              <ul>
+                <li>This section <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1198-31208)</b>.</li>
+                <ul>
+                  <li>
+                    <p><strong>SHALL</strong> contain child elements (CONF:1198-31210).</p>
+                  </li>
+                </ul>
+              </ul>
+              <ul>
+                <li>
+                  <p>All sections defined in the DIR Section Type Codes table <strong>SHALL</strong> be top-level
+                    sections (CONF:1198-31211).</p>
+                </li>
+              </ul>
+              <ul>
+                <li>
+                  <p><strong>SHALL</strong> contain at least one text element or one or more component elements
+                    (CONF:1198-31212).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Diagnostic%20Imaging%20Report%20(V3)_2.16.840.1.113883.10.20.22.1.5/DIR%20Participant%20Example.xml"><i class="fab fa-github"></i>&nbsp;DIR Participant Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Diagnostic%20Imaging%20Report%20(V3)_2.16.840.1.113883.10.20.22.1.5/DIR%20Participant%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;DIR Participant Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.6.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.6.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,580 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Note (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.6, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.6.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Note (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.6,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.6.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Procedure Note encompasses many types of non-operative procedures including interventional cardiology, gastrointestinal endoscopy, osteopathic manipulation, and many other specialty fields. Procedure Notes are differentiated from Operative Notes because they do not involve incision or excision as the primary act.The Procedure Note is created immediately following a non-operative procedure. It records the indications for the procedure and, when applicable, postprocedure diagnosis, pertinent events of the procedure, and the patient's tolerance for the procedure. It should be detailed enough to justify the procedure, describe the course of the procedure, and provide continuity of care.</p></div>
+    <div id="description">
+      <p>A Procedure Note encompasses many types of non-operative procedures including interventional cardiology,
+        gastrointestinal endoscopy, osteopathic manipulation, and many other specialty fields. Procedure Notes are
+        differentiated from Operative Notes because they do not involve incision or excision as the primary act.The
+        Procedure Note is created immediately following a non-operative procedure. It records the indications for the
+        procedure and, when applicable, postprocedure diagnosis, pertinent events of the procedure, and the patient's
+        tolerance for the procedure. It should be detailed enough to justify the procedure, describe the course of the
+        procedure, and provide continuity of care.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.37.html">Complications Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.27.html">Procedure Description Section</a><br><a href="2.16.840.1.113883.10.20.22.2.29.html">Procedure Indications Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.36.html">Postprocedure Diagnosis Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.25.html">Anesthesia Section (V2)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a href="2.16.840.1.113883.10.20.22.2.13.html">Chief Complaint and Reason for Visit Section</a><br><a href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a href="2.16.840.1.113883.10.20.22.2.39.html">Medical (General) History Section</a><br><a href="2.16.840.1.113883.10.20.22.2.1.html">Medications Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.38.html">Medications Administered Section (V2)</a><br><a href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.30.html">Planned Procedure Section (V2)</a><br><a href="2.16.840.1.113883.10.20.18.2.12.html">Procedure Disposition Section</a><br><a href="2.16.840.1.113883.10.20.18.2.9.html">Procedure Estimated Blood Loss Section</a><br><a href="2.16.840.1.113883.10.20.22.2.28.html">Procedure Findings Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.40.html">Procedure Implants Section</a><br><a href="2.16.840.1.113883.10.20.22.2.31.html">Procedure Specimens Taken Section</a><br><a href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.12.html">Reason for Visit Section</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time
+              (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.37.html">Complications Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.27.html">Procedure Description Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.29.html">Procedure Indications Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.36.html">Postprocedure Diagnosis Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section (entries optional)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.25.html">Anesthesia Section (V2)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.13.html">Chief Complaint and Reason for Visit Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.39.html">Medical (General) History Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.1.html">Medications Section (entries optional) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.38.html">Medications Administered Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.30.html">Planned Procedure Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.18.2.12.html">Procedure Disposition Section</a><br><a
+              href="2.16.840.1.113883.10.20.18.2.9.html">Procedure Estimated Blood Loss Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.28.html">Procedure Findings Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.40.html">Procedure Implants Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.31.html">Procedure Specimens Taken Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.12.html">Reason for Visit Section</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8496)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.6"</b><b> (CONF:1198-10050)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32520)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32941).</p></li></ul></li>
-<li class="list-group-item"><p>The Procedure Note recommends use of a single document type code, 28570-0 "Procedure Note", with further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any coded values describing the author or performer of the service act or the practice setting must be consistent with the LOINC document type. <br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-17182)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ProcedureNoteDocumentTypeCodes<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.6.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.6.1</a></b><b> DYNAMIC</b><b> (CONF:1198-17183)</b>.</li></ul></li>
-<li class="list-group-item"><p>Heading: participant<br>The participant element in the Procedure Note header follows the General Header Constraints for participants.<br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8504)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> Individual (CodeSystem: <b>HL7ParticipationFunction <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationFunction.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.88</a></b><b> STATIC</b>)<b> (CONF:1198-8505)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>functionCode</b>=<b>"PCP"</b> Primary Care Physician (CodeSystem: <b>HL7ParticipationFunction <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationFunction.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.88</a></b><b> STATIC</b>)<b> (CONF:1198-8506)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity/@classCode</b>=<b>"PROV"</b> Provider (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8507)</b>.</li><ul><li>This associatedEntity/@classCode <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b> (CONF:1198-8508)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>Heading: documentationOf<br>A serviceEvent is required in the Procedure Note to represent the main act, such as a colonoscopy or a cardiac stress study, being documented. It must be equivalent to or further specialize the value inherent in the ClinicalDocument/@code (such as where the ClinicalDocument/@code is simply "Procedure Note" and the procedure is "colonoscopy"), and it shall not conflict with the value inherent in the ClinicalDocument/@code, as such a conflict would create ambiguity. A serviceEvent/effectiveTime element indicates the time the actual event (as opposed to the encounter surrounding the event) took place. serviceEvent/effectiveTime may be represented two different ways in the Procedure Note. For accuracy to the second, the best method is effectiveTime/low together with effectiveTime/high. If a more general time, such as minutes or hours, is acceptable OR if the duration is unknown, an effectiveTime/low with a width element may be used. If the duration is unknown, the appropriate HL7 null value such as "NI" or "NA" must be used for the width element.<br></p> <b>SHALL</b> contain at least one [1..*] <b>documentationOf</b><b> (CONF:1198-8510)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-10061)</b>.</li><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-10062)</b>.</li><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-26449)</b>.</li></ul><ul><li><p>The serviceEvent/effectiveTime <strong>SHALL</strong> be present with effectiveTime/low (CONF:1198-8513).</p></li></ul><ul><li><p>If a width is not present, the serviceEvent/effectiveTime <strong>SHALL</strong> include effectiveTime/high (CONF:1198-8514).</p></li></ul><ul><li><p>When only the date and the length of the procedure are known a width element <strong>SHALL</strong> be present and the serviceEvent/effectiveTime/high <strong>SHALL NOT</strong> be present (CONF:1198-8515).</p></li></ul></ul><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>performer</b><b> (CONF:1198-8520)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PPRF"</b> Primary Performer (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8521)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-14911)</b>.</li><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1198-14912)</b>.</li></ul></ul></ul><ul><li>This serviceEvent <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-32732)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRF"</b> Secondary Performer (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1198-32734)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-32733)</b>.</li><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b> (CONF:1198-32735)</b>.</li></ul></ul></ul><ul><li><p>The value of Clinical Document /documentationOf/serviceEvent/code <strong>SHALL</strong> be from ICD9 CM Procedures (codeSystem 2.16.840.1.113883.6.104), CPT-4 (codeSystem <a href="https://terminology.hl7.org/CodeSystem-CPT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>), or values descending from 71388002 (Procedure) from the SNOMED CT (codeSystem <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) ValueSet <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.28/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.28 </a>Procedure <em>DYNAMIC</em> (CONF:1198-8511).</p></li></ul></ul></li>
-<li class="list-group-item"><p>Authorization represents consent. Consent, if present, shall be represented by authorization/consent.<br></p> <b>MAY</b> contain zero or one [0..1] <b>authorization</b><b> (CONF:1198-32412)</b>.<ul><li>The authorization, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"AUTH"</b> authorized by (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32413)</b>.</li></ul><ul><li>The authorization, if present, <b>SHALL</b> contain exactly one [1..1] <b>consent</b><b> (CONF:1198-32414)</b>.</li><ul><li>This consent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CONS"</b> consent (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-32415)</b>.</li></ul><ul><li>This consent <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1198-32416)</b>.</li></ul><ul><li>This consent <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32417)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>componentOf</b><b> (CONF:1198-30871)</b>.<ul><li>The componentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b> (CONF:1198-30872)</b>.</li><ul><li>This encompassingEncounter <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-32395)</b>.</li></ul><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-30873)</b>.</li></ul><ul><li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>encounterParticipant</b><b> (CONF:1198-30874)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REF"</b> Referrer<b> (CONF:1198-30875)</b>.</li></ul></ul><ul><li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>location</b><b> (CONF:1198-30876)</b>.</li><ul><li>Such locations <b>SHALL</b> contain exactly one [1..1] <b>healthCareFacility</b><b> (CONF:1198-30877)</b>.</li><ul><li>This healthCareFacility <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30878)</b>.</li></ul></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-9588)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30352)</b>.</li><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30353)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Complications Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.37)</b><b> (CONF:1198-30387)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30355)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Description Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.27)</b><b> (CONF:1198-30356)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30357)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Indications Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.29)</b><b> (CONF:1198-30358)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30359)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Postprocedure Diagnosis Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.36)</b><b> (CONF:1198-30360)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30361)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-30362)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30363)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment and Plan Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-30364)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30365)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Plan of Treatment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30366)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30367)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergies and Intolerances Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.6)</b><b> (CONF:1198-30368)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30369)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Anesthesia Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.25)</b><b> (CONF:1198-30370)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30371)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Chief Complaint Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-30372)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30373)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Chief Complaint and Reason for Visit Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.13)</b><b> (CONF:1198-30374)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30375)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-30376)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30377)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Past Medical History (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-30378)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30379)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  History of Present Illness Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-30380)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30381)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medical (General) History Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.39)</b><b> (CONF:1198-30382)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30383)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medications Section (entries optional) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.1)</b><b> (CONF:1198-30384)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30388)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medications Administered Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.38)</b><b> (CONF:1198-30389)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30390)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Physical Exam Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-30391)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30392)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Procedure Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.30)</b><b> (CONF:1198-30393)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30394)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Disposition Section<b> (identifier: 2.16.840.1.113883.10.20.18.2.12)</b><b> (CONF:1198-30395)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30396)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Estimated Blood Loss Section<b> (identifier: 2.16.840.1.113883.10.20.18.2.9)</b><b> (CONF:1198-30397)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30398)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Findings Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.28)</b><b> (CONF:1198-30399)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30400)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Implants Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.40)</b><b> (CONF:1198-30401)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30402)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Specimens Taken Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.31)</b><b> (CONF:1198-30403)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30404)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedures Section (entries optional) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-30405)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30406)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Reason for Visit Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.12)</b><b> (CONF:1198-30407)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30408)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Review of Systems Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30409)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30410)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-30411)</b>.</li></ul></ul><ul><li><p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-30412).</p></li></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-30414).</p></li></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain a Chief Complaint and Reason for Visit Section (2.16.840.1.113883.10.20.22.2.13) when either a Chief Complaint Section (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) is present (CONF:1198-30415).</p></li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8496)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.6"</b><b>
+              (CONF:1198-10050)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32520)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32941).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The Procedure Note recommends use of a single document type code, 28570-0 "Procedure Note", with further
+          specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any
+          coded values describing the author or performer of the service act or the practice setting must be consistent
+          with the LOINC document type. <br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b>
+          (CONF:1198-17182)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ProcedureNoteDocumentTypeCodes<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.6.1/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.6.1</a></b><b> DYNAMIC</b><b>
+              (CONF:1198-17183)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: participant<br>The participant element in the Procedure Note header follows the General Header
+          Constraints for participants.<br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b>
+          (CONF:1198-8504)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> Individual (CodeSystem:
+            <b>HL7ParticipationFunction <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationFunction.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.88</a></b><b> STATIC</b>)<b>
+              (CONF:1198-8505)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>functionCode</b>=<b>"PCP"</b> Primary Care Physician
+            (CodeSystem: <b>HL7ParticipationFunction <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationFunction.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.88</a></b><b> STATIC</b>)<b>
+              (CONF:1198-8506)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>associatedEntity/@classCode</b>=<b>"PROV"</b> Provider
+            (CodeSystem: <b>HL7ParticipationType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b>
+              (CONF:1198-8507)</b>.</li>
+          <ul>
+            <li>This associatedEntity/@classCode <b>SHALL</b> contain exactly one [1..1] <b>associatedPerson</b><b>
+                (CONF:1198-8508)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: documentationOf<br>A serviceEvent is required in the Procedure Note to represent the main act, such
+          as a colonoscopy or a cardiac stress study, being documented. It must be equivalent to or further specialize
+          the value inherent in the ClinicalDocument/@code (such as where the ClinicalDocument/@code is simply
+          "Procedure Note" and the procedure is "colonoscopy"), and it shall not conflict with the value inherent in the
+          ClinicalDocument/@code, as such a conflict would create ambiguity. A serviceEvent/effectiveTime element
+          indicates the time the actual event (as opposed to the encounter surrounding the event) took place.
+          serviceEvent/effectiveTime may be represented two different ways in the Procedure Note. For accuracy to the
+          second, the best method is effectiveTime/low together with effectiveTime/high. If a more general time, such as
+          minutes or hours, is acceptable OR if the duration is unknown, an effectiveTime/low with a width element may
+          be used. If the duration is unknown, the appropriate HL7 null value such as "NI" or "NA" must be used for the
+          width element.<br></p> <b>SHALL</b> contain at least one [1..*] <b>documentationOf</b><b> (CONF:1198-8510)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-10061)</b>.</li>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] US Realm Date and Time (DT.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-10062)</b>.</li>
+            <ul>
+              <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-26449)</b>.</li>
+            </ul>
+            <ul>
+              <li>
+                <p>The serviceEvent/effectiveTime <strong>SHALL</strong> be present with effectiveTime/low
+                  (CONF:1198-8513).</p>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <p>If a width is not present, the serviceEvent/effectiveTime <strong>SHALL</strong> include
+                  effectiveTime/high (CONF:1198-8514).</p>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <p>When only the date and the length of the procedure are known a width element <strong>SHALL</strong>
+                  be present and the serviceEvent/effectiveTime/high <strong>SHALL NOT</strong> be present
+                  (CONF:1198-8515).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>performer</b><b> (CONF:1198-8520)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PPRF"</b> Primary Performer (CodeSystem:
+                <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+                  STATIC</b>)<b> (CONF:1198-8521)</b>.</li>
+            </ul>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-14911)</b>.</li>
+              <ul>
+                <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be
+                  selected from ValueSet Healthcare Provider Taxonomy<b> <a
+                      href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                      target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b>
+                    DYNAMIC</b><b> (CONF:1198-14912)</b>.</li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-32732)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRF"</b> Secondary Performer
+                (CodeSystem: <b>HL7ParticipationType <a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1198-32734)</b>.
+              </li>
+            </ul>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-32733)</b>.</li>
+              <ul>
+                <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be
+                  selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b>
+                    DYNAMIC</b><b> (CONF:1198-32735)</b>.</li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>The value of Clinical Document /documentationOf/serviceEvent/code <strong>SHALL</strong> be from ICD9
+                CM Procedures (codeSystem 2.16.840.1.113883.6.104), CPT-4 (codeSystem <a
+                  href="https://terminology.hl7.org/CodeSystem-CPT.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>), or values descending from
+                71388002 (Procedure) from the SNOMED CT (codeSystem <a
+                  href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) ValueSet <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.28/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.28 </a>Procedure
+                <em>DYNAMIC</em> (CONF:1198-8511).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Authorization represents consent. Consent, if present, shall be represented by authorization/consent.<br></p>
+        <b>MAY</b> contain zero or one [0..1] <b>authorization</b><b> (CONF:1198-32412)</b>.<ul>
+          <li>The authorization, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"AUTH"</b>
+            authorized by (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32413)</b>.</li>
+        </ul>
+        <ul>
+          <li>The authorization, if present, <b>SHALL</b> contain exactly one [1..1] <b>consent</b><b>
+              (CONF:1198-32414)</b>.</li>
+          <ul>
+            <li>This consent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CONS"</b> consent
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+                (CONF:1198-32415)</b>.</li>
+          </ul>
+          <ul>
+            <li>This consent <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> event (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1198-32416)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This consent <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32417)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>componentOf</b><b> (CONF:1198-30871)</b>.
+        <ul>
+          <li>The componentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b>
+              (CONF:1198-30872)</b>.</li>
+          <ul>
+            <li>This encompassingEncounter <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-32395)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-30873)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>encounterParticipant</b><b>
+                (CONF:1198-30874)</b> such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REF"</b> Referrer<b>
+                  (CONF:1198-30875)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>location</b><b>
+                (CONF:1198-30876)</b>.</li>
+            <ul>
+              <li>Such locations <b>SHALL</b> contain exactly one [1..1] <b>healthCareFacility</b><b>
+                  (CONF:1198-30877)</b>.</li>
+              <ul>
+                <li>This healthCareFacility <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30878)</b>.
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-9588)</b>.<ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30352)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30353)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Complications Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.37)</b><b> (CONF:1198-30387)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30355)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Description Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.27)</b><b> (CONF:1198-30356)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30357)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Indications Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.29)</b><b> (CONF:1198-30358)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30359)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Postprocedure Diagnosis Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.36)</b><b> (CONF:1198-30360)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30361)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-30362)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30363)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment and Plan Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-30364)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30365)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Plan of Treatment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30366)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30367)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Allergies and Intolerances Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.6)</b><b> (CONF:1198-30368)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30369)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Anesthesia Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.25)</b><b> (CONF:1198-30370)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30371)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Chief Complaint Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-30372)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30373)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Chief Complaint and Reason for Visit Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.13)</b><b> (CONF:1198-30374)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30375)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Family History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-30376)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30377)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Past Medical History (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-30378)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30379)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] History of Present Illness Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-30380)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30381)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medical (General) History Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.39)</b><b> (CONF:1198-30382)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30383)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medications Section (entries optional) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.1)</b><b> (CONF:1198-30384)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30388)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medications Administered Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.38)</b><b> (CONF:1198-30389)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30390)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Physical Exam Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-30391)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30392)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Planned Procedure Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.30)</b><b> (CONF:1198-30393)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30394)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Disposition Section<b> (identifier:
+                  2.16.840.1.113883.10.20.18.2.12)</b><b> (CONF:1198-30395)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30396)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Estimated Blood Loss Section<b> (identifier:
+                  2.16.840.1.113883.10.20.18.2.9)</b><b> (CONF:1198-30397)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30398)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Findings Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.28)</b><b> (CONF:1198-30399)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30400)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Implants Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.40)</b><b> (CONF:1198-30401)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30402)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Specimens Taken Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.31)</b><b> (CONF:1198-30403)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30404)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedures Section (entries optional) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-30405)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30406)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Reason for Visit Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.12)</b><b> (CONF:1198-30407)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30408)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Review of Systems Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30409)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30410)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Social History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-30411)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan
+                of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-30412).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a
+                Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-30414).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain a Chief Complaint and Reason for Visit Section
+                (2.16.840.1.113883.10.20.22.2.13) when either a Chief Complaint Section
+                (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) is
+                present (CONF:1198-30415).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.6/Procedure%20Note%20performer%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Note performer Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.6/Procedure%20Note%20serviceEvent%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Note serviceEvent Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.6/Procedure%20Note%20performer%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Note performer Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.6/Procedure%20Note%20serviceEvent%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Note serviceEvent Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.7.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.7.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,395 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Operative Note (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.7, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.7.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Operative Note (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.7,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.7.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Operative Note is a frequently used type of procedure note with specific requirements set forth by regulatory agencies.The Operative Note is created immediately following a surgical or other high-risk procedure. It records the pre- and post-surgical diagnosis, pertinent events of the procedure, as well as the condition of the patient following the procedure. The report should be sufficiently detailed to support the diagnoses, justify the treatment, document the course of the procedure, and provide continuity of care.</p></div>
+    <div id="description">
+      <p>The Operative Note is a frequently used type of procedure note with specific requirements set forth by
+        regulatory agencies.The Operative Note is created immediately following a surgical or other high-risk procedure.
+        It records the pre- and post-surgical diagnosis, pertinent events of the procedure, as well as the condition of
+        the patient following the procedure. The report should be sufficiently detailed to support the diagnoses,
+        justify the treatment, document the course of the procedure, and provide continuity of care.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.25.html">Anesthesia Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.37.html">Complications Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.34.html">Preoperative Diagnosis Section (V3)</a><br><a href="2.16.840.1.113883.10.20.18.2.9.html">Procedure Estimated Blood Loss Section</a><br><a href="2.16.840.1.113883.10.20.22.2.28.html">Procedure Findings Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.31.html">Procedure Specimens Taken Section</a><br><a href="2.16.840.1.113883.10.20.22.2.27.html">Procedure Description Section</a><br><a href="2.16.840.1.113883.10.20.22.2.35.html">Postoperative Diagnosis Section</a><br><a href="2.16.840.1.113883.10.20.22.2.40.html">Procedure Implants Section</a><br><a href="2.16.840.1.113883.10.20.7.12.html">Operative Note Fluids Section</a><br><a href="2.16.840.1.113883.10.20.7.14.html">Operative Note Surgical Procedure Section</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.30.html">Planned Procedure Section (V2)</a><br><a href="2.16.840.1.113883.10.20.18.2.12.html">Procedure Disposition Section</a><br><a href="2.16.840.1.113883.10.20.22.2.29.html">Procedure Indications Section (V2)</a><br><a href="2.16.840.1.113883.10.20.7.13.html">Surgical Drains Section</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time
+              (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.25.html">Anesthesia Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.37.html">Complications Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.34.html">Preoperative Diagnosis Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.18.2.9.html">Procedure Estimated Blood Loss Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.28.html">Procedure Findings Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.31.html">Procedure Specimens Taken Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.27.html">Procedure Description Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.35.html">Postoperative Diagnosis Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.40.html">Procedure Implants Section</a><br><a
+              href="2.16.840.1.113883.10.20.7.12.html">Operative Note Fluids Section</a><br><a
+              href="2.16.840.1.113883.10.20.7.14.html">Operative Note Surgical Procedure Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.30.html">Planned Procedure Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.18.2.12.html">Procedure Disposition Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.29.html">Procedure Indications Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.7.13.html">Surgical Drains Section</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8483)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.7"</b><b> (CONF:1198-10048)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32519)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32940).</p></li></ul></li>
-<li class="list-group-item"><p>The Operative Note recommends use of a single document type code, 11504-8 "Provider-unspecified Operation Note", with further specification provided by author or performer, setting, or specialty data in the CDA header. Some of the LOINC codes in the Surgical Operation Note Document Type Code table are pre-coordinated with the practice setting or the training or professional level of the author. Use of pre-coordinated codes is not recommended because of potential conflict with other information in the header. When these codes are used, any coded values describing the author or performer of the service act or the practice setting must be consistent with the LOINC document type.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-17187)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet SurgicalOperationNoteDocumentTypeCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.1.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.1.1</a></b><b> DYNAMIC</b><b> (CONF:1198-17188)</b>.</li></ul></li>
-<li class="list-group-item"><p>Heading: documentationOf<br>A serviceEvent represents the main act, such as a colonoscopy or an appendectomy, being documented. A serviceEvent can further specialize the act inherent in the ClinicalDocument/code, such as where the ClinicalDocument/code is simply "Surgical Operation Note" and the procedure is "Appendectomy." serviceEvent is required in the Operative Note and it must be equivalent to or further specialize the value inherent in the ClinicalDocument/code; it shall not conflict with the value inherent in the ClinicalDocument/code, as such a conflict would create ambiguity. serviceEvent/effectiveTime can be used to indicate the time the actual event (as opposed to the encounter surrounding the event) took place. If the date and the duration of the procedure is known, serviceEvent/effectiveTime/low is used with a width element that describes the duration; no high element is used. However, if only the date is known, the date is placed in both the low and high elements.<br></p> <b>SHALL</b> contain at least one [1..*] <b>documentationOf</b><b> (CONF:1198-8486)</b>.<ul><li>Such documentationOfs <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-8493)</b>.</li><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-8494)</b>.</li><ul><li><p>The serviceEvent/effectiveTime <strong>SHALL</strong> be present with effectiveTime/low (CONF:1198-8488).</p></li></ul><ul><li><p>If a width is not present, the serviceEvent/effectiveTime <strong>SHALL</strong> include effectiveTime/high (CONF:1198-10058).</p></li></ul><ul><li><p>When only the date and the length of the procedure are known a width element <strong>SHALL</strong> be present and the serviceEvent/effectiveTime/high <strong>SHALL NOT</strong> be present (CONF:1198-10060).</p></li></ul></ul><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>performer</b><b> (CONF:1198-8489)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PPRF"</b> Primary performer (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8495)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>functionCode</b>, which <b>SHOULD</b> be selected from ValueSet Care Team Member Function<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.30</a></b><b> DYNAMIC</b><b> (CONF:1198-32963)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-10917)</b>.</li><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1198-8490)</b>.</li></ul></ul></ul><ul><li>This serviceEvent <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-32736)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRF"</b> Secondary performer (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1198-32738)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>functionCode</b>, which <b>SHOULD</b> be selected from ValueSet Care Team Member Function<b> 2.16.840.1.113762.1.4.1099.30</b><b> DYNAMIC</b><b> (CONF:1198-32964)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-32737)</b>.</li><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b> DYNAMIC</b><b> (CONF:1198-32739)</b>.</li></ul></ul></ul><ul><li><p>The value of serviceEvent/code <strong>SHALL</strong> be from ICD9 CM Procedures (CodeSystem 2.16.840.1.113883.6.104), CPT-4 (CodeSystem <a href="https://terminology.hl7.org/CodeSystem-CPT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>), or values descending from 71388002 (Procedure) from the SNOMED CT (CodeSystem <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) ValueSet Procedure <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.28/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.28 </a><em>DYNAMIC</em> (CONF:1198-8487).</p></li></ul></ul></li>
-<li class="list-group-item"><p>Authorization represents consent. Consent, if present, shall be represented by authorization/consent.<br></p> <b>MAY</b> contain zero or one [0..1] <b>authorization</b><b> (CONF:1198-32404)</b>.<ul><li>The authorization, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"AUTH"</b> authorized by (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32408)</b>.</li></ul><ul><li>The authorization, if present, <b>SHALL</b> contain exactly one [1..1] <b>consent</b><b> (CONF:1198-32405)</b>.</li><ul><li>This consent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CONS"</b> consent (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-32409)</b>.</li></ul><ul><li>This consent <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1198-32410)</b>.</li></ul><ul><li>This consent <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32411)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-9585)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30485)</b>.</li><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30486)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Anesthesia Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.25)</b><b> (CONF:1198-30487)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30488)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Complications Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.37)</b><b> (CONF:1198-30489)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30490)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Preoperative Diagnosis Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.34)</b><b> (CONF:1198-30491)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30492)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Estimated Blood Loss Section<b> (identifier: 2.16.840.1.113883.10.20.18.2.9)</b><b> (CONF:1198-30493)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30494)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Findings Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.28)</b><b> (CONF:1198-30495)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30496)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Specimens Taken Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.31)</b><b> (CONF:1198-30497)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30498)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Description Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.27)</b><b> (CONF:1198-30499)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30500)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Postoperative Diagnosis Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.35)</b><b> (CONF:1198-30501)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30502)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Implants Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.40)</b><b> (CONF:1198-30503)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30504)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Operative Note Fluids Section<b> (identifier: 2.16.840.1.113883.10.20.7.12)</b><b> (CONF:1198-30505)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30506)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Operative Note Surgical Procedure Section<b> (identifier: 2.16.840.1.113883.10.20.7.14)</b><b> (CONF:1198-30507)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30508)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Plan of Treatment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30509)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30510)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Procedure Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.30)</b><b> (CONF:1198-30511)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30512)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Disposition Section<b> (identifier: 2.16.840.1.113883.10.20.18.2.12)</b><b> (CONF:1198-30513)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30514)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Indications Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.29)</b><b> (CONF:1198-30515)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30516)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Surgical Drains Section<b> (identifier: 2.16.840.1.113883.10.20.7.13)</b><b> (CONF:1198-30517)</b>.</li></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8483)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.7"</b><b>
+              (CONF:1198-10048)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32519)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32940).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The Operative Note recommends use of a single document type code, 11504-8 "Provider-unspecified Operation
+          Note", with further specification provided by author or performer, setting, or specialty data in the CDA
+          header. Some of the LOINC codes in the Surgical Operation Note Document Type Code table are pre-coordinated
+          with the practice setting or the training or professional level of the author. Use of pre-coordinated codes is
+          not recommended because of potential conflict with other information in the header. When these codes are used,
+          any coded values describing the author or performer of the service act or the practice setting must be
+          consistent with the LOINC document type.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b>
+          (CONF:1198-17187)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet SurgicalOperationNoteDocumentTypeCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.1.1/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.1.1</a></b><b> DYNAMIC</b><b>
+              (CONF:1198-17188)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: documentationOf<br>A serviceEvent represents the main act, such as a colonoscopy or an appendectomy,
+          being documented. A serviceEvent can further specialize the act inherent in the ClinicalDocument/code, such as
+          where the ClinicalDocument/code is simply "Surgical Operation Note" and the procedure is "Appendectomy."
+          serviceEvent is required in the Operative Note and it must be equivalent to or further specialize the value
+          inherent in the ClinicalDocument/code; it shall not conflict with the value inherent in the
+          ClinicalDocument/code, as such a conflict would create ambiguity. serviceEvent/effectiveTime can be used to
+          indicate the time the actual event (as opposed to the encounter surrounding the event) took place. If the date
+          and the duration of the procedure is known, serviceEvent/effectiveTime/low is used with a width element that
+          describes the duration; no high element is used. However, if only the date is known, the date is placed in
+          both the low and high elements.<br></p> <b>SHALL</b> contain at least one [1..*] <b>documentationOf</b><b>
+          (CONF:1198-8486)</b>.<ul>
+          <li>Such documentationOfs <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-8493)</b>.
+          </li>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] US Realm Date and Time (DT.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-8494)</b>.</li>
+            <ul>
+              <li>
+                <p>The serviceEvent/effectiveTime <strong>SHALL</strong> be present with effectiveTime/low
+                  (CONF:1198-8488).</p>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <p>If a width is not present, the serviceEvent/effectiveTime <strong>SHALL</strong> include
+                  effectiveTime/high (CONF:1198-10058).</p>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <p>When only the date and the length of the procedure are known a width element <strong>SHALL</strong>
+                  be present and the serviceEvent/effectiveTime/high <strong>SHALL NOT</strong> be present
+                  (CONF:1198-10060).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>performer</b><b> (CONF:1198-8489)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PPRF"</b> Primary performer (CodeSystem:
+                <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+                  STATIC</b>)<b> (CONF:1198-8495)</b>.</li>
+            </ul>
+            <ul>
+              <li><b>MAY</b> contain zero or one [0..1] <b>functionCode</b>, which <b>SHOULD</b> be selected from
+                ValueSet Care Team Member Function<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.30</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-32963)</b>.</li>
+            </ul>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-10917)</b>.</li>
+              <ul>
+                <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be
+                  selected from ValueSet Healthcare Provider Taxonomy<b> <a
+                      href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                      target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b>
+                    DYNAMIC</b><b> (CONF:1198-8490)</b>.</li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-32736)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRF"</b> Secondary performer
+                (CodeSystem: <b>HL7ParticipationType <a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1198-32738)</b>.
+              </li>
+            </ul>
+            <ul>
+              <li><b>MAY</b> contain zero or one [0..1] <b>functionCode</b>, which <b>SHOULD</b> be selected from
+                ValueSet Care Team Member Function<b> 2.16.840.1.113762.1.4.1099.30</b><b> DYNAMIC</b><b>
+                  (CONF:1198-32964)</b>.</li>
+            </ul>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-32737)</b>.</li>
+              <ul>
+                <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be
+                  selected from ValueSet Healthcare Provider Taxonomy<b> 2.16.840.1.114222.4.11.1066</b><b>
+                    DYNAMIC</b><b> (CONF:1198-32739)</b>.</li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>The value of serviceEvent/code <strong>SHALL</strong> be from ICD9 CM Procedures (CodeSystem
+                2.16.840.1.113883.6.104), CPT-4 (CodeSystem <a href="https://terminology.hl7.org/CodeSystem-CPT.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>), or values
+                descending from 71388002 (Procedure) from the SNOMED CT (CodeSystem <a
+                  href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) ValueSet Procedure <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.28/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.28
+                </a><em>DYNAMIC</em> (CONF:1198-8487).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Authorization represents consent. Consent, if present, shall be represented by authorization/consent.<br></p>
+        <b>MAY</b> contain zero or one [0..1] <b>authorization</b><b> (CONF:1198-32404)</b>.<ul>
+          <li>The authorization, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"AUTH"</b>
+            authorized by (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32408)</b>.</li>
+        </ul>
+        <ul>
+          <li>The authorization, if present, <b>SHALL</b> contain exactly one [1..1] <b>consent</b><b>
+              (CONF:1198-32405)</b>.</li>
+          <ul>
+            <li>This consent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CONS"</b> consent
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+                (CONF:1198-32409)</b>.</li>
+          </ul>
+          <ul>
+            <li>This consent <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> event (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1198-32410)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This consent <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32411)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-9585)</b>.<ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30485)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30486)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Anesthesia Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.25)</b><b> (CONF:1198-30487)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30488)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Complications Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.37)</b><b> (CONF:1198-30489)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30490)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Preoperative Diagnosis Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.34)</b><b> (CONF:1198-30491)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30492)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Estimated Blood Loss Section<b> (identifier:
+                  2.16.840.1.113883.10.20.18.2.9)</b><b> (CONF:1198-30493)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30494)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Findings Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.28)</b><b> (CONF:1198-30495)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30496)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Specimens Taken Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.31)</b><b> (CONF:1198-30497)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30498)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Description Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.27)</b><b> (CONF:1198-30499)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30500)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Postoperative Diagnosis Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.35)</b><b> (CONF:1198-30501)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30502)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Implants Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.40)</b><b> (CONF:1198-30503)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30504)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Operative Note Fluids Section<b> (identifier:
+                  2.16.840.1.113883.10.20.7.12)</b><b> (CONF:1198-30505)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30506)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Operative Note Surgical Procedure Section<b> (identifier:
+                  2.16.840.1.113883.10.20.7.14)</b><b> (CONF:1198-30507)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30508)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Plan of Treatment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30509)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30510)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Planned Procedure Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.30)</b><b> (CONF:1198-30511)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30512)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Disposition Section<b> (identifier:
+                  2.16.840.1.113883.10.20.18.2.12)</b><b> (CONF:1198-30513)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30514)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedure Indications Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.29)</b><b> (CONF:1198-30515)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30516)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Surgical Drains Section<b> (identifier:
+                  2.16.840.1.113883.10.20.7.13)</b><b> (CONF:1198-30517)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Operative%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.7/Operative%20Note%20performer%20Example.xml"><i class="fab fa-github"></i>&nbsp;Operative Note performer Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Operative%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.7/Operative%20Note%20serviceEvent%20Example.xml"><i class="fab fa-github"></i>&nbsp;Operative Note serviceEvent Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Operative%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.7/Operative%20Note%20performer%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Operative Note performer Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Operative%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.7/Operative%20Note%20serviceEvent%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Operative Note serviceEvent Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.8.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.8.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,426 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Discharge Summary (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.8, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.8.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Discharge Summary (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.8,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.8.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Discharge Summary is a document which synopsizes a patient's admission to a hospital, LTPAC provider, or other setting. It provides information for the continuation of care following discharge. The Joint Commission requires the following information to be included in the Discharge Summary (<a href="http://www.jointcommission.org/">http://www.jointcommission.org/</a>):'  The reason for hospitalization (the admission)'  The procedures performed, as applicable'  The care, treatment, and services provided'  The patient's condition and disposition at discharge'  Information provided to the patient and family'  Provisions for follow-up care</p><p>The best practice for a Discharge Summary is to include the discharge disposition in the display of the header.</p></div>
+    <div id="description">
+      <p>The Discharge Summary is a document which synopsizes a patient's admission to a hospital, LTPAC provider, or
+        other setting. It provides information for the continuation of care following discharge. The Joint Commission
+        requires the following information to be included in the Discharge Summary (<a
+          href="http://www.jointcommission.org/">http://www.jointcommission.org/</a>):' The reason for hospitalization
+        (the admission)' The procedures performed, as applicable' The care, treatment, and services provided' The
+        patient's condition and disposition at discharge' Information provided to the patient and family' Provisions for
+        follow-up care</p>
+      <p>The best practice for a Discharge Summary is to include the discharge disposition in the display of the header.
+      </p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section (entries optional) (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.5.html">Hospital Course Section</a><br><a href="2.16.840.1.113883.10.20.22.2.24.html">Discharge Diagnosis Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.11.html">Discharge Medications Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a href="2.16.840.1.113883.10.20.22.2.13.html">Chief Complaint and Reason for Visit Section</a><br><a href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a href="2.16.840.1.113883.10.20.22.2.43.html">Admission Diagnosis Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.44.html">Admission Medications Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.42.html">Hospital Consultations Section</a><br><a href="2.16.840.1.113883.10.20.22.2.41.html">Hospital Discharge Instructions Section</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.26.html">Hospital Discharge Physical Section</a><br><a href="2.16.840.1.113883.10.20.22.2.16.html">Hospital Discharge Studies Summary Section</a><br><a href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.12.html">Reason for Visit Section</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.4.html">Vital Signs Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.11.1.html">Discharge Medications Section (entries required) (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section (entries
+              optional) (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.5.html">Hospital Course Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.24.html">Discharge Diagnosis Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.11.html">Discharge Medications Section (entries optional)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.13.html">Chief Complaint and Reason for Visit Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.20.html">Past Medical History (V3)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.4.html">History of Present Illness Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.43.html">Admission Diagnosis Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.44.html">Admission Medications Section (entries optional)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.42.html">Hospital Consultations Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.41.html">Hospital Discharge Instructions Section</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.26.html">Hospital Discharge Physical Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.16.html">Hospital Discharge Studies Summary Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.12.html">Reason for Visit Section</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.4.html">Vital Signs Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.11.1.html">Discharge Medications Section (entries required)
+              (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8463)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.8"</b><b> (CONF:1198-10044)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32517)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32938).</p></li></ul></li>
-<li class="list-group-item"><p>The Discharge Summary recommends use of a single document type code, 18842-5 "Discharge summary", with further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any coded values describing the author or performer of the service act or the practice setting must be consistent with the LOINC document type. <br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-17178)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet DischargeSummaryDocumentTypeCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.4.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.4.1</a></b><b> DYNAMIC</b><b> (CONF:1198-17179)</b>.</li></ul></li>
-<li class="list-group-item"><p>Heading: participant<br>The participant element in the Discharge Summary header follows the General Header Constraints for participants. Discharge Summary does not specify any use for functionCode for participants. Local policies will determine how this element should be used in implementations.<br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8467)</b>.<ul><li><p>When participant/@typeCode is IND, associatedEntity/@classCode <strong>SHALL</strong> be selected from ValueSet <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33 </a>INDRoleclassCodes STATIC 2011-09-30 (CONF:1198-8469).</p></li></ul></li>
-<li class="list-group-item"><p>Heading: componentOf<br>The Discharge Summary is always associated with a Hospital Admission using the encompassingEncounter element in the header.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>componentOf</b><b> (CONF:1198-8471)</b>.<ul><li>This componentOf <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b> (CONF:1198-8472)</b>.</li><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-32611)</b>.</li><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-8473)</b>.</li></ul><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1198-8475)</b>.</li></ul></ul><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>dischargeDispositionCode</b>, which <b>SHOULD</b> be selected from ValueSet NUBC UB-04 FL17 Patient Status<b> 2.16.840.1.113883.3.88.12.80.33</b><b> DYNAMIC</b><b> (CONF:1198-8476)</b>.</li></ul><ul><li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>responsibleParty</b><b> (CONF:1198-8479)</b>.</li><ul><li>The responsibleParty, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-32613)</b>.</li><ul><li><p>This assignedEntity <strong>SHALL</strong> contain an assignedPerson or a representedOrganization or both (CONF:1198-32898).</p></li></ul></ul></ul><ul><li>This encompassingEncounter <b>MAY</b> contain zero or more [0..*] <b>encounterParticipant</b><b> (CONF:1198-8478)</b>.</li><ul><li>The encounterParticipant, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-32615)</b>.</li><ul><li><p>This assignedEntity <strong>SHALL</strong> contain an assignedPerson or a representedOrganization or both (CONF:1198-32899).</p></li></ul></ul></ul></ul></li>
-<li class="list-group-item"><p>In this template (templateId 2.16.840.1.113883.10.20.22.1.8.2), coded entries are optional.</p> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-9539)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30518)</b>.</li><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30519)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergies and Intolerances Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.6)</b><b> (CONF:1198-30520)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30521)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Hospital Course Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.5)</b><b> (CONF:1198-30522)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30523)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Discharge Diagnosis Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.24)</b><b> (CONF:1198-30524)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30525)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Discharge Medications Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.11)</b><b> (CONF:1198-30526)</b>.</li></ul></ul><ul><li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30527)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Plan of Treatment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30528)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30529)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Chief Complaint Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-30530)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30531)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Chief Complaint and Reason for Visit Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.13)</b><b> (CONF:1198-30532)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30533)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-30534)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30535)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-30536)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30537)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-30538)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30539)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Past Medical History (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-30540)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30541)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  History of Present Illness Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-30542)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30543)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Admission Diagnosis Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.43)</b><b> (CONF:1198-30544)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30545)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Admission Medications Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.44)</b><b> (CONF:1198-30546)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30547)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Hospital Consultations Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.42)</b><b> (CONF:1198-30548)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30549)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Hospital Discharge Instructions Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.41)</b><b> (CONF:1198-30550)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30551)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Hospital Discharge Physical Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.26)</b><b> (CONF:1198-30552)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30553)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Hospital Discharge Studies Summary Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.16)</b><b> (CONF:1198-30554)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30555)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Immunizations Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.2)</b><b> (CONF:1198-30556)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30557)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.5)</b><b> (CONF:1198-30558)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30559)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedures Section (entries optional) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-30560)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30561)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Reason for Visit Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.12)</b><b> (CONF:1198-30562)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30563)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Review of Systems Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30564)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30565)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-30566)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30567)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Signs Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.4)</b><b> (CONF:1198-30568)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31586)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Discharge Medications Section (entries required) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.11.1)</b><b> (CONF:1198-31587)</b>.</li></ul></ul><ul><li><p>This structuredBody <em><strong>SHALL NOT</strong></em> contain a Chief Complaint and Reason for Visit Section (2.16.840.1.113883.10.20.22.2.13) when either a Chief Complaint Section (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) is present (CONF:1198-30569).</p></li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8463)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.8"</b><b>
+              (CONF:1198-10044)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32517)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32938).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The Discharge Summary recommends use of a single document type code, 18842-5 "Discharge summary", with
+          further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are
+          used, any coded values describing the author or performer of the service act or the practice setting must be
+          consistent with the LOINC document type. <br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b>
+          (CONF:1198-17178)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet DischargeSummaryDocumentTypeCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.4.1/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.4.1</a></b><b> DYNAMIC</b><b>
+              (CONF:1198-17179)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: participant<br>The participant element in the Discharge Summary header follows the General Header
+          Constraints for participants. Discharge Summary does not specify any use for functionCode for participants.
+          Local policies will determine how this element should be used in implementations.<br></p> <b>MAY</b> contain
+        zero or more [0..*] <b>participant</b><b> (CONF:1198-8467)</b>.<ul>
+          <li>
+            <p>When participant/@typeCode is IND, associatedEntity/@classCode <strong>SHALL</strong> be selected from
+              ValueSet <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.33/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.33
+              </a>INDRoleclassCodes STATIC 2011-09-30 (CONF:1198-8469).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: componentOf<br>The Discharge Summary is always associated with a Hospital Admission using the
+          encompassingEncounter element in the header.<br></p> <b>SHALL</b> contain exactly one [1..1]
+        <b>componentOf</b><b> (CONF:1198-8471)</b>.<ul>
+          <li>This componentOf <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b>
+              (CONF:1198-8472)</b>.</li>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+                (CONF:1198-32611)</b>.</li>
+            <ul>
+              <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-8473)</b>.</li>
+            </ul>
+            <ul>
+              <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1198-8475)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>dischargeDispositionCode</b>,
+              which <b>SHOULD</b> be selected from ValueSet NUBC UB-04 FL17 Patient Status<b>
+                2.16.840.1.113883.3.88.12.80.33</b><b> DYNAMIC</b><b> (CONF:1198-8476)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>MAY</b> contain zero or one [0..1] <b>responsibleParty</b><b>
+                (CONF:1198-8479)</b>.</li>
+            <ul>
+              <li>The responsibleParty, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+                  (CONF:1198-32613)</b>.</li>
+              <ul>
+                <li>
+                  <p>This assignedEntity <strong>SHALL</strong> contain an assignedPerson or a representedOrganization
+                    or both (CONF:1198-32898).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>MAY</b> contain zero or more [0..*] <b>encounterParticipant</b><b>
+                (CONF:1198-8478)</b>.</li>
+            <ul>
+              <li>The encounterParticipant, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+                  (CONF:1198-32615)</b>.</li>
+              <ul>
+                <li>
+                  <p>This assignedEntity <strong>SHALL</strong> contain an assignedPerson or a representedOrganization
+                    or both (CONF:1198-32899).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>In this template (templateId 2.16.840.1.113883.10.20.22.1.8.2), coded entries are optional.</p> <b>SHALL</b>
+        contain exactly one [1..1] <b>component</b><b> (CONF:1198-9539)</b>.<ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30518)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30519)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Allergies and Intolerances Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.6)</b><b> (CONF:1198-30520)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30521)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Hospital Course Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.5)</b><b> (CONF:1198-30522)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30523)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Discharge Diagnosis Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.24)</b><b> (CONF:1198-30524)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30525)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Discharge Medications Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.11)</b><b> (CONF:1198-30526)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-30527)</b>
+              such that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Plan of Treatment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30528)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30529)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Chief Complaint Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-30530)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30531)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Chief Complaint and Reason for Visit Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.13)</b><b> (CONF:1198-30532)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30533)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Nutrition Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-30534)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30535)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Family History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.15)</b><b> (CONF:1198-30536)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30537)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Functional Status Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.14)</b><b> (CONF:1198-30538)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30539)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Past Medical History (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.20)</b><b> (CONF:1198-30540)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30541)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] History of Present Illness Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.4)</b><b> (CONF:1198-30542)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30543)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Admission Diagnosis Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.43)</b><b> (CONF:1198-30544)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30545)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Admission Medications Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.44)</b><b> (CONF:1198-30546)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30547)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Hospital Consultations Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.42)</b><b> (CONF:1198-30548)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30549)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Hospital Discharge Instructions Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.41)</b><b> (CONF:1198-30550)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30551)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Hospital Discharge Physical Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.26)</b><b> (CONF:1198-30552)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30553)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Hospital Discharge Studies Summary Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.16)</b><b> (CONF:1198-30554)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30555)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Immunizations Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.2)</b><b> (CONF:1198-30556)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30557)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Problem Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.5)</b><b> (CONF:1198-30558)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30559)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Procedures Section (entries optional) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.7)</b><b> (CONF:1198-30560)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30561)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Reason for Visit Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.12)</b><b> (CONF:1198-30562)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30563)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Review of Systems Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30564)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30565)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Social History Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.17)</b><b> (CONF:1198-30566)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30567)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Vital Signs Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.4)</b><b> (CONF:1198-30568)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-31586)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Discharge Medications Section (entries required) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.11.1)</b><b> (CONF:1198-31587)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <em><strong>SHALL NOT</strong></em> contain a Chief Complaint and Reason for Visit
+                Section (2.16.840.1.113883.10.20.22.2.13) when either a Chief Complaint Section
+                (1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1) or a Reason for Visit Section (2.16.840.1.113883.10.20.22.2.12) is
+                present (CONF:1198-30569).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Discharge%20Summary%20(V3)_2.16.840.1.113883.10.20.22.1.8/Discharge%20Summary%20encompassingEncounter%20Example.xml"><i class="fab fa-github"></i>&nbsp;Discharge Summary encompassingEncounter Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Discharge%20Summary%20(V3)_2.16.840.1.113883.10.20.22.1.8/Discharge%20Summary%20encompassingEncounter%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Discharge Summary encompassingEncounter Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.1.9.html
+++ b/templates/2.16.840.1.113883.10.20.22.1.9.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,358 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Progress Note (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.9, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.9.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Progress Note (V3) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.22.1.9,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.1.9.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a patient's clinical status during a hospitalization, outpatient visit, treatment with a LTPAC provider, or other healthcare encounter.</p><p>Taber's medical dictionary defines a Progress Note as 'An ongoing record of a patient's illness and treatment. Physicians, nurses, consultants, and therapists record their notes concerning the progress or lack of progress made by the patient between the time of the previous note and the most recent note.'</p><p>Mosby's medical dictionary defines a Progress Note as 'Notes made by a nurse, physician, social worker, physical therapist, and other health care professionals that describe the patient's condition and the treatment given or planned.'</p><p>A Progress Note is not a re-evaluation note. A Progress Note is not intended to be a Progress Report for Medicare. Medicare B Section 1833(e) defines the requirements of a Medicare Progress Report.</p></div>
+    <div id="description">
+      <p>This template represents a patient's clinical status during a hospitalization, outpatient visit, treatment with
+        a LTPAC provider, or other healthcare encounter.</p>
+      <p>Taber's medical dictionary defines a Progress Note as 'An ongoing record of a patient's illness and treatment.
+        Physicians, nurses, consultants, and therapists record their notes concerning the progress or lack of progress
+        made by the patient between the time of the previous note and the most recent note.'</p>
+      <p>Mosby's medical dictionary defines a Progress Note as 'Notes made by a nurse, physician, social worker,
+        physical therapist, and other health care professionals that describe the patient's condition and the treatment
+        given or planned.'</p>
+      <p>A Progress Note is not a re-evaluation note. A Progress Note is not intended to be a Progress Report for
+        Medicare. Medicare B Section 1833(e) defines the requirements of a Medicare Progress Report.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section (entries optional) (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.45.html">Instructions Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.1.html">Medications Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.21.2.1.html">Objective Section</a><br><a href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.3.html">Results Section (entries optional) (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a href="2.16.840.1.113883.10.20.21.2.2.html">Subjective Section</a><br><a href="2.16.840.1.113883.10.20.22.2.4.html">Vital Signs Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time
+              (DT.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.2.8.html">Assessment Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section (entries optional)
+              (V3)</a><br><a href="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1.html">Chief Complaint Section</a><br><a
+              href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.45.html">Instructions Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.1.html">Medications Section (entries optional) (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.21.2.1.html">Objective Section</a><br><a
+              href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.3.html">Results Section (entries optional) (V3)</a><br><a
+              href="1.3.6.1.4.1.19376.1.5.3.1.3.18.html">Review of Systems Section</a><br><a
+              href="2.16.840.1.113883.10.20.21.2.2.html">Subjective Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.4.html">Vital Signs Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7588)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.9"</b><b> (CONF:1198-10052)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32521)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32942).</p></li></ul></li>
-<li class="list-group-item"><p>The Progress Note recommends use of a single document type code, 11506-3 "Subsequent evaluation note", with further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are used, any coded values describing the author or performer of the service act or the practice setting must be consistent with the LOINC document type. <br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-17189)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ProgressNoteDocumentTypeCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.8.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.8.1</a></b><b> DYNAMIC</b><b> (CONF:1198-17190)</b>.</li></ul></li>
-<li class="list-group-item"><p>Heading: documentationOf<br>A documentationOf can contain a serviceEvent to further specialize the act inherent in the ClinicalDocument/code. In a Progress Note, a serviceEvent can represent the event of writing the Progress Note. The serviceEvent/effectiveTime is the time period the note documents.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>documentationOf</b><b> (CONF:1198-7603)</b>.<ul><li>The documentationOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-7604)</b>.</li><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Care Provision (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-26420)</b>.</li></ul><ul><li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-9480)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.21.3.1"</b><b> (CONF:1198-10068)</b>.</li></ul></ul><ul><li>This serviceEvent <b>SHOULD</b> contain zero or one [0..1]  US Realm Date and Time (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-9481)</b>.</li><ul><li><p>The serviceEvent/effectiveTime element <strong>SHOULD</strong> be present with effectiveTime/low element (CONF:1198-9482).</p></li></ul><ul><li><p>If a width element is not present, the serviceEvent <strong>SHALL</strong> include effectiveTime/high (CONF:1198-10066).</p></li></ul></ul></ul></li>
-<li class="list-group-item"><p>Heading: componentOf<br>The Progress Note is always associated with an encounter by the componentOf/encompassingEncounter element in the header. The effectiveTime element for an encompassingEncounter represents the time or time interval in which the encounter took place. A single encounter may contain multiple Progress Notes; hence the effectiveTime elements for a Progress Note (recorded in serviceEvent) and for an encounter (recorded in encompassingEncounter) represent different time intervals. For outpatient encounters that are a point in time, set effectiveTime/high, effectiveTime/low, and effectiveTime/@value to the same time. All visits take place at a specific location. When available, the location ID is included in the encompassingEncounter/location/healthCareFacility/id element.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>componentOf</b><b> (CONF:1198-7595)</b>.<ul><li>This componentOf <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b> (CONF:1198-7596)</b>.</li><ul><li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7597)</b>.</li></ul><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-7598)</b>.</li><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-7599)</b>.</li></ul></ul><ul><li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>location</b><b> (CONF:1198-30879)</b>.</li><ul><li>This location <b>SHALL</b> contain exactly one [1..1] <b>healthCareFacility</b><b> (CONF:1198-30880)</b>.</li><ul><li>This healthCareFacility <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30881)</b>.</li></ul></ul></ul></ul></li>
-<li class="list-group-item"><p>In this template (templateId 2.16.840.1.113883.10.20.22.1.9.2), coded entries are optional</p> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:1198-9591)</b>.<ul><li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30617)</b>.</li><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30618)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-30619)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30620)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Plan of Treatment Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30621)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30622)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment and Plan Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-30623)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30624)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergies and Intolerances Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.6)</b><b> (CONF:1198-30625)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30626)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Chief Complaint Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-30627)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30628)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Interventions Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.21.2.3)</b><b> (CONF:1198-30629)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30639)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Instructions Section (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.45)</b><b> (CONF:1198-31386)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30641)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Medications Section (entries optional) (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.2.1)</b><b> (CONF:1198-30642)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30643)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Objective Section<b> (identifier: 2.16.840.1.113883.10.20.21.2.1)</b><b> (CONF:1198-30644)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30645)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Physical Exam Section (V3)<b> (identifier: 2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-30646)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30647)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.5)</b><b> (CONF:1198-30648)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30649)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Results Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.3)</b><b> (CONF:1198-30650)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30651)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Review of Systems Section<b> (identifier: 1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30652)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30653)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Subjective Section<b> (identifier: 2.16.840.1.113883.10.20.21.2.2)</b><b> (CONF:1198-30654)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30655)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Signs Section (entries optional) (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.2.4)</b><b> (CONF:1198-30656)</b>.</li></ul></ul><ul><li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32626)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Section<b> (identifier: 2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-32627)</b>.</li></ul></ul><ul><li><p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-30657).</p></li></ul><ul><li><p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2) (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-30658).</p></li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7588)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.1.9"</b><b>
+              (CONF:1198-10052)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32521)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32942).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The Progress Note recommends use of a single document type code, 11506-3 "Subsequent evaluation note", with
+          further specification provided by author or performer, setting, or specialty. When pre-coordinated codes are
+          used, any coded values describing the author or performer of the service act or the practice setting must be
+          consistent with the LOINC document type. <br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b>
+          (CONF:1198-17189)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ProgressNoteDocumentTypeCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.8.1/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.8.1</a></b><b> DYNAMIC</b><b>
+              (CONF:1198-17190)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: documentationOf<br>A documentationOf can contain a serviceEvent to further specialize the act
+          inherent in the ClinicalDocument/code. In a Progress Note, a serviceEvent can represent the event of writing
+          the Progress Note. The serviceEvent/effectiveTime is the time period the note documents.<br></p> <b>SHOULD</b>
+        contain zero or one [0..1] <b>documentationOf</b><b> (CONF:1198-7603)</b>.<ul>
+          <li>The documentationOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b>
+              (CONF:1198-7604)</b>.</li>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Care Provision
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+                STATIC</b>)<b> (CONF:1198-26420)</b>.</li>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-9480)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.21.3.1"</b><b>
+                  (CONF:1198-10068)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHOULD</b> contain zero or one [0..1] US Realm Date and Time (DT.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-9481)</b>.</li>
+            <ul>
+              <li>
+                <p>The serviceEvent/effectiveTime element <strong>SHOULD</strong> be present with effectiveTime/low
+                  element (CONF:1198-9482).</p>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <p>If a width element is not present, the serviceEvent <strong>SHALL</strong> include effectiveTime/high
+                  (CONF:1198-10066).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Heading: componentOf<br>The Progress Note is always associated with an encounter by the
+          componentOf/encompassingEncounter element in the header. The effectiveTime element for an
+          encompassingEncounter represents the time or time interval in which the encounter took place. A single
+          encounter may contain multiple Progress Notes; hence the effectiveTime elements for a Progress Note (recorded
+          in serviceEvent) and for an encounter (recorded in encompassingEncounter) represent different time intervals.
+          For outpatient encounters that are a point in time, set effectiveTime/high, effectiveTime/low, and
+          effectiveTime/@value to the same time. All visits take place at a specific location. When available, the
+          location ID is included in the encompassingEncounter/location/healthCareFacility/id element.<br></p>
+        <b>SHALL</b> contain exactly one [1..1] <b>componentOf</b><b> (CONF:1198-7595)</b>.<ul>
+          <li>This componentOf <b>SHALL</b> contain exactly one [1..1] <b>encompassingEncounter</b><b>
+              (CONF:1198-7596)</b>.</li>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7597)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] US Realm Date and Time
+              (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1198-7598)</b>.</li>
+            <ul>
+              <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-7599)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This encompassingEncounter <b>SHALL</b> contain exactly one [1..1] <b>location</b><b>
+                (CONF:1198-30879)</b>.</li>
+            <ul>
+              <li>This location <b>SHALL</b> contain exactly one [1..1] <b>healthCareFacility</b><b>
+                  (CONF:1198-30880)</b>.</li>
+              <ul>
+                <li>This healthCareFacility <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30881)</b>.
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>In this template (templateId 2.16.840.1.113883.10.20.22.1.9.2), coded entries are optional</p> <b>SHALL</b>
+        contain exactly one [1..1] <b>component</b><b> (CONF:1198-9591)</b>.<ul>
+          <li>This component <b>SHALL</b> contain exactly one [1..1] <b>structuredBody</b><b> (CONF:1198-30617)</b>.
+          </li>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30618)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.8)</b><b> (CONF:1198-30619)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30620)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Plan of Treatment Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.10)</b><b> (CONF:1198-30621)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30622)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Assessment and Plan Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.9)</b><b> (CONF:1198-30623)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30624)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Allergies and Intolerances Section (entries optional) (V3)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.2.6)</b><b> (CONF:1198-30625)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30626)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Chief Complaint Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1)</b><b> (CONF:1198-30627)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30628)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Interventions Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.21.2.3)</b><b> (CONF:1198-30629)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30639)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Instructions Section (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.45)</b><b> (CONF:1198-31386)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30641)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Medications Section (entries optional) (V2)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.1)</b><b> (CONF:1198-30642)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30643)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Objective Section<b> (identifier:
+                  2.16.840.1.113883.10.20.21.2.1)</b><b> (CONF:1198-30644)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30645)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Physical Exam Section (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.2.10)</b><b> (CONF:1198-30646)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30647)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Problem Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.5)</b><b> (CONF:1198-30648)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30649)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Results Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.3)</b><b> (CONF:1198-30650)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30651)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Review of Systems Section<b> (identifier:
+                  1.3.6.1.4.1.19376.1.5.3.1.3.18)</b><b> (CONF:1198-30652)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30653)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Subjective Section<b> (identifier:
+                  2.16.840.1.113883.10.20.21.2.2)</b><b> (CONF:1198-30654)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-30655)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Vital Signs Section (entries optional) (V3)<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.4)</b><b> (CONF:1198-30656)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This structuredBody <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:1198-32626)</b> such
+              that it</li>
+            <ul>
+              <li><b>SHALL</b> contain exactly one [1..1] Nutrition Section<b> (identifier:
+                  2.16.840.1.113883.10.20.22.2.57)</b><b> (CONF:1198-32627)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9), or an Assessment Section (2.16.840.1.113883.10.20.22.2.8) and a Plan
+                of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) (CONF:1198-30657).</p>
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p>This structuredBody <strong>SHALL NOT</strong> contain an Assessment and Plan Section (V2)
+                (2.16.840.1.113883.10.20.22.2.9) when either an Assessment Section (2.16.840.1.113883.10.20.22.2.8) or a
+                Plan of Treatment Section (V2) (2.16.840.1.113883.10.20.22.2.10) is present (CONF:1198-30658).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Progress%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.9/Progress%20Note%20encompassingEncounter%20Example.xml"><i class="fab fa-github"></i>&nbsp;Progress Note encompassingEncounter Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Progress%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.9/Progress%20Note%20serviceEvent%20Example.xml"><i class="fab fa-github"></i>&nbsp;Progress Note serviceEvent Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Progress%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.9/Progress%20Note%20encompassingEncounter%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Progress Note encompassingEncounter Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Progress%20Note%20(V3)_2.16.840.1.113883.10.20.22.1.9/Progress%20Note%20serviceEvent%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Progress Note serviceEvent Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.1.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.1.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,114 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medications Section (entries required) (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.1.1, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.1.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medications Section (entries required) (V2) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.1.1, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.1.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Medications Section contains a patient's current medications and pertinent medication history. At a minimum, the currently active medications are listed. An entire medication history is an option. The section can describe a patient's prescription and dispense history and information about intended drug monitoring.</p><p>This section requires either an entry indicating the subject is not known to be on any medications or entries summarizing the subject's medications.</p></div>
+    <div id="description">
+      <p>The Medications Section contains a patient's current medications and pertinent medication history. At a
+        minimum, the currently active medications are listed. An entire medication history is an option. The section can
+        describe a patient's prescription and dispense history and information about intended drug monitoring.</p>
+      <p>This section requires either an entry indicating the subject is not known to be on any medications or entries
+        summarizing the subject's medications.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Medications Section (entries optional) (V2) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.1:2014-06-09)</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1098-32845)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7568)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.1.1"</b><b> (CONF:1098-10433)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32499)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15387)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10160-0"</b> History of medication use<b> (CONF:1098-15388)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30825)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7570)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7571)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1098-7572)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-10077)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Medications Section (entries optional) (V2) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.1:2014-06-09)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1098-32845)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7568)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.1.1"</b><b>
+              (CONF:1098-10433)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32499)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15387)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10160-0"</b> History of medication
+            use<b> (CONF:1098-15388)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30825)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7570)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7571)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1098-7572)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-10077)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medications%20Section%20(entries%20required)%20(V2)_2.16.840.1.113883.10.20.22.2.1.1/Medications%20Section%20(entries%20required)%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Medications Section (entries required) (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medications%20Section%20(entries%20required)%20(V2)_2.16.840.1.113883.10.20.22.2.1.1/Medications%20Section%20(entries%20required)%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Medications Section (entries required) (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i> Medications</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i>
+          Medications</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,100 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medications Section (entries optional) (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.1, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medications Section (entries optional) (V2) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.1, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Medications Section contains a patient's current medications and pertinent medication history. At a minimum, the currently active medications are listed. An entire medication history is an option. The section can describe a patient's prescription and dispense history and information about intended drug monitoring.</p></div>
+    <div id="description">
+      <p>The Medications Section contains a patient's current medications and pertinent medication history. At a
+        minimum, the currently active medications are listed. An entire medication history is an option. The section can
+        describe a patient's prescription and dispense history and information about intended drug monitoring.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7791)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.1"</b><b> (CONF:1098-10432)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32500)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15385)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10160-0"</b> History of medication use<b> (CONF:1098-15386)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30824)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7793)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7794)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-7795)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-10076)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7791)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.1"</b><b>
+              (CONF:1098-10432)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32500)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15385)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10160-0"</b> History of medication
+            use<b> (CONF:1098-15386)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30824)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7793)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7794)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-7795)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-10076)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i> Medications</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i>
+          Medications</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.10.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.10.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,61 +52,197 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Plan of Treatment Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.10, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.10.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Plan of Treatment Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.10,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.10.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section, formerly known as "Plan of Care", contains data that define pending orders, interventions, encounters, services, and procedures for the patient. It is limited to prospective, unfulfilled, or incomplete orders and requests only. These are indicated by the @moodCode of the entries within this section. All active, incomplete, or pending orders, appointments, referrals, procedures, services, or any other pending event of clinical significance to the current care of the patient should be listed.Clinical reminders are placed here to provide prompts for disease prevention and management, patient safety, and healthcare quality improvements, including widely accepted performance measures.The plan may also indicate that patient education will be provided.When used in a document that includes a Goals Section, all the goals (whether narrative only, or structured Goal Observation entries) should be recorded in the Goals Section, rather than in the Plan of Treatment Section, to avoid confusion as to 'which/whose goals should be in which section?'When used in a document that does not include a Goals Section, the Plan of Treatment section may also contain information about care team members' goals, including the patient's values, beliefs, preferences, care expectations, and overarching care goals. Values may include the importance of quality of life over longevity. These values are taken into account when prioritizing all problems and their treatments. Beliefs may include comfort with dying or the refusal of blood transfusions because of the patient's religious convictions. Preferences may include liquid medicines over tablets, or treatment via secure email instead of in person. Care expectations may range from being treated only by female clinicians, to expecting all calls to be returned within 24 hours. Overarching goals described in this section are not tied to a specific condition, problem, health concern, or intervention. Examples of overarching goals could be to minimize pain or dependence on others, or to walk a daughter down the aisle for her marriage.</p></div>
+    <div id="description">
+      <p>This section, formerly known as "Plan of Care", contains data that define pending orders, interventions,
+        encounters, services, and procedures for the patient. It is limited to prospective, unfulfilled, or incomplete
+        orders and requests only. These are indicated by the @moodCode of the entries within this section. All active,
+        incomplete, or pending orders, appointments, referrals, procedures, services, or any other pending event of
+        clinical significance to the current care of the patient should be listed.Clinical reminders are placed here to
+        provide prompts for disease prevention and management, patient safety, and healthcare quality improvements,
+        including widely accepted performance measures.The plan may also indicate that patient education will be
+        provided.When used in a document that includes a Goals Section, all the goals (whether narrative only, or
+        structured Goal Observation entries) should be recorded in the Goals Section, rather than in the Plan of
+        Treatment Section, to avoid confusion as to 'which/whose goals should be in which section?'When used in a
+        document that does not include a Goals Section, the Plan of Treatment section may also contain information about
+        care team members' goals, including the patient's values, beliefs, preferences, care expectations, and
+        overarching care goals. Values may include the importance of quality of life over longevity. These values are
+        taken into account when prioritizing all problems and their treatments. Beliefs may include comfort with dying
+        or the refusal of blood transfusions because of the patient's religious convictions. Preferences may include
+        liquid medicines over tablets, or treatment via secure email instead of in person. Care expectations may range
+        from being treated only by female clinicians, to expecting all calls to be returned within 24 hours. Overarching
+        goals described in this section are not tied to a specific condition, problem, health concern, or intervention.
+        Examples of overarching goals could be to minimize pain or dependence on others, or to walk a daughter down the
+        aisle for her marriage.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7723)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.10"</b><b> (CONF:1098-10435)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32501)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14749)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"18776-5"</b> Plan of Treatment<b> (CONF:1098-14750)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30813)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-16986)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7725)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-7726)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.44)</b><b> (CONF:1098-14751)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8805)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Encounter (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.40)</b><b> (CONF:1098-30472)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8807)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.39)</b><b> (CONF:1098-30473)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8809)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.41)</b><b> (CONF:1098-30474)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8811)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.42)</b><b> (CONF:1098-30475)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8813)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Supply (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.43)</b><b> (CONF:1098-30476)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14695)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31397)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-29621)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Handoff Communication Participants<b> (identifier: 2.16.840.1.113883.10.20.22.4.141)</b><b> (CONF:1098-30868)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-31841)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Recommendation<b> (identifier: 2.16.840.1.113883.10.20.22.4.130)</b><b> (CONF:1098-31864)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-32353)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Immunization Activity<b> (identifier: 2.16.840.1.113883.10.20.22.4.120)</b><b> (CONF:1098-32354)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-32887)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Goal Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.121)</b><b> (CONF:1098-32888)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7723)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.10"</b><b>
+              (CONF:1098-10435)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32501)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14749)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"18776-5"</b> Plan of Treatment<b>
+              (CONF:1098-14750)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30813)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-16986)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7725)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-7726)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.44)</b><b> (CONF:1098-14751)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8805)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Encounter (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.40)</b><b> (CONF:1098-30472)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8807)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.39)</b><b> (CONF:1098-30473)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8809)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.41)</b><b> (CONF:1098-30474)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8811)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.42)</b><b> (CONF:1098-30475)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8813)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Supply (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.43)</b><b> (CONF:1098-30476)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14695)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31397)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-29621)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Handoff Communication Participants<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.141)</b><b> (CONF:1098-30868)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-31841)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Nutrition Recommendation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.130)</b><b> (CONF:1098-31864)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-32353)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Immunization Activity<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.120)</b><b> (CONF:1098-32354)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-32887)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Goal Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.121)</b><b> (CONF:1098-32888)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Plan%20of%20Treatment%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.10/Plan%20of%20Treatment%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Plan of Treatment Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Plan%20of%20Treatment%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.10/Plan%20of%20Treatment%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Plan of Treatment Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.11.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.11.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,120 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Discharge Medications Section (entries required) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.11.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.11.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Discharge Medications Section (entries required) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.11.1, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.11.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains the medications the patient is intended to take or stop after discharge. Current, active medications must be listed. The section may also include a patient's prescription history and indicate the source of the medication list.</p></div>
+    <div id="description">
+      <p>This section contains the medications the patient is intended to take or stop after discharge. Current, active
+        medications must be listed. The section may also include a patient's prescription history and indicate the
+        source of the medication list.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.35.html">Discharge Medication (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.35.html">Discharge Medication (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Discharge Medications Section (entries optional) (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.11:2015-08-01)</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32812)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7822)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.11.1"</b><b> (CONF:1198-10397)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32562)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15361)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10183-2"</b> Hospital Discharge Medications<b> (CONF:1198-15362)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32145)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32857)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75311-1"</b> Discharge Medications<b> (CONF:1198-32858)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32859)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7824)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7825)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1198-7826)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Discharge Medication (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.35)</b><b> (CONF:1198-15491)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Discharge Medications Section (entries optional) (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.11:2015-08-01)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1198-32812)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7822)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.11.1"</b><b>
+              (CONF:1198-10397)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32562)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15361)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10183-2"</b> Hospital Discharge
+            Medications<b> (CONF:1198-15362)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32145)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32857)</b> such that it
+          </li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75311-1"</b> Discharge Medications<b>
+                (CONF:1198-32858)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem:
+              <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32859)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7824)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7825)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1198-7826)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Discharge Medication (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.35)</b><b> (CONF:1198-15491)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Discharge%20Medications%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.11.1/Discharge%20Medication%20Section%20(V3)%20(entries%20required)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Discharge Medication Section (V3) (entries required) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Discharge%20Medications%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.11.1/Discharge%20Medication%20Section%20(V3)%20(entries%20required)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Discharge Medication Section (V3) (entries required) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.11.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.11.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,109 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Discharge Medications Section (entries optional) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.11, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.11.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Discharge Medications Section (entries optional) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.11, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.11.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains the medications the patient is intended to take or stop after discharge. Current, active medications must be listed. The section may also include a patient's prescription history and indicate the source of the medication list.</p></div>
+    <div id="description">
+      <p>This section contains the medications the patient is intended to take or stop after discharge. Current, active
+        medications must be listed. The section may also include a patient's prescription history and indicate the
+        source of the medication list.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.35.html">Discharge Medication (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.35.html">Discharge Medication (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7816)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.11"</b><b> (CONF:1198-10396)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32561)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15359)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10183-2"</b> Hospital Discharge medications (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-15360)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32480)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32854)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75311-1"</b> Discharge medications<b> (CONF:1198-32855)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32856)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7818)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7819)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7820)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Discharge Medication (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.35)</b><b> (CONF:1198-15490)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7816)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.11"</b><b>
+              (CONF:1198-10396)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32561)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15359)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10183-2"</b> Hospital Discharge
+            medications (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-15360)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32480)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32854)</b> such that it
+          </li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75311-1"</b> Discharge medications<b>
+                (CONF:1198-32855)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem:
+              <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32856)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7818)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7819)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7820)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Discharge Medication (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.35)</b><b> (CONF:1198-15490)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.12.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.12.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,92 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Reason for Visit Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.12, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.12.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Reason for Visit Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.12, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.22.2.12.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section records the patient's reason for the patient's visit (as documented by the provider). Local policy determines whether Reason for Visit and Chief Complaint are in separate or combined sections.</p></div>
+    <div id="description">
+      <p>This section records the patient's reason for the patient's visit (as documented by the provider). Local policy
+        determines whether Reason for Visit and Chief Complaint are in separate or combined sections.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7836)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.12"</b><b> (CONF:81-10448)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15429)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29299-5"</b> Reason for Visit<b> (CONF:81-15430)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26494)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7838)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7839)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7836)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.12"</b><b>
+              (CONF:81-10448)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15429)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29299-5"</b> Reason for Visit<b>
+              (CONF:81-15430)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26494)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7838)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7839)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Reason%20for%20Visit%20Section_2.16.840.1.113883.10.20.22.2.12/Reason%20for%20Visit%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Reason for Visit Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Reason%20for%20Visit%20Section_2.16.840.1.113883.10.20.22.2.12/Reason%20for%20Visit%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Reason for Visit Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.13.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.13.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,94 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Chief Complaint and Reason for Visit Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.13, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.13.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Chief Complaint and Reason for Visit Section <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.13, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.13.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section records the patient's chief complaint (the patient's own description) and/or the reason for the patient's visit (the provider's description of the reason for visit). Local policy determines whether the information is divided into two sections or recorded in one section serving both purposes.</p></div>
+    <div id="description">
+      <p>This section records the patient's chief complaint (the patient's own description) and/or the reason for the
+        patient's visit (the provider's description of the reason for visit). Local policy determines whether the
+        information is divided into two sections or recorded in one section serving both purposes.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7840)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.13"</b><b> (CONF:81-10383)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15449)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46239-0"</b> Chief Complaint and Reason for Visit<b> (CONF:81-15450)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26473)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7842)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7843)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7840)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.13"</b><b>
+              (CONF:81-10383)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15449)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46239-0"</b> Chief Complaint and Reason
+            for Visit<b> (CONF:81-15450)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26473)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7842)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7843)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Chief%20Complaint%20and%20Reason%20for%20Visit%20Section_2.16.840.1.113883.10.20.22.2.13/Chief%20Complaint%20and%20Reason%20for%20Visit%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Chief Complaint and Reason for Visit Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Chief%20Complaint%20and%20Reason%20for%20Visit%20Section_2.16.840.1.113883.10.20.22.2.13/Chief%20Complaint%20and%20Reason%20for%20Visit%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Chief Complaint and Reason for Visit Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.14.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.14.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,60 +52,171 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Functional Status Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.14, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.14.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Functional Status Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.14,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.14.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Functional Status Section contains observations and assessments of a patient's physical abilities. A patient's functional status may include information regarding the patient's ability to perform Activities of Daily Living (ADLs) in areas such as Mobility (e.g., ambulation), Self-Care (e.g., bathing, dressing, feeding, grooming) or Instrumental Activities of Daily Living (IADLs) (e.g., shopping, using a telephone, balancing a check book). Problems that impact function (e.g., dyspnea, dysphagia) can be contained in the section.</p></div>
+    <div id="description">
+      <p>The Functional Status Section contains observations and assessments of a patient's physical abilities. A
+        patient's functional status may include information regarding the patient's ability to perform Activities of
+        Daily Living (ADLs) in areas such as Mobility (e.g., ambulation), Self-Care (e.g., bathing, dressing, feeding,
+        grooming) or Instrumental Activities of Daily Living (IADLs) (e.g., shopping, using a telephone, balancing a
+        check book). Problems that impact function (e.g., dyspnea, dysphagia) can be contained in the section.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.66.html">Functional Status Organizer (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a href="2.16.840.1.113883.10.20.22.4.127.html">Sensory Status</a><br><a href="2.16.840.1.113883.10.20.22.4.73.html">Cognitive Status Problem Observation (DEPRECATED)</a><br><a href="2.16.840.1.113883.10.20.22.4.68.html">Functional Status Problem Observation (DEPRECATED)</a><br><a href="2.16.840.1.113883.10.20.22.4.70.html">Pressure Ulcer Observation (DEPRECATED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.66.html">Functional Status Organizer (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.127.html">Sensory Status</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.73.html">Cognitive Status Problem Observation (DEPRECATED)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.68.html">Functional Status Problem Observation (DEPRECATED)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.70.html">Pressure Ulcer Observation (DEPRECATED)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7920)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.14"</b><b> (CONF:1098-10389)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32567)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14578)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"47420-5"</b> Functional Status<b> (CONF:1098-14579)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30866)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7922)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7923)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14414)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Organizer (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.66)</b><b> (CONF:1098-14415)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14418)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.67)</b><b> (CONF:1098-14419)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14426)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Caregiver Characteristics<b> (identifier: 2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:1098-14427)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14580)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1098-14581)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14582)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Non-Medicinal Supply Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1098-30783)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-32792)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Self-Care Activities (ADL and IADL)<b> (identifier: 2.16.840.1.113883.10.20.22.4.128)</b><b> (CONF:1098-31009)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-16779)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Sensory Status<b> (identifier: 2.16.840.1.113883.10.20.22.4.127)</b><b> (CONF:1098-31011)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14424)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Cognitive Status Problem Observation (DEPRECATED)<b> (identifier: 2.16.840.1.113883.10.20.22.4.73)</b><b> (CONF:1098-14425)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14422)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Problem Observation (DEPRECATED)<b> (identifier: 2.16.840.1.113883.10.20.22.4.68)</b><b> (CONF:1098-14423)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-16777)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Pressure Ulcer Observation (DEPRECATED)<b> (identifier: 2.16.840.1.113883.10.20.22.4.70)</b><b> (CONF:1098-16778)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7920)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.14"</b><b>
+              (CONF:1098-10389)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32567)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14578)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"47420-5"</b> Functional Status<b>
+              (CONF:1098-14579)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30866)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7922)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7923)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14414)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Functional Status Organizer (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.66)</b><b> (CONF:1098-14415)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14418)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Functional Status Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.67)</b><b> (CONF:1098-14419)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14426)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Caregiver Characteristics<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:1098-14427)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14580)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1098-14581)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14582)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Non-Medicinal Supply Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1098-30783)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-32792)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Self-Care Activities (ADL and IADL)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.128)</b><b> (CONF:1098-31009)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-16779)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Sensory Status<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.127)</b><b> (CONF:1098-31011)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14424)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Cognitive Status Problem Observation (DEPRECATED)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.73)</b><b> (CONF:1098-14425)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-14422)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Functional Status Problem Observation (DEPRECATED)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.68)</b><b> (CONF:1098-14423)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-16777)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Pressure Ulcer Observation (DEPRECATED)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.70)</b><b> (CONF:1098-16778)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Functional%20Status%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.14/Functional%20Status%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Functional Status Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Functional%20Status%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.14/Functional%20Status%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Functional Status Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Functional%20Status"><i class="fas fa-external-link-alt"></i> Functional Status</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Functional%20Status"><i class="fas fa-external-link-alt"></i>
+          Functional Status</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.15.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.15.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,107 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Family History Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.15, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.15.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Family History Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.15,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.15.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains data defining the patient's genetic relatives in terms of possible or relevant health risk factors that have a potential impact on the patient's healthcare risk profile.</p></div>
+    <div id="description">
+      <p>This section contains data defining the patient's genetic relatives in terms of possible or relevant health
+        risk factors that have a potential impact on the patient's healthcare risk profile.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.45.html">Family History Organizer (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.45.html">Family History Organizer (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7932)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.15"</b><b> (CONF:1198-10388)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32607)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15469)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10157-6"</b> Family History<b> (CONF:1198-15470)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32481)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7934)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7935)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32430)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.45)</b><b> (CONF:1198-32431)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7932)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.15"</b><b>
+              (CONF:1198-10388)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32607)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15469)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10157-6"</b> Family History<b>
+              (CONF:1198-15470)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32481)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7934)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7935)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32430)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Family History Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.45)</b><b> (CONF:1198-32431)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Family%20History%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.15/Family%20History%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Family History Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Family%20History%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.15/Family%20History%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Family History Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Family%20History"><i class="fas fa-external-link-alt"></i> Family History</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Family%20History"><i class="fas fa-external-link-alt"></i> Family
+          History</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.16.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.16.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,104 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Hospital Discharge Studies Summary Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.16, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.16.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Hospital Discharge Studies Summary Section <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.16, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.16.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section records the results of observations generated by laboratories, imaging procedures, and other procedures. The scope includes hematology, chemistry, serology, virology, toxicology, microbiology, plain x-ray, ultrasound, CT, MRI, angiography, echocardiography, nuclear medicine, pathology, and procedure observations. This section often includes notable results such as abnormal values or relevant trends, and could record all results for the period of time being documented.</p><p>Laboratory results are typically generated by laboratories providing analytic services in areas such as chemistry, hematology, serology, histology, cytology, anatomic pathology, microbiology, and/or virology. These observations are based on analysis of specimens obtained from the patient and submitted to the laboratory.Imaging results are typically generated by a clinician reviewing the output of an imaging procedure, such as when a cardiologist reports the left ventricular ejection fraction based on the review of an echocardiogram.</p><p>Procedure results are typically generated by a clinician wanting to provide more granular information about component observations made during the performance of a procedure, such as when a gastroenterologist reports the size of a polyp observed during a colonoscopy.</p><p>Note that there are discrepancies between CCD and the lab domain model, such as the effectiveTime in specimen collection.</p></div>
+    <div id="description">
+      <p>This section records the results of observations generated by laboratories, imaging procedures, and other
+        procedures. The scope includes hematology, chemistry, serology, virology, toxicology, microbiology, plain x-ray,
+        ultrasound, CT, MRI, angiography, echocardiography, nuclear medicine, pathology, and procedure observations.
+        This section often includes notable results such as abnormal values or relevant trends, and could record all
+        results for the period of time being documented.</p>
+      <p>Laboratory results are typically generated by laboratories providing analytic services in areas such as
+        chemistry, hematology, serology, histology, cytology, anatomic pathology, microbiology, and/or virology. These
+        observations are based on analysis of specimens obtained from the patient and submitted to the
+        laboratory.Imaging results are typically generated by a clinician reviewing the output of an imaging procedure,
+        such as when a cardiologist reports the left ventricular ejection fraction based on the review of an
+        echocardiogram.</p>
+      <p>Procedure results are typically generated by a clinician wanting to provide more granular information about
+        component observations made during the performance of a procedure, such as when a gastroenterologist reports the
+        size of a polyp observed during a colonoscopy.</p>
+      <p>Note that there are discrepancies between CCD and the lab domain model, such as the effectiveTime in specimen
+        collection.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7910)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.16"</b><b> (CONF:81-10398)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15365)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11493-4"</b> Hospital Discharge Studies Summary<b> (CONF:81-15366)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26483)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7912)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7913)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7910)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.16"</b><b>
+              (CONF:81-10398)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15365)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11493-4"</b> Hospital Discharge Studies
+            Summary<b> (CONF:81-15366)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26483)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-7912)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7913)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Discharge%20Studies%20Summary%20Section_2.16.840.1.113883.10.20.22.2.16/Hospital%20Discharge%20Studies%20Summary%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Hospital Discharge Studies Summary Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Discharge%20Studies%20Summary%20Section_2.16.840.1.113883.10.20.22.2.16/Hospital%20Discharge%20Studies%20Summary%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Hospital Discharge Studies Summary Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.17.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.17.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,150 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Social History Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.17, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.17.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Social History Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.17,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.17.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains social history data that influence a patient's physical, psychological or emotional health (e.g., smoking status, pregnancy). Demographic data, such as marital status, race, ethnicity, and religious affiliation, is captured in the header.</p></div>
+    <div id="description">
+      <p>This section contains social history data that influence a patient's physical, psychological or emotional
+        health (e.g., smoking status, pregnancy). Demographic data, such as marital status, race, ethnicity, and
+        religious affiliation, is captured in the header.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.38.html">Social History Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.15.3.8.html">Pregnancy Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.78.html">Smoking Status - Meaningful Use (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.85.html">Tobacco Use (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a href="2.16.840.1.113883.10.20.22.4.111.html">Cultural and Religious Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.109.html">Characteristics of Home Environment</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.38.html">Social History Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.15.3.8.html">Pregnancy Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.78.html">Smoking Status - Meaningful Use (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.85.html">Tobacco Use (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.111.html">Cultural and Religious Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.109.html">Characteristics of Home Environment</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7936)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.17"</b><b> (CONF:1198-10449)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32494)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14819)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29762-2"</b> Social History<b> (CONF:1198-14820)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30814)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7938)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7939)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7953)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.38)</b><b> (CONF:1198-14821)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-9132)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Pregnancy Observation<b> (identifier: 2.16.840.1.113883.10.20.15.3.8)</b><b> (CONF:1198-14822)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-14823)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Smoking Status - Meaningful Use (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.78)</b><b> (CONF:1198-14824)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-16816)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Tobacco Use (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.85)</b><b> (CONF:1198-16817)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28361)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Caregiver Characteristics<b> (identifier: 2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:1198-28362)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28366)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Cultural and Religious Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.111)</b><b> (CONF:1198-28367)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28825)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Characteristics of Home Environment<b> (identifier: 2.16.840.1.113883.10.20.22.4.109)</b><b> (CONF:1198-28826)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7936)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.17"</b><b>
+              (CONF:1198-10449)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32494)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14819)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29762-2"</b> Social History<b>
+              (CONF:1198-14820)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30814)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7938)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7939)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7953)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Social History Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.38)</b><b> (CONF:1198-14821)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-9132)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Pregnancy Observation<b> (identifier:
+              2.16.840.1.113883.10.20.15.3.8)</b><b> (CONF:1198-14822)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-14823)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Smoking Status - Meaningful Use (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.78)</b><b> (CONF:1198-14824)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-16816)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Tobacco Use (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.85)</b><b> (CONF:1198-16817)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28361)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Caregiver Characteristics<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:1198-28362)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28366)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Cultural and Religious Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.111)</b><b> (CONF:1198-28367)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28825)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Characteristics of Home Environment<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.109)</b><b> (CONF:1198-28826)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Social%20History%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.17/Social%20History%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Social History Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Social%20History%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.17/Social%20History%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Social History Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social History</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social
+          History</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.18.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.18.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,110 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Payers Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.18, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.18.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Payers Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.18, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.18.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Payers Section contains data on the patient's payers, whether "third party" insurance, self-pay, other payer or guarantor, or some combination of payers, and is used to define which entity is the responsible fiduciary for the financial aspects of a patient's care.Each unique instance of a payer and all the pertinent data needed to contact, bill to, and collect from that payer should be included. Authorization information that can be used to define pertinent referral, authorization tracking number, procedure, therapy, intervention, device, or similar authorizations for the patient or provider, or both should be included. At a minimum, the patient's pertinent current payment sources should be listed.The sources of payment are represented as a Coverage Activity, which identifies all of the insurance policies or government or other programs that cover some or all of the patient's healthcare expenses. The policies or programs are sequenced by preference. The Coverage Activity has a sequence number that represents the preference order. Each policy or program identifies the covered party with respect to the payer, so that the identifiers can be recorded.</p></div>
+    <div id="description">
+      <p>The Payers Section contains data on the patient's payers, whether "third party" insurance, self-pay, other
+        payer or guarantor, or some combination of payers, and is used to define which entity is the responsible
+        fiduciary for the financial aspects of a patient's care.Each unique instance of a payer and all the pertinent
+        data needed to contact, bill to, and collect from that payer should be included. Authorization information that
+        can be used to define pertinent referral, authorization tracking number, procedure, therapy, intervention,
+        device, or similar authorizations for the patient or provider, or both should be included. At a minimum, the
+        patient's pertinent current payment sources should be listed.The sources of payment are represented as a
+        Coverage Activity, which identifies all of the insurance policies or government or other programs that cover
+        some or all of the patient's healthcare expenses. The policies or programs are sequenced by preference. The
+        Coverage Activity has a sequence number that represents the preference order. Each policy or program identifies
+        the covered party with respect to the payer, so that the identifiers can be recorded.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.60.html">Coverage Activity (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.60.html">Coverage Activity (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7924)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.18"</b><b> (CONF:1198-10434)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32597)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15395)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48768-6"</b> Payers<b> (CONF:1198-15396)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32149)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7926)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7927)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7959)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Coverage Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.60)</b><b> (CONF:1198-15501)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7924)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.18"</b><b>
+              (CONF:1198-10434)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32597)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15395)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48768-6"</b> Payers<b>
+              (CONF:1198-15396)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32149)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7926)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7927)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7959)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Coverage Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.60)</b><b> (CONF:1198-15501)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Payers%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.18/Payers%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Payers Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Payers%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.18/Payers%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Payers Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.2.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.2.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,111 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Immunizations Section (entries required) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.2.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.2.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Immunizations Section (entries required) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.2.1, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.2.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Immunizations Section defines a patient's current immunization status and pertinent immunization history. The primary use case for the Immunization Section is to enable communication of a patient's immunization status. The section should include current immunization status, and may contain the entire immunization history that is relevant to the period of time being summarized.</p></div>
+    <div id="description">
+      <p>The Immunizations Section defines a patient's current immunization status and pertinent immunization history.
+        The primary use case for the Immunization Section is to enable communication of a patient's immunization status.
+        The section should include current immunization status, and may contain the entire immunization history that is
+        relevant to the period of time being summarized.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Immunizations Section (entries optional) (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.2:2015-08-01)</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32833)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-9015)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.2.1"</b><b> (CONF:1198-10400)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32530)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15369)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11369-6"</b> Immunizations<b> (CONF:1198-15370)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32147)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9017)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-9018)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1198-9019)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Immunization Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.52)</b><b> (CONF:1198-15495)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Immunizations Section (entries optional) (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.2:2015-08-01)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1198-32833)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-9015)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.2.1"</b><b>
+              (CONF:1198-10400)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32530)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15369)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11369-6"</b> Immunizations<b>
+              (CONF:1198-15370)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32147)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9017)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-9018)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1198-9019)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Immunization Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.52)</b><b> (CONF:1198-15495)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Immunizations%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.2.1/Immunizations%20Section%20(entries%20required)%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Immunizations Section (entries required) (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Immunizations%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.2.1/Immunizations%20Section%20(entries%20required)%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Immunizations Section (entries required) (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i> Immunizations</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i>
+          Immunizations</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.2.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.2.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,102 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Immunizations Section (entries optional) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.2, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Immunizations Section (entries optional) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.2, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Immunizations Section defines a patient's current immunization status and pertinent immunization history. The primary use case for the Immunization Section is to enable communication of a patient's immunization status. The section should include current immunization status, and may contain the entire immunization history that is relevant to the period of time being summarized.</p></div>
+    <div id="description">
+      <p>The Immunizations Section defines a patient's current immunization status and pertinent immunization history.
+        The primary use case for the Immunization Section is to enable communication of a patient's immunization status.
+        The section should include current immunization status, and may contain the entire immunization history that is
+        relevant to the period of time being summarized.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7965)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.2"</b><b> (CONF:1198-10399)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32529)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15367)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11369-6"</b> Immunizations<b> (CONF:1198-15368)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32146)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7967)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7968)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7969)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Immunization Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.52)</b><b> (CONF:1198-15494)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7965)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.2"</b><b>
+              (CONF:1198-10399)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32529)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15367)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11369-6"</b> Immunizations<b>
+              (CONF:1198-15368)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32146)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7967)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7968)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7969)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Immunization Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.52)</b><b> (CONF:1198-15494)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i> Immunizations</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i>
+          Immunizations</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.20.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.20.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,105 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Past Medical History (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.20, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.20.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Past Medical History (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.20,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.20.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains a record of the patient's past complaints, problems, and diagnoses. It contains data from the patient's past up to the patient's current complaint or reason for seeking medical care.</p></div>
+    <div id="description">
+      <p>This section contains a record of the patient's past complaints, problems, and diagnoses. It contains data from
+        the patient's past up to the patient's current complaint or reason for seeking medical care.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7828)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.20"</b><b> (CONF:1198-10390)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32536)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15474)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11348-0"</b> History of Past Illness<b> (CONF:1198-15475)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30831)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7830)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7831)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-8791)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15476)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7828)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.20"</b><b>
+              (CONF:1198-10390)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32536)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15474)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11348-0"</b> History of Past Illness<b>
+              (CONF:1198-15475)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30831)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7830)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7831)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-8791)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15476)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Past%20Medical%20History%20(V3)_2.16.840.1.113883.10.20.22.2.20/Past%20Medical%20History%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Past Medical History (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Past%20Medical%20History%20(V3)_2.16.840.1.113883.10.20.22.2.20/Past%20Medical%20History%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Past Medical History (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.21.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.21.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,122 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Advance Directives Section (entries required) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.21.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.21.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Advance Directives Section (entries required) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.21.1, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.21.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains data defining the patient's advance directives and any reference to supporting documentation, including living wills, healthcare proxies, and CPR and resuscitation status. If the referenced documents are available, they can be included in the exchange package.</p><p>The most recent directives are required, if known, and should be listed in as much detail as possible.</p><p>This section differentiates between "advance directives" and "advance directive documents". The former is the directions to be followed whereas the latter refers to a legal document containing those directions.</p></div>
+    <div id="description">
+      <p>This section contains data defining the patient's advance directives and any reference to supporting
+        documentation, including living wills, healthcare proxies, and CPR and resuscitation status. If the referenced
+        documents are available, they can be included in the exchange package.</p>
+      <p>The most recent directives are required, if known, and should be listed in as much detail as possible.</p>
+      <p>This section differentiates between "advance directives" and "advance directive documents". The former is the
+        directions to be followed whereas the latter refers to a legal document containing those directions.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.108.html">Advance Directive Organizer (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.108.html">Advance Directive Organizer (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Advance Directives Section (entries optional) (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.21:2015-08-01)</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32800)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-30227)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.21.1"</b><b> (CONF:1198-30228)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32512)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-32929)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42348-3"</b> Advance Directives<b> (CONF:1198-32930)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32931)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-32932)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-32933)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present <br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1198-30235)</b> such that it<ul><li><b>MAY</b> contain zero or one [0..1]  Advance Directive Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-30236)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1]  Advance Directive Organizer (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.108)</b><b> (CONF:1198-32420)</b>.</li></ul><ul><li><p>This entry <strong>SHALL</strong> contain <em>EITHER</em> an Advance Directive Observation (V2) <em>OR</em> an Advance Directive Organizer (CONF:1198-32881).</p></li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Advance Directives Section (entries optional) (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.21:2015-08-01)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1198-32800)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-30227)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.21.1"</b><b>
+              (CONF:1198-30228)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32512)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-32929)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42348-3"</b> Advance Directives<b>
+              (CONF:1198-32930)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32931)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-32932)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-32933)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present <br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1198-30235)</b> such that it<ul>
+          <li><b>MAY</b> contain zero or one [0..1] Advance Directive Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-30236)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] Advance Directive Organizer (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.108)</b><b> (CONF:1198-32420)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>This entry <strong>SHALL</strong> contain <em>EITHER</em> an Advance Directive Observation (V2)
+              <em>OR</em> an Advance Directive Organizer (CONF:1198-32881).</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Advance%20Directives%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.21.1/Advance%20Directives%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Advance Directives Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Advance%20Directives%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.21.1/Advance%20Directives%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Advance Directives Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.21.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.21.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,109 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Advance Directives Section (entries optional) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.21, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.21.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Advance Directives Section (entries optional) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.21, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.21.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains data defining the patient's advance directives and any reference to supporting documentation, including living wills, healthcare proxies, and CPR and resuscitation status. If the referenced documents are available, they can be included in the exchange package.</p><p>The most recent directives are required, if known, and should be listed in as much detail as possible.</p><p>This section differentiates between "advance directives" and "advance directive documents". The former is the directions to be followed whereas the latter refers to a legal document containing those directions.</p></div>
+    <div id="description">
+      <p>This section contains data defining the patient's advance directives and any reference to supporting
+        documentation, including living wills, healthcare proxies, and CPR and resuscitation status. If the referenced
+        documents are available, they can be included in the exchange package.</p>
+      <p>The most recent directives are required, if known, and should be listed in as much detail as possible.</p>
+      <p>This section differentiates between "advance directives" and "advance directive documents". The former is the
+        directions to be followed whereas the latter refers to a legal document containing those directions.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.108.html">Advance Directive Organizer (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.108.html">Advance Directive Organizer (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7928)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.21"</b><b> (CONF:1198-10376)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32497)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15340)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42348-3"</b> Advance Directives<b> (CONF:1198-15342)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30812)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7930)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7931)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7957)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Advance Directive Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-15443)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32891)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Advance Directive Organizer (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.108)</b><b> (CONF:1198-32892)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7928)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.21"</b><b>
+              (CONF:1198-10376)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32497)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15340)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42348-3"</b> Advance Directives<b>
+              (CONF:1198-15342)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30812)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7930)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7931)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7957)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Advance Directive Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-15443)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32891)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Advance Directive Organizer (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.108)</b><b> (CONF:1198-32892)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.22.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.22.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,113 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Encounters Section (entries required) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.22.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.22.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Encounters Section (entries required) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.22.1, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.22.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section lists and describes any healthcare encounters pertinent to the patient's current health status or historical health history. An encounter is an interaction, regardless of the setting, between a patient and a practitioner who is vested with primary responsibility for diagnosing, evaluating, or treating the patient's condition. It may include visits, appointments, as well as non-face-to-face interactions. It is also a contact between a patient and a practitioner who has primary responsibility (exercising independent judgment) for assessing and treating the patient at a given contact. This section may contain all encounters for the time period being summarized, but should include notable encounters.</p></div>
+    <div id="description">
+      <p>This section lists and describes any healthcare encounters pertinent to the patient's current health status or
+        historical health history. An encounter is an interaction, regardless of the setting, between a patient and a
+        practitioner who is vested with primary responsibility for diagnosing, evaluating, or treating the patient's
+        condition. It may include visits, appointments, as well as non-face-to-face interactions. It is also a contact
+        between a patient and a practitioner who has primary responsibility (exercising independent judgment) for
+        assessing and treating the patient at a given contact. This section may contain all encounters for the time
+        period being summarized, but should include notable encounters.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Encounters Section (entries optional) (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.22:2015-08-01)</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32815)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8705)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.22.1"</b><b> (CONF:1198-10387)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32548)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15466)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46240-8"</b> Encounters<b> (CONF:1198-15467)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>" 2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-31137)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8707)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8708)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1198-8709)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Encounter Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.49)</b><b> (CONF:1198-15468)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Encounters Section (entries optional) (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.22:2015-08-01)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1198-32815)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8705)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.22.1"</b><b>
+              (CONF:1198-10387)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32548)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15466)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46240-8"</b> Encounters<b>
+              (CONF:1198-15467)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>" 2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-31137)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8707)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8708)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1198-8709)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Encounter Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.49)</b><b> (CONF:1198-15468)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Encounters%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.22.1/Encounters%20Section%20(entries%20required)%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Encounters Section (entries required) (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Encounters%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.22.1/Encounters%20Section%20(entries%20required)%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Encounters Section (entries required) (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Encounters"><i class="fas fa-external-link-alt"></i> Encounters</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Encounters"><i class="fas fa-external-link-alt"></i> Encounters</a>
+      </li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.22.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.22.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,103 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Encounters Section (entries optional) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.22, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.22.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Encounters Section (entries optional) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.22, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.22.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section lists and describes any healthcare encounters pertinent to the patient's current health status or historical health history. An encounter is an interaction, regardless of the setting, between a patient and a practitioner who is vested with primary responsibility for diagnosing, evaluating, or treating the patient's condition. It may include visits, appointments, or non-face-to-face interactions. It is also a contact between a patient and a practitioner who has primary responsibility (exercising independent judgment) for assessing and treating the patient at a given contact. This section may contain all encounters for the time period being summarized, but should include notable encounters.</p></div>
+    <div id="description">
+      <p>This section lists and describes any healthcare encounters pertinent to the patient's current health status or
+        historical health history. An encounter is an interaction, regardless of the setting, between a patient and a
+        practitioner who is vested with primary responsibility for diagnosing, evaluating, or treating the patient's
+        condition. It may include visits, appointments, or non-face-to-face interactions. It is also a contact between a
+        patient and a practitioner who has primary responsibility (exercising independent judgment) for assessing and
+        treating the patient at a given contact. This section may contain all encounters for the time period being
+        summarized, but should include notable encounters.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD)
+              (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7940)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.22"</b><b> (CONF:1198-10386)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32547)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15461)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46240-8"</b> Encounters<b> (CONF:1198-15462)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31136)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7942)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7943)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7951)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Encounter Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.49)</b><b> (CONF:1198-15465)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7940)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.22"</b><b>
+              (CONF:1198-10386)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32547)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15461)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46240-8"</b> Encounters<b>
+              (CONF:1198-15462)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31136)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7942)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7943)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7951)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Encounter Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.49)</b><b> (CONF:1198-15465)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Encounters"><i class="fas fa-external-link-alt"></i> Encounters</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Encounters"><i class="fas fa-external-link-alt"></i> Encounters</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.23.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.23.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,124 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medical Equipment Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.23, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.23.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medical Equipment Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.23,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.23.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section defines a patient's implanted and external health and medical devices and equipment. This section lists any pertinent durable medical equipment (DME) used to help maintain the patient's health status. All equipment relevant to the diagnosis, care, or treatment of a patient should be included.Devices applied to, or placed in, the patient are represented with the Procedure Activity Procedure (V2) template. Equipment supplied to the patient (e.g., pumps, inhalers, wheelchairs) is represented by the Non-Medicinal Supply Activity V2 template.These devices may be grouped together within a Medical Equipment Organizer. The organizer would probably not be used with devices applied in or on the patient but rather to organize a group of medical supplies the patient has been supplied with.</p></div>
+    <div id="description">
+      <p>This section defines a patient's implanted and external health and medical devices and equipment. This section
+        lists any pertinent durable medical equipment (DME) used to help maintain the patient's health status. All
+        equipment relevant to the diagnosis, care, or treatment of a patient should be included.Devices applied to, or
+        placed in, the patient are represented with the Procedure Activity Procedure (V2) template. Equipment supplied
+        to the patient (e.g., pumps, inhalers, wheelchairs) is represented by the Non-Medicinal Supply Activity V2
+        template.These devices may be grouped together within a Medical Equipment Organizer. The organizer would
+        probably not be used with devices applied in or on the patient but rather to organize a group of medical
+        supplies the patient has been supplied with.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.135.html">Medical Equipment Organizer</a><br><a href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.135.html">Medical Equipment Organizer</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7944)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.23"</b><b> (CONF:1098-10404)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32523)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15381)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46264-8"</b> Medical Equipment<b> (CONF:1098-15382)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30828)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7946)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7947)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-7948)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Medical Equipment Organizer<b> (identifier: 2.16.840.1.113883.10.20.22.4.135)</b><b> (CONF:1098-30351)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-31125)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Non-Medicinal Supply Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1098-31861)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-31885)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-31886)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7944)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.23"</b><b>
+              (CONF:1098-10404)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32523)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15381)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46264-8"</b> Medical Equipment<b>
+              (CONF:1098-15382)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30828)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7946)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7947)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-7948)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medical Equipment Organizer<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.135)</b><b> (CONF:1098-30351)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-31125)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Non-Medicinal Supply Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1098-31861)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-31885)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-31886)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medical%20Equipment%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.23/Medical%20Equipment%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Medical Equipment Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medical%20Equipment%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.23/Medical%20Equipment%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Medical Equipment Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.24.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.24.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,114 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Discharge Diagnosis Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.24, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.24.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Discharge Diagnosis Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.24,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.24.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents problems or diagnoses present at the time of discharge which occurred during the hospitalization. This section includes an optional entry to record patient diagnoses specific to this visit. Problems that need ongoing tracking should also be included in the Problem Section.</p></div>
+    <div id="description">
+      <p>This template represents problems or diagnoses present at the time of discharge which occurred during the
+        hospitalization. This section includes an optional entry to record patient diagnoses specific to this visit.
+        Problems that need ongoing tracking should also be included in the Problem Section.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.33.html">Hospital Discharge Diagnosis (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.33.html">Hospital Discharge Diagnosis (V3)</a><br>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7979)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.24"</b><b> (CONF:1198-10394)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32549)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15355)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11535-2"</b> Hospital Discharge Diagnosis (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-15356)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30861)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32834)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"78375-3"</b> Discharge Diagnosis<b> (CONF:1198-32835)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32836)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7981)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7982)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-7983)</b>.<ul><li>The entry, if present, <b>SHALL</b> contain exactly one [1..1]  Hospital Discharge Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.33)</b><b> (CONF:1198-15489)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7979)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.24"</b><b>
+              (CONF:1198-10394)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32549)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15355)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11535-2"</b> Hospital Discharge
+            Diagnosis (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-15356)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30861)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32834)</b> such that it
+          </li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"78375-3"</b> Discharge Diagnosis<b>
+                (CONF:1198-32835)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem:
+              <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32836)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7981)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7982)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-7983)</b>.<ul>
+          <li>The entry, if present, <b>SHALL</b> contain exactly one [1..1] Hospital Discharge Diagnosis (V3)<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.33)</b><b> (CONF:1198-15489)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Discharge%20Diagnosis%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.24/Discharge%20Diagnosis%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Discharge Diagnosis Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Discharge%20Diagnosis%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.24/Discharge%20Diagnosis%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Discharge Diagnosis Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.25.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.25.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,109 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Anesthesia Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.25, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.25.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Anesthesia Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.25, release
+        2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.25.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Anesthesia Section records the type of anesthesia (e.g., general or local) and may state the actual agent used. This may be a subsection of the Procedure Description Section. The full details of anesthesia are usually found in a separate Anesthesia Note.</p></div>
+    <div id="description">
+      <p>The Anesthesia Section records the type of anesthesia (e.g., general or local) and may state the actual agent
+        used. This may be a subsection of the Procedure Description Section. The full details of anesthesia are usually
+        found in a separate Anesthesia Note.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8066)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.25"</b><b> (CONF:1098-10380)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32531)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15351)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59774-0"</b> Anesthesia<b> (CONF:1098-15352)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30830)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8068)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8069)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8092)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-15447)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8094)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-31127)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8066)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.25"</b><b>
+              (CONF:1098-10380)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32531)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15351)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59774-0"</b> Anesthesia<b>
+              (CONF:1098-15352)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30830)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8068)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8069)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8092)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-15447)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8094)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-31127)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Anesthesia%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.25/Anesthesia%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Anesthesia Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Anesthesia%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.25/Anesthesia%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Anesthesia Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.26.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.26.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,92 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Surgery Description Section (DEPRECATED) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.26, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.26.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Surgery Description Section (DEPRECATED) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.26, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.26.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p><p><em>Reason for deprecation</em>: This template has been replaced by the Procedure Description Section (2.16.840.1.113883.10.20.22.2.27).</p></div>
+    <div id="description">
+      <p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION
+        GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p>
+      <p><em>Reason for deprecation</em>: This template has been replaced by the Procedure Description Section
+        (2.16.840.1.113883.10.20.22.2.27).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8022)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.26"</b><b> (CONF:1098-10450)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32893)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15439)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29554-3"</b> Surgery Description<b> (CONF:1098-15440)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-26497)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8024)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8025)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8022)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.26"</b><b>
+              (CONF:1098-10450)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32893)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15439)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29554-3"</b> Surgery Description<b>
+              (CONF:1098-15440)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-26497)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8024)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8025)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.27.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.27.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,50 +52,96 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Description Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.27, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.27.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Description Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.27,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.27.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Procedure Description section records the particulars of the procedure and may include procedure site preparation, surgical site preparation, pertinent details related to sedation/anesthesia, pertinent details related to measurements and markings, procedure times, medications administered, estimated blood loss, specimens removed, implants, instrumentation, sponge counts, tissue manipulation, wound closure, sutures used, vital signs and other monitoring data. Local practice often identifies the level and type of detail required based on the procedure or specialty.</p></div>
+    <div id="description">
+      <p>The Procedure Description section records the particulars of the procedure and may include procedure site
+        preparation, surgical site preparation, pertinent details related to sedation/anesthesia, pertinent details
+        related to measurements and markings, procedure times, medications administered, estimated blood loss, specimens
+        removed, implants, instrumentation, sponge counts, tissue manipulation, wound closure, sutures used, vital signs
+        and other monitoring data. Local practice often identifies the level and type of detail required based on the
+        procedure or specialty.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8062)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.27"</b><b> (CONF:81-10442)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15411)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29554-3"</b> Procedure Description<b> (CONF:81-15412)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26489)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8064)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8065)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8062)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.27"</b><b>
+              (CONF:81-10442)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15411)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29554-3"</b> Procedure Description<b>
+              (CONF:81-15412)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26489)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8064)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8065)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Description%20Section_2.16.840.1.113883.10.20.22.2.27/Procedure%20Description%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Description Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Description%20Section_2.16.840.1.113883.10.20.22.2.27/Procedure%20Description%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Description Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.28.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.28.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,102 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Findings Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.28, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.28.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Findings Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.28,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.28.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Procedure Findings Section records clinically significant observations confirmed or discovered during a procedure or surgery.</p></div>
+    <div id="description">
+      <p>The Procedure Findings Section records clinically significant observations confirmed or discovered during a
+        procedure or surgery.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8078)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.28"</b><b> (CONF:1198-10443)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32537)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15417)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59776-5"</b> Procedure Findings<b> (CONF:1198-15418)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30859)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8080)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8081)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-8090)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15507)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8078)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.28"</b><b>
+              (CONF:1198-10443)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32537)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15417)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59776-5"</b> Procedure Findings<b>
+              (CONF:1198-15418)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30859)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8080)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8081)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-8090)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15507)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Findings%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.28/Procedure%20Findings%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Findings Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Findings%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.28/Procedure%20Findings%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Findings Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.29.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.29.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,102 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Indications Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.29, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.29.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Indications Section (V2) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.29, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.29.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains the reason(s) for the procedure or surgery. This section may include the preprocedure diagnoses as well as symptoms contributing to the reason for the procedure.</p></div>
+    <div id="description">
+      <p>This section contains the reason(s) for the procedure or surgery. This section may include the preprocedure
+        diagnoses as well as symptoms contributing to the reason for the procedure.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8058)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.29"</b><b> (CONF:1098-10445)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32572)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15419)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59768-2"</b> Procedure Indications <b> (CONF:1098-15420)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30827)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8060)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8061)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8743)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-15508)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8058)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.29"</b><b>
+              (CONF:1098-10445)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32572)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15419)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59768-2"</b> Procedure Indications <b>
+              (CONF:1098-15420)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30827)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8060)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8061)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8743)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-15508)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Indications%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.29/Procedure%20Indications%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Indications Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Indications%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.29/Procedure%20Indications%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Indications Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.3.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.3.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,123 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Results Section (entries required) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.3.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.3.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Results Section (entries required) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.3.1, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.3.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Results Section contains observations of results generated by laboratories, imaging procedures, and other procedures. These coded result observations are contained within a Results Organizer in the Results Section. The scope includes observations such as hematology, chemistry, serology, virology, toxicology, microbiology, plain x-ray, ultrasound, CT, MRI, angiography, echocardiography, nuclear medicine, pathology, and procedure observations. The section often includes notable results such as abnormal values or relevant trends, and could contain all results for the period of time being documented.</p><p>Laboratory results are typically generated by laboratories providing analytic services in areas such as chemistry, hematology, serology, histology, cytology, anatomic pathology, microbiology, and/or virology. These observations are based on analysis of specimens obtained from the patient and submitted to the laboratory.Imaging results are typically generated by a clinician reviewing the output of an imaging procedure, such as where a cardiologist reports the left ventricular ejection fraction based on the review of a cardiac echocardiogram.</p><p>Procedure results are typically generated by a clinician to provide more granular information about component observations made during a procedure, such as where a gastroenterologist reports the size of a polyp observed during a colonoscopy.</p></div>
+    <div id="description">
+      <p>The Results Section contains observations of results generated by laboratories, imaging procedures, and other
+        procedures. These coded result observations are contained within a Results Organizer in the Results Section. The
+        scope includes observations such as hematology, chemistry, serology, virology, toxicology, microbiology, plain
+        x-ray, ultrasound, CT, MRI, angiography, echocardiography, nuclear medicine, pathology, and procedure
+        observations. The section often includes notable results such as abnormal values or relevant trends, and could
+        contain all results for the period of time being documented.</p>
+      <p>Laboratory results are typically generated by laboratories providing analytic services in areas such as
+        chemistry, hematology, serology, histology, cytology, anatomic pathology, microbiology, and/or virology. These
+        observations are based on analysis of specimens obtained from the patient and submitted to the
+        laboratory.Imaging results are typically generated by a clinician reviewing the output of an imaging procedure,
+        such as where a cardiologist reports the left ventricular ejection fraction based on the review of a cardiac
+        echocardiogram.</p>
+      <p>Procedure results are typically generated by a clinician to provide more granular information about component
+        observations made during a procedure, such as where a gastroenterologist reports the size of a polyp observed
+        during a colonoscopy.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Results Section (entries optional) (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.3:2015-08-01)</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32875)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7108)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.3.1"</b><b> (CONF:1198-9137)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32592)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15433)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"30954-2"</b> Relevant diagnostic tests and/or laboratory data<b> (CONF:1198-15434)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31040)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8892)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7111)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1198-7112)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Result Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.1)</b><b> (CONF:1198-15516)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Results Section (entries optional) (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.3:2015-08-01)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1198-32875)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7108)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.3.1"</b><b>
+              (CONF:1198-9137)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32592)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15433)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"30954-2"</b> Relevant diagnostic tests
+            and/or laboratory data<b> (CONF:1198-15434)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31040)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8892)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7111)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1198-7112)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Result Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.1)</b><b> (CONF:1198-15516)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Results%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.3.1/Results%20Section%20(entries%20required)%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Results Section (entries required) (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Results%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.3.1/Results%20Section%20(entries%20required)%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Results Section (entries required) (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Results"><i class="fas fa-external-link-alt"></i> Results</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Results"><i class="fas fa-external-link-alt"></i> Results</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.3.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.3.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,109 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Results Section (entries optional) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.3, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Results Section (entries optional) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.3, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains the results of observations generated by laboratories, imaging and other procedures. The scope includes observations of hematology, chemistry, serology, virology, toxicology, microbiology, plain x-ray, ultrasound, CT, MRI, angiography, echocardiography, nuclear medicine, pathology, and procedure observations.This section often includes notable results such as abnormal values or relevant trends. It can contain all results for the period of time being documented.</p><p>Laboratory results are typically generated by laboratories providing analytic services in areas such as chemistry, hematology, serology, histology, cytology, anatomic pathology, microbiology, and/or virology. These observations are based on analysis of specimens obtained from the patient and submitted to the laboratory.</p><p>Imaging results are typically generated by a clinician reviewing the output of an imaging procedure, such as where a cardiologist reports the left ventricular ejection fraction based on the review of a cardiac echocardiogram.</p><p>Procedure results are typically generated by a clinician to provide more granular information about component observations made during a procedure, such as where a gastroenterologist reports the size of a polyp observed during a colonoscopy.</p></div>
+    <div id="description">
+      <p>This section contains the results of observations generated by laboratories, imaging and other procedures. The
+        scope includes observations of hematology, chemistry, serology, virology, toxicology, microbiology, plain x-ray,
+        ultrasound, CT, MRI, angiography, echocardiography, nuclear medicine, pathology, and procedure observations.This
+        section often includes notable results such as abnormal values or relevant trends. It can contain all results
+        for the period of time being documented.</p>
+      <p>Laboratory results are typically generated by laboratories providing analytic services in areas such as
+        chemistry, hematology, serology, histology, cytology, anatomic pathology, microbiology, and/or virology. These
+        observations are based on analysis of specimens obtained from the patient and submitted to the laboratory.</p>
+      <p>Imaging results are typically generated by a clinician reviewing the output of an imaging procedure, such as
+        where a cardiologist reports the left ventricular ejection fraction based on the review of a cardiac
+        echocardiogram.</p>
+      <p>Procedure results are typically generated by a clinician to provide more granular information about component
+        observations made during a procedure, such as where a gastroenterologist reports the size of a polyp observed
+        during a colonoscopy.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7116)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.3"</b><b> (CONF:1198-9136)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32591)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15431)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"30954-2"</b> Relevant diagnostic tests and/or laboratory data<b> (CONF:1198-15432)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31041)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8891)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7118)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7119)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Result Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.1)</b><b> (CONF:1198-15515)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7116)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.3"</b><b>
+              (CONF:1198-9136)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32591)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15431)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"30954-2"</b> Relevant diagnostic tests
+            and/or laboratory data<b> (CONF:1198-15432)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31041)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8891)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7118)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7119)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Result Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.1)</b><b> (CONF:1198-15515)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Results"><i class="fas fa-external-link-alt"></i> Results</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Results"><i class="fas fa-external-link-alt"></i> Results</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.30.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.30.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,101 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Procedure Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.30, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.30.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Procedure Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.30,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.30.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains the procedure(s) that a clinician planned based on the preoperative assessment.</p></div>
+    <div id="description">
+      <p>This section contains the procedure(s) that a clinician planned based on the preoperative assessment.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8082)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.30"</b><b> (CONF:1098-10436)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32590)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15399)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59772-4"</b> Planned Procedure<b> (CONF:1098-15400)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32151)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8084)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8085)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8744)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.41)</b><b> (CONF:1098-15502)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8082)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.30"</b><b>
+              (CONF:1098-10436)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32590)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15399)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59772-4"</b> Planned Procedure<b>
+              (CONF:1098-15400)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32151)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8084)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8085)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8744)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.41)</b><b> (CONF:1098-15502)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Procedure%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.30/Planned%20Procedure%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Planned Procedure Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Procedure%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.30/Planned%20Procedure%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Planned Procedure Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.31.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.31.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,97 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Specimens Taken Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.31, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.31.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Specimens Taken Section <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.31, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.31.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Procedure Specimens Taken Section records the tissues, objects, or samples taken from the patient during the procedure including biopsies, aspiration fluid, or other samples sent for pathological analysis. The narrative may include a description of the specimens.</p></div>
+    <div id="description">
+      <p>The Procedure Specimens Taken Section records the tissues, objects, or samples taken from the patient during
+        the procedure including biopsies, aspiration fluid, or other samples sent for pathological analysis. The
+        narrative may include a description of the specimens.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8086)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.31"</b><b> (CONF:81-10446)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15421)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59773-2"</b> Procedure Specimens Taken<b> (CONF:81-15422)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26493)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8088)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8089)</b>.</li>
-<li class="list-group-item"> <p>The Procedure Specimens Taken section SHALL list all specimens removed or SHALL explicitly state that no specimens were taken (CONF:81-8742).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8086)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.31"</b><b>
+              (CONF:81-10446)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15421)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59773-2"</b> Procedure Specimens
+            Taken<b> (CONF:81-15422)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26493)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8088)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8089)</b>.</li>
+      <li class="list-group-item">
+        <p>The Procedure Specimens Taken section SHALL list all specimens removed or SHALL explicitly state that no
+          specimens were taken (CONF:81-8742).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Specimens%20Taken%20Section_2.16.840.1.113883.10.20.22.2.31/Procedure%20Specimens%20Taken%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Specimens Taken Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Specimens%20Taken%20Section_2.16.840.1.113883.10.20.22.2.31/Procedure%20Specimens%20Taken%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Specimens Taken Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.33.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.33.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,92 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Implants Section (DEPRECATED) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.33, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.33.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Implants Section (DEPRECATED) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.33,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.33.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p><p><em>Reason for Deprecation</em>: Replaced by the Procedure Implants Section (2.16.840.1.113883.10.20.22.2.40)</p></div>
+    <div id="description">
+      <p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION
+        GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p>
+      <p><em>Reason for Deprecation</em>: Replaced by the Procedure Implants Section (2.16.840.1.113883.10.20.22.2.40)
+      </p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8042)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.33"</b><b> (CONF:1098-32608)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32609)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15371)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"55122-6"</b> Implants<b> (CONF:1098-15372)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-26471)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8044)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8045)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8042)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.33"</b><b>
+              (CONF:1098-32608)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32609)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15371)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"55122-6"</b> Implants<b>
+              (CONF:1098-15372)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-26471)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8044)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8045)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.34.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.34.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,101 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Preoperative Diagnosis Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.34, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.34.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Preoperative Diagnosis Section (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.34, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.34.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Preoperative Diagnosis Section records the surgical diagnoses assigned to the patient before the surgical procedure which are the reason for the surgery. The preoperative diagnosis is, in the surgeon's opinion, the diagnosis that will be confirmed during surgery.</p></div>
+    <div id="description">
+      <p>The Preoperative Diagnosis Section records the surgical diagnoses assigned to the patient before the surgical
+        procedure which are the reason for the surgery. The preoperative diagnosis is, in the surgeon's opinion, the
+        diagnosis that will be confirmed during surgery.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.65.html">Preoperative Diagnosis (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.65.html">Preoperative Diagnosis (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8097)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.34"</b><b> (CONF:1198-10439)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32551)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15405)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10219-4"</b> Preoperative Diagnosis<b> (CONF:1198-15406)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30863)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8099)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8100)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-10096)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Preoperative Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.65)</b><b> (CONF:1198-15504)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8097)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.34"</b><b>
+              (CONF:1198-10439)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32551)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15405)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10219-4"</b> Preoperative Diagnosis<b>
+              (CONF:1198-15406)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30863)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8099)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8100)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-10096)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Preoperative Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.65)</b><b> (CONF:1198-15504)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Preoperative%20Diagnosis%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.34/Preoperative%20Diagnosis%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Preoperative Diagnosis Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Preoperative%20Diagnosis%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.34/Preoperative%20Diagnosis%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Preoperative Diagnosis Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.35.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.35.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,90 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Postoperative Diagnosis Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.35, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.35.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Postoperative Diagnosis Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.35,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.35.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Postoperative Diagnosis Section records the diagnosis or diagnoses discovered or confirmed during the surgery. Often it is the same as the preoperative diagnosis.</p></div>
+    <div id="description">
+      <p>The Postoperative Diagnosis Section records the diagnosis or diagnoses discovered or confirmed during the
+        surgery. Often it is the same as the preoperative diagnosis.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8101)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.35"</b><b> (CONF:81-10437)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15401)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10218-6"</b> Postoperative Diagnosis<b> (CONF:81-15402)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26488)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8103)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8104)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8101)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.35"</b><b>
+              (CONF:81-10437)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15401)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10218-6"</b> Postoperative Diagnosis<b>
+              (CONF:81-15402)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26488)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8103)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8104)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Postoperative%20Diagnosis%20Section_2.16.840.1.113883.10.20.22.2.35/Postoperative%20Diagnosis%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Postoperative Diagnosis Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Postoperative%20Diagnosis%20Section_2.16.840.1.113883.10.20.22.2.35/Postoperative%20Diagnosis%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Postoperative Diagnosis Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.36.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.36.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,100 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Postprocedure Diagnosis Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.36, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.36.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Postprocedure Diagnosis Section (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.36, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.36.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Postprocedure Diagnosis Section records the diagnosis or diagnoses discovered or confirmed during the procedure. Often it is the same as the preprocedure diagnosis or indication.</p></div>
+    <div id="description">
+      <p>The Postprocedure Diagnosis Section records the diagnosis or diagnoses discovered or confirmed during the
+        procedure. Often it is the same as the preprocedure diagnosis or indication.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.51.html">Postprocedure Diagnosis (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.51.html">Postprocedure Diagnosis (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8167)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.36"</b><b> (CONF:1198-10438)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32550)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15403)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59769-0"</b> Postprocedure Diagnosis<b> (CONF:1198-15404)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30862)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8170)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8171)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-8762)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Postprocedure Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.51)</b><b> (CONF:1198-15503)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8167)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.36"</b><b>
+              (CONF:1198-10438)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32550)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15403)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59769-0"</b> Postprocedure Diagnosis<b>
+              (CONF:1198-15404)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30862)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8170)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8171)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-8762)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Postprocedure Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.51)</b><b> (CONF:1198-15503)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Postprocedure%20Diagnosis%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.36/Postprocedure%20Diagnosis%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Postprocedure Diagnosis Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Postprocedure%20Diagnosis%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.36/Postprocedure%20Diagnosis%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Postprocedure Diagnosis Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.37.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.37.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,103 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Complications Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.37, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.37.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Complications Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.37,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.37.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains problems that occurred during or around the time of a procedure. The complications may be known risks or unanticipated problems.</p></div>
+    <div id="description">
+      <p>This section contains problems that occurred during or around the time of a procedure. The complications may be
+        known risks or unanticipated problems.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8174)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.37"</b><b> (CONF:1198-10384)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32538)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15453)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"55109-3"</b> Complications<b> (CONF:1198-15454)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30860)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8176)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8177)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-8795)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15455)</b>.<br>Note: When no coded entries or negation of entries are present, narrative section/text will be provided containing details of the complication(s) or that there were no complications.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8174)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.37"</b><b>
+              (CONF:1198-10384)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32538)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15453)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"55109-3"</b> Complications<b>
+              (CONF:1198-15454)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30860)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-8176)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-8177)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-8795)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15455)</b>.<br>Note: When no coded entries or negation
+            of entries are present, narrative section/text will be provided containing details of the complication(s) or
+            that there were no complications.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Complications%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.37/Complications%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Complications Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Complications%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.37/Complications%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Complications Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.38.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.38.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,102 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medications Administered Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.38, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.38.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medications Administered Section (V2) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.38, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.38.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Medications Administered Section usually resides inside a Procedure Note describing a procedure. This section defines medications and fluids administered during the procedure, its related encounter, or other procedure related activity excluding anesthetic medications. Anesthesia medications should be documented as described in the Anesthesia SectiontemplateId 2.16.840.1.113883.10.20.22.2.25.</p></div>
+    <div id="description">
+      <p>The Medications Administered Section usually resides inside a Procedure Note describing a procedure. This
+        section defines medications and fluids administered during the procedure, its related encounter, or other
+        procedure related activity excluding anesthetic medications. Anesthesia medications should be documented as
+        described in the Anesthesia SectiontemplateId 2.16.840.1.113883.10.20.22.2.25.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8152)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.38"</b><b> (CONF:1098-10405)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32525)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15383)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29549-3"</b> Medications Administered<b> (CONF:1098-15384)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30829)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8154)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8155)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8156)</b>.<ul><li>The entry, if present, <b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15499)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8152)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.38"</b><b>
+              (CONF:1098-10405)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32525)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15383)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29549-3"</b> Medications
+            Administered<b> (CONF:1098-15384)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30829)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-8154)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-8155)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8156)</b>.<ul>
+          <li>The entry, if present, <b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15499)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medications%20Administered%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.38/Medications%20Administered%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Medications Administered Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medications%20Administered%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.38/Medications%20Administered%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Medications Administered Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i> Medications</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i>
+          Medications</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.39.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.39.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,90 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medical (General) History Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.39, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.39.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medical (General) History Section <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.39, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.39.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Medical History Section describes all aspects of the medical history of the patient even if not pertinent to the current procedure, and may include chief complaint, past medical history, social history, family history, surgical or procedure history, medication history, and other history information. The history may be limited to information pertinent to the current procedure or may be more comprehensive. The history may be reported as a collection of random clinical statements or it may be reported categorically. Categorical report formats may be divided into multiple subsections including Past Medical History, Social History.</p></div>
+    <div id="description">
+      <p>The Medical History Section describes all aspects of the medical history of the patient even if not pertinent
+        to the current procedure, and may include chief complaint, past medical history, social history, family history,
+        surgical or procedure history, medication history, and other history information. The history may be limited to
+        information pertinent to the current procedure or may be more comprehensive. The history may be reported as a
+        collection of random clinical statements or it may be reported categorically. Categorical report formats may be
+        divided into multiple subsections including Past Medical History, Social History.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8160)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.39"</b><b> (CONF:81-10403)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15379)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11329-0"</b> Medical (General) History<b> (CONF:81-15380)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26484)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8162)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8163)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8160)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.39"</b><b>
+              (CONF:81-10403)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15379)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11329-0"</b> Medical (General)
+            History<b> (CONF:81-15380)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26484)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8162)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8163)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.4.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.4.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,114 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Vital Signs Section (entries required) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.4.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.4.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Vital Signs Section (entries required) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.4.1, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.4.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Vital Signs Section contains relevant vital signs for the context and use case of the document type, such as blood pressure, heart rate, respiratory rate, height, weight, body mass index, head circumference, pulse oximetry, temperature, and body surface area. The section should include notable vital signs such as the most recent, maximum and/or minimum, baseline, or relevant trends.Vital signs are represented in the same way as other results, but are aggregated into their own section to follow clinical conventions.</p></div>
+    <div id="description">
+      <p>The Vital Signs Section contains relevant vital signs for the context and use case of the document type, such
+        as blood pressure, heart rate, respiratory rate, height, weight, body mass index, head circumference, pulse
+        oximetry, temperature, and body surface area. The section should include notable vital signs such as the most
+        recent, maximum and/or minimum, baseline, or relevant trends.Vital signs are represented in the same way as
+        other results, but are aggregated into their own section to follow clinical conventions.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.26.html">Vital Signs Organizer (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.26.html">Vital Signs Organizer (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Vital Signs Section (entries optional) (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.4:2015-08-01)</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32874)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7273)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.4.1"</b><b> (CONF:1198-10452)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32585)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15962)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8716-3"</b> Vital Signs<b> (CONF:1198-15963)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30903)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9967)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7275)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1198-7276)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Signs Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.26)</b><b> (CONF:1198-15964)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Vital Signs Section (entries optional) (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.4:2015-08-01)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1198-32874)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7273)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.4.1"</b><b>
+              (CONF:1198-10452)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32585)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15962)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8716-3"</b> Vital Signs<b>
+              (CONF:1198-15963)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30903)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9967)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7275)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1198-7276)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Vital Signs Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.26)</b><b> (CONF:1198-15964)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Vital%20Signs%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.4.1/Vital%20Signs%20Section%20(entries%20required)%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Vital Signs Section (entries required) (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Vital%20Signs%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.4.1/Vital%20Signs%20Section%20(entries%20required)%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Vital Signs Section (entries required) (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Vital%20Signs"><i class="fas fa-external-link-alt"></i> Vital Signs</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Vital%20Signs"><i class="fas fa-external-link-alt"></i> Vital
+          Signs</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.4.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.4.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,102 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Vital Signs Section (entries optional) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.4, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.4.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Vital Signs Section (entries optional) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.4, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.4.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Vital Signs Section contains relevant vital signs for the context and use case of the document type, such as blood pressure, heart rate, respiratory rate, height, weight, body mass index, head circumference, pulse oximetry, temperature, and body surface area. The section should include notable vital signs such as the most recent, maximum and/or minimum, baseline, or relevant trends.Vital signs are represented in the same way as other results, but are aggregated into their own section to follow clinical conventions.</p></div>
+    <div id="description">
+      <p>The Vital Signs Section contains relevant vital signs for the context and use case of the document type, such
+        as blood pressure, heart rate, respiratory rate, height, weight, body mass index, head circumference, pulse
+        oximetry, temperature, and body surface area. The section should include notable vital signs such as the most
+        recent, maximum and/or minimum, baseline, or relevant trends.Vital signs are represented in the same way as
+        other results, but are aggregated into their own section to follow clinical conventions.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.26.html">Vital Signs Organizer (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.26.html">Vital Signs Organizer (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7268)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.4"</b><b> (CONF:1198-10451)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32584)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15242)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8716-3"</b> Vital Signs<b> (CONF:1198-15243)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30902)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9966)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7270)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7271)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Signs Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.26)</b><b> (CONF:1198-15517)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7268)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.4"</b><b>
+              (CONF:1198-10451)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32584)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15242)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8716-3"</b> Vital Signs<b>
+              (CONF:1198-15243)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30902)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9966)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7270)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7271)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Vital Signs Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.26)</b><b> (CONF:1198-15517)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Vital%20Signs"><i class="fas fa-external-link-alt"></i> Vital Signs</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Vital%20Signs"><i class="fas fa-external-link-alt"></i> Vital
+          Signs</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.40.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.40.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,95 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Implants Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.40, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.40.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Implants Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.40, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.22.2.40.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Procedure Implants Section records any materials placed during the procedure including stents, tubes, and drains.</p></div>
+    <div id="description">
+      <p>The Procedure Implants Section records any materials placed during the procedure including stents, tubes, and
+        drains.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8178)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.40"</b><b> (CONF:81-10444)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15373)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59771-6"</b> Procedure Implants<b> (CONF:81-15374)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26492)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8180)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8181)</b>.</li>
-<li class="list-group-item"> <p>The Procedure Implants section <strong>SHALL</strong> include a statement providing details of the implants placed, or assert no implants were placed (CONF:81-8769).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8178)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.40"</b><b>
+              (CONF:81-10444)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15373)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59771-6"</b> Procedure Implants<b>
+              (CONF:81-15374)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26492)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8180)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8181)</b>.</li>
+      <li class="list-group-item">
+        <p>The Procedure Implants section <strong>SHALL</strong> include a statement providing details of the implants
+          placed, or assert no implants were placed (CONF:81-8769).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Implants%20Section_2.16.840.1.113883.10.20.22.2.40/Procedure%20Implants%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Implants Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Implants%20Section_2.16.840.1.113883.10.20.22.2.40/Procedure%20Implants%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Implants Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.41.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.41.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,89 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Hospital Discharge Instructions Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.41, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.41.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Hospital Discharge Instructions Section <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.41, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.41.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Hospital Discharge Instructions Section records instructions at discharge.</p></div>
+    <div id="description">
+      <p>The Hospital Discharge Instructions Section records instructions at discharge.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9919)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.41"</b><b> (CONF:81-10395)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15357)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8653-8"</b> Hospital Discharge Instructions<b> (CONF:81-15358)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26481)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-9921)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-9922)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9919)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.41"</b><b>
+              (CONF:81-10395)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15357)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8653-8"</b> Hospital Discharge
+            Instructions<b> (CONF:81-15358)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26481)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-9921)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-9922)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Discharge%20Instructions%20Section_2.16.840.1.113883.10.20.22.2.41/Hospital%20Discharge%20Instructions%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Hospital Discharge Instructions Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Discharge%20Instructions%20Section_2.16.840.1.113883.10.20.22.2.41/Hospital%20Discharge%20Instructions%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Hospital Discharge Instructions Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.42.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.42.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,89 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Hospital Consultations Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.42, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.42.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Hospital Consultations Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.42,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.42.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Hospital Consultations Section records consultations that occurred during the admission.</p></div>
+    <div id="description">
+      <p>The Hospital Consultations Section records consultations that occurred during the admission.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9915)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.42"</b><b> (CONF:81-10393)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15485)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"18841-7"</b> Hospital Consultations Section<b> (CONF:81-15486)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26479)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-9917)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-9918)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9915)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.42"</b><b>
+              (CONF:81-10393)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15485)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"18841-7"</b> Hospital Consultations
+            Section<b> (CONF:81-15486)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26479)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-9917)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-9918)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Consultations%20Section_2.16.840.1.113883.10.20.22.2.42/Hospital%20Consultations%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Hospital Consultations Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Consultations%20Section_2.16.840.1.113883.10.20.22.2.42/Hospital%20Consultations%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Hospital Consultations Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.43.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.43.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,114 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Admission Diagnosis Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.43, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.43.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Admission Diagnosis Section (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.43,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.43.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains a narrative description of the problems or diagnoses identified by the clinician at the time of the patient's admission. This section may contain a coded entry which represents the admitting diagnoses.</p></div>
+    <div id="description">
+      <p>This section contains a narrative description of the problems or diagnoses identified by the clinician at the
+        time of the patient's admission. This section may contain a coded entry which represents the admitting
+        diagnoses.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.34.html">Hospital Admission Diagnosis (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.34.html">Hospital Admission Diagnosis (V3)</a><br>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-9930)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.43"</b><b> (CONF:1198-10391)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32563)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15479)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46241-6"</b> Hospital Admission diagnosis<b> (CONF:1198-15480)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30865)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32749)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42347-5"</b> Admission Diagnosis<b> (CONF:1198-32750)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-32751)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9932)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-9933)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-9934)</b>.<ul><li>The entry, if present, <b>SHALL</b> contain exactly one [1..1]  Hospital Admission Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.34)</b><b> (CONF:1198-15481)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-9930)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.43"</b><b>
+              (CONF:1198-10391)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32563)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15479)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46241-6"</b> Hospital Admission
+            diagnosis<b> (CONF:1198-15480)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30865)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32749)</b> such that it
+          </li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42347-5"</b> Admission Diagnosis<b>
+                (CONF:1198-32750)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem:
+              <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-32751)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9932)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-9933)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-9934)</b>.<ul>
+          <li>The entry, if present, <b>SHALL</b> contain exactly one [1..1] Hospital Admission Diagnosis (V3)<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.34)</b><b> (CONF:1198-15481)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Admission%20Diagnosis%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.43/Admission%20Diagnosis%20Section%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Admission Diagnosis Section (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Admission%20Diagnosis%20Section%20(V3)_2.16.840.1.113883.10.20.22.2.43/Admission%20Diagnosis%20Section%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Admission Diagnosis Section (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.44.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.44.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,97 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Admission Medications Section (entries optional) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.44, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.44.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Admission Medications Section (entries optional) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.44, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.44.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The section contains the medications taken by the patient prior to and at the time of admission to the facility.</p></div>
+    <div id="description">
+      <p>The section contains the medications taken by the patient prior to and at the time of admission to the
+        facility.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.36.html">Admission Medication (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.36.html">Admission Medication (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-10098)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.44"</b><b> (CONF:1198-10392)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32560)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15482)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42346-7"</b> Medications on Admission<b> (CONF:1198-15483)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32142)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-10100)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-10101)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-10102)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Admission Medication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.36)</b><b> (CONF:1198-15484)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-10098)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.44"</b><b>
+              (CONF:1198-10392)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32560)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15482)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42346-7"</b> Medications on
+            Admission<b> (CONF:1198-15483)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32142)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-10100)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-10101)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-10102)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Admission Medication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.36)</b><b> (CONF:1198-15484)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.45.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.45.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,105 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Instructions Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.45, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.45.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Instructions Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.45,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.45.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Instructions Section records instructions given to a patient. List patient decision aids here.</p></div>
+    <div id="description">
+      <p>The Instructions Section records instructions given to a patient. List patient decision aids here.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1098-32835)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-10112)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.45"</b><b> (CONF:1098-31384)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32599)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15375)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"69730-0"</b> Instructions<b> (CONF:1098-15376)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32148)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-10114)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-10115)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1098-10116)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31398)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1098-32835)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-10112)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.45"</b><b>
+              (CONF:1098-31384)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32599)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15375)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"69730-0"</b> Instructions<b>
+              (CONF:1098-15376)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32148)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-10114)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-10115)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1098-10116)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31398)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Instructions%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.45/Instructions%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Instructions Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Instructions%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.45/Instructions%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Instructions Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.5.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.5.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,122 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Problem Section (entries required) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.5.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.5.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Problem Section (entries required) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.5.1, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.5.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section lists and describes all relevant clinical problems at the time the document is generated. At a minimum, all pertinent current and historical problems should be listed. Overall health status may be represented in this section.</p></div>
+    <div id="description">
+      <p>This section lists and describes all relevant clinical problems at the time the document is generated. At a
+        minimum, all pertinent current and historical problems should be listed. Overall health status may be
+        represented in this section.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.5.html">Health Status Observation (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.5.html">Health Status Observation (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Problem Section (entries optional) (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.5:2015-08-01)</li>
-  <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32864)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-9179)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.5.1"</b><b> (CONF:1198-10441)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32510)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15409)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11450-4"</b> Problem List<b> (CONF:1198-15410)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31142)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9181)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-9182)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1198-9183)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Concern Act (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.3)</b><b> (CONF:1198-15506)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-30479)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Health Status Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.5)</b><b> (CONF:1198-30480)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Problem Section (entries optional) (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.5:2015-08-01)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1198-32864)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-9179)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.5.1"</b><b>
+              (CONF:1198-10441)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32510)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15409)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11450-4"</b> Problem List<b>
+              (CONF:1198-15410)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31142)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-9181)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-9182)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1198-9183)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Concern Act (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.3)</b><b> (CONF:1198-15506)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-30479)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Health Status Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.5)</b><b> (CONF:1198-30480)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.5.1/No%20Known%20Problems%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;No Known Problems Section Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.5.1/Problem%20Section%20(entries%20required)%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Problem Section (entries required) (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.5.1/No%20Known%20Problems%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;No Known Problems Section Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.5.1/Problem%20Section%20(entries%20required)%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Problem Section (entries required) (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a>
+      </li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.5.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.5.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,107 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Problem Section (entries optional) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.5, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Problem Section (entries optional) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.5, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section lists and describes all relevant clinical problems at the time the document is generated. At a minimum, all pertinent current and historical problems should be listed. Overall health status may be represented in this section.</p></div>
+    <div id="description">
+      <p>This section lists and describes all relevant clinical problems at the time the document is generated. At a
+        minimum, all pertinent current and historical problems should be listed. Overall health status may be
+        represented in this section.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.5.html">Health Status Observation (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.5.html">Health Status Observation (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7877)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.5"</b><b> (CONF:1198-10440)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32511)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15407)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11450-4"</b> Problem List<b> (CONF:1198-15408)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31141)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7879)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7880)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7881)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Concern Act (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.3)</b><b> (CONF:1198-15505)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-30481)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Health Status Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.5)</b><b> (CONF:1198-30482)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7877)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.5"</b><b>
+              (CONF:1198-10440)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32511)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15407)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11450-4"</b> Problem List<b>
+              (CONF:1198-15408)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-31141)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7879)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7880)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7881)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Concern Act (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.3)</b><b> (CONF:1198-15505)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entry</b><b> (CONF:1198-30481)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Health Status Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.5)</b><b> (CONF:1198-30482)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.500.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.500.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,73 +24,136 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Care Teams Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.500, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.500.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Care Teams Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.500, release
+        2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.500.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Care Team Section is used to share historical and current Care Team information.</p><p>The Care Team Section may be included in any type of C-CDA structured document that is an open template.</p><p>An individual can have more than one Care Team.  A Care Team can exist over time such as a longitudinal care team which includes historical members that may be active or inactive on the care team as needed. Or a Care Team, such as a rehabilitation team, may exist to address a person's needs associated with a particular care event, or a team can be based on addressing a specific condition.</p><p>The Care Team Organizer entry template used in the C-CDA Care Teams Section is meant to support the foundation of effective communication, interaction channels and maintenance of current clinical context awareness for the patient, caregivers and care providers to promote care coordination.</p></div>
+    <div id="description">
+      <p>The Care Team Section is used to share historical and current Care Team information.</p>
+      <p>The Care Team Section may be included in any type of C-CDA structured document that is an open template.</p>
+      <p>An individual can have more than one Care Team. A Care Team can exist over time such as a longitudinal care
+        team which includes historical members that may be active or inactive on the care team as needed. Or a Care
+        Team, such as a rehabilitation team, may exist to address a person's needs associated with a particular care
+        event, or a team can be based on addressing a specific condition.</p>
+      <p>The Care Team Organizer entry template used in the C-CDA Care Teams Section is meant to support the foundation
+        of effective communication, interaction channels and maintenance of current clinical context awareness for the
+        patient, caregivers and care providers to promote care coordination.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.500.html">Care Team Organizer (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.500.html">Care Team Organizer (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-3)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.500"</b><b> (CONF:4515-7)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-8)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-5)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"85847-2"</b> Patient Care team information (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-9)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-10)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:4515-4)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:4515-6)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:4515-1)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Care Team Organizer (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.500)</b><b> (CONF:4515-159)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-3)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.500"</b><b>
+              (CONF:4515-7)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-8)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-5)</b> such that it
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"85847-2"</b> Patient Care team information
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-9)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem:
+            <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-10)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:4515-4)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:4515-6)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:4515-1)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Care Team Organizer (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.500)</b><b> (CONF:4515-159)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Teams%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.500/Care%20Teams%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Teams Section</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Teams%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.500/Care%20Teams%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Teams Section</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a>
+      </li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.56.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.56.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,125 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Mental Status Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.56, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.56.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Mental Status Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.56,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.56.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Mental Status Section contains observations and evaluations related to a patient's psychological and mental competency and deficits including, but not limited to any of the following types of information:'  Appearance (e.g., unusual grooming, clothing or body modifications)'  Attitude (e.g., cooperative, guarded, hostile)'  Behavior/psychomotor (e.g., abnormal movements, eye contact, tics)'  Mood and affect (e.g., anxious, angry, euphoric)'  Speech and Language (e.g., pressured speech, perseveration)'  Thought process (e.g., logic, coherence)'  Thought content (e.g., delusions, phobias)'  Perception (e.g., voices, hallucinations)'  Cognition (e.g., memory, alertness/consciousness, attention, orientation) ' which were included in Cognitive Status Observation in earlier publications of C-CDA.'  Insight and judgment (e.g., understanding of condition, decision making)</p></div>
+    <div id="description">
+      <p>The Mental Status Section contains observations and evaluations related to a patient's psychological and mental
+        competency and deficits including, but not limited to any of the following types of information:' Appearance
+        (e.g., unusual grooming, clothing or body modifications)' Attitude (e.g., cooperative, guarded, hostile)'
+        Behavior/psychomotor (e.g., abnormal movements, eye contact, tics)' Mood and affect (e.g., anxious, angry,
+        euphoric)' Speech and Language (e.g., pressured speech, perseveration)' Thought process (e.g., logic,
+        coherence)' Thought content (e.g., delusions, phobias)' Perception (e.g., voices, hallucinations)' Cognition
+        (e.g., memory, alertness/consciousness, attention, orientation) ' which were included in Cognitive Status
+        Observation in earlier publications of C-CDA.' Insight and judgment (e.g., understanding of condition, decision
+        making)</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.75.html">Mental Status Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.75.html">Mental Status Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28293)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.56"</b><b> (CONF:1198-28294)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32793)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-28295)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10190-7"</b> Mental Status<b> (CONF:1198-28296)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30826)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-28297)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-28298)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28301)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.75)</b><b> (CONF:1198-28302)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28305)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:1198-28306)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28313)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1198-28314)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28293)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.56"</b><b>
+              (CONF:1198-28294)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32793)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-28295)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10190-7"</b> Mental Status<b>
+              (CONF:1198-28296)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-30826)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-28297)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-28298)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28301)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Mental Status Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.75)</b><b> (CONF:1198-28302)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28305)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Mental Status Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:1198-28306)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-28313)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1198-28314)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Mental%20Status%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.56/Mental%20Status%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Mental Status Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Mental%20Status%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.56/Mental%20Status%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Mental Status Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Mental%20Status"><i class="fas fa-external-link-alt"></i> Mental Status</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Mental%20Status"><i class="fas fa-external-link-alt"></i> Mental
+          Status</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.57.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.57.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,101 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Nutrition Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.57, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.57.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Nutrition Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.57, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.57.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Nutrition Section represents diet and nutrition information including special diet requirements and restrictions (e.g., texture modified diet, liquids only, enteral feeding). It also represents the overall nutritional status of the patient and nutrition assessment findings.</p></div>
+    <div id="description">
+      <p>The Nutrition Section represents diet and nutrition information including special diet requirements and
+        restrictions (e.g., texture modified diet, liquids only, enteral feeding). It also represents the overall
+        nutritional status of the patient and nutrition assessment findings.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.124.html">Nutritional Status Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.124.html">Nutritional Status Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30477)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.57"</b><b> (CONF:1098-30478)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-30318)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"61144-2"</b>  Diet and nutrition <b> (CONF:1098-30319)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30320)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-31042)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-31043)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-30321)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Nutritional Status Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.124)</b><b> (CONF:1098-30322)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30477)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.57"</b><b>
+              (CONF:1098-30478)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-30318)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"61144-2"</b> Diet and nutrition <b>
+              (CONF:1098-30319)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-30320)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-31042)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-31043)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-30321)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Nutritional Status Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.124)</b><b> (CONF:1098-30322)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Nutrition%20Section_2.16.840.1.113883.10.20.22.2.57/Nutrition%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Nutrition Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Nutrition%20Section_2.16.840.1.113883.10.20.22.2.57/Nutrition%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Nutrition Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.58.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.58.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,132 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Health Concerns Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.58, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.58.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Health Concerns Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.58,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.58.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section contains data describing an interest or worry about a health state or process that could possibly require attention, intervention, or management. A Health Concern is a health related matter that is of interest, importance or worry to someone, who may be the patient, patient's family or patient's health care provider. Health concerns are derived from a variety of sources within an EHR (such as Problem List, Family History, Social History, Social Worker Note, etc.). Health concerns can be medical, surgical, nursing, allied health or patient-reported concerns.</p><p>Problem Concerns are a subset of Health Concerns that have risen to the level of importance that they typically would belong on a classic 'Problem List', such as 'Diabetes Mellitus' or 'Family History of Melanoma' or 'Tobacco abuse'. These are of broad interest to multiple members of the care team. Examples of other Health Concerns that might not typically be considered a Problem Concern include 'Risk of Hyperkalemia' for a patient taking an ACE-inhibitor medication, or 'Transportation difficulties' for someone who doesn't drive and has trouble getting to appointments, or 'Under-insured' for someone who doesn't have sufficient insurance to properly cover their medical needs such as medications. These are typically most important to just a limited number of care team members.</p></div>
+    <div id="description">
+      <p>This section contains data describing an interest or worry about a health state or process that could possibly
+        require attention, intervention, or management. A Health Concern is a health related matter that is of interest,
+        importance or worry to someone, who may be the patient, patient's family or patient's health care provider.
+        Health concerns are derived from a variety of sources within an EHR (such as Problem List, Family History,
+        Social History, Social Worker Note, etc.). Health concerns can be medical, surgical, nursing, allied health or
+        patient-reported concerns.</p>
+      <p>Problem Concerns are a subset of Health Concerns that have risen to the level of importance that they typically
+        would belong on a classic 'Problem List', such as 'Diabetes Mellitus' or 'Family History of Melanoma' or
+        'Tobacco abuse'. These are of broad interest to multiple members of the care team. Examples of other Health
+        Concerns that might not typically be considered a Problem Concern include 'Risk of Hyperkalemia' for a patient
+        taking an ACE-inhibitor medication, or 'Transportation difficulties' for someone who doesn't drive and has
+        trouble getting to appointments, or 'Under-insured' for someone who doesn't have sufficient insurance to
+        properly cover their medical needs such as medications. These are typically most important to just a limited
+        number of care team members.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.5.html">Health Status Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.5.html">Health Status Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32802)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28804)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.58"</b><b> (CONF:1198-28805)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32862)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-28806)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75310-3"</b> Health concerns document<b> (CONF:1198-28807)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-28808)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-28809)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-28810)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-30483)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Health Status Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.5)</b><b> (CONF:1198-30484)</b>.</li></ul></li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1198-30768)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Health Concern Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.132)</b><b> (CONF:1198-30769)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32308)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Risk Concern Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.136)</b><b> (CONF:1198-32309)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1198-32802)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28804)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.58"</b><b>
+              (CONF:1198-28805)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32862)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-28806)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75310-3"</b> Health concerns
+            document<b> (CONF:1198-28807)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-28808)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-28809)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-28810)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-30483)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Health Status Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.5)</b><b> (CONF:1198-30484)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1198-30768)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Health Concern Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.132)</b><b> (CONF:1198-30769)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-32308)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Risk Concern Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.136)</b><b> (CONF:1198-32309)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Concerns%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.58/Health%20Concerns%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Health Concerns Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Concerns%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.58/Health%20Concerns%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Health Concerns Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Health%20Concerns"><i class="fas fa-external-link-alt"></i> Health Concerns</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Health%20Concerns"><i class="fas fa-external-link-alt"></i> Health
+          Concerns</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.6.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.6.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,113 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Allergies and Intolerances Section (entries required) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.6.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.6.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Allergies and Intolerances Section (entries required) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.6.1, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.6.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section lists and describes any medication allergies, adverse reactions, idiosyncratic reactions, anaphylaxis/anaphylactoid reactions to food items, and metabolic variations or adverse reactions/allergies to other substances (such as latex, iodine, tape adhesives). At a minimum, it should list currently active and any relevant historical allergies and adverse reactions.</p></div>
+    <div id="description">
+      <p>This section lists and describes any medication allergies, adverse reactions, idiosyncratic reactions,
+        anaphylaxis/anaphylactoid reactions to food items, and metabolic variations or adverse reactions/allergies to
+        other substances (such as latex, iodine, tape adhesives). At a minimum, it should list currently active and any
+        relevant historical allergies and adverse reactions.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.30.html">Allergy Concern Act (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.30.html">Allergy Concern Act (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Allergies and Intolerances Section (entries optional) (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.6:2015-08-01)</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1198-32824)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7527)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.6.1"</b><b> (CONF:1198-10379)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32545)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15349)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48765-2"</b> Allergies, adverse reactions, alerts<b> (CONF:1198-15350)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32140)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7534)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7530)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1198-7531)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Allergy Concern Act (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.30)</b><b> (CONF:1198-15446)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Allergies and Intolerances Section (entries optional) (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.6:2015-08-01)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1198-32824)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7527)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.6.1"</b><b>
+              (CONF:1198-10379)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32545)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15349)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48765-2"</b> Allergies, adverse
+            reactions, alerts<b> (CONF:1198-15350)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32140)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7534)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7530)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present:<br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1198-7531)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Allergy Concern Act (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.30)</b><b> (CONF:1198-15446)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Allergies%20and%20Intolerances%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.6.1/Allergies%20and%20Intolerances%20Section%20(entries%20required)%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Allergies and Intolerances Section (entries required) (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Allergies%20and%20Intolerances%20Section%20(entries%20required)%20(V3)_2.16.840.1.113883.10.20.22.2.6.1/Allergies%20and%20Intolerances%20Section%20(entries%20required)%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Allergies and Intolerances Section (entries required) (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a>
+      </li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.6.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.6.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,102 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Allergies and Intolerances Section (entries optional) (V3) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.6, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.6.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Allergies and Intolerances Section (entries optional) (V3) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.6, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.6.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section lists and describes any medication allergies, adverse reactions, idiosyncratic reactions, anaphylaxis/anaphylactoid reactions to food items, and metabolic variations or adverse reactions/allergies to other substances (such as latex, iodine, tape adhesives). At a minimum, it should list currently active and any relevant historical allergies and adverse reactions.</p></div>
+    <div id="description">
+      <p>This section lists and describes any medication allergies, adverse reactions, idiosyncratic reactions,
+        anaphylaxis/anaphylactoid reactions to food items, and metabolic variations or adverse reactions/allergies to
+        other substances (such as latex, iodine, tape adhesives). At a minimum, it should list currently active and any
+        relevant historical allergies and adverse reactions.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.30.html">Allergy Concern Act (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.30.html">Allergy Concern Act (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7800)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.6"</b><b> (CONF:1198-10378)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32544)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15345)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48765-2"</b> Allergies, adverse reactions, alerts<b> (CONF:1198-15346)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32139)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7802)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7803)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7804)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Allergy Concern Act (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.30)</b><b> (CONF:1198-15444)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7800)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.6"</b><b>
+              (CONF:1198-10378)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32544)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-15345)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48765-2"</b> Allergies, adverse
+            reactions, alerts<b> (CONF:1198-15346)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32139)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1198-7802)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1198-7803)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1198-7804)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Allergy Concern Act (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.30)</b><b> (CONF:1198-15444)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.60.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.60.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,101 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Goals Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.60, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.60.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Goals Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.60, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.60.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents patient Goals. A goal is a defined outcome or condition to be achieved in the process of patient care. Goals include patient-defined over-arching goals (e.g., alleviation of health concerns, desired/intended positive outcomes from interventions, longevity, function, symptom management, comfort) and health concern-specific or intervention-specific goals to achieve desired outcomes.</p></div>
+    <div id="description">
+      <p>This template represents patient Goals. A goal is a defined outcome or condition to be achieved in the process
+        of patient care. Goals include patient-defined over-arching goals (e.g., alleviation of health concerns,
+        desired/intended positive outcomes from interventions, longevity, function, symptom management, comfort) and
+        health concern-specific or intervention-specific goals to achieve desired outcomes.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1098-32819)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29584)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.60"</b><b> (CONF:1098-29585)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29586)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"61146-7"</b> Goals<b> (CONF:1098-29587)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-29588)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-30721)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-30722)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1098-30719)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Goal Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.121)</b><b> (CONF:1098-30720)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1098-32819)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29584)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.60"</b><b>
+              (CONF:1098-29585)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29586)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"61146-7"</b> Goals<b>
+              (CONF:1098-29587)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-29588)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-30721)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-30722)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1098-30719)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Goal Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.121)</b><b> (CONF:1098-30720)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Goals%20Section_2.16.840.1.113883.10.20.22.2.60/Goals%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Goals Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Goals%20Section_2.16.840.1.113883.10.20.22.2.60/Goals%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Goals Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Goals"><i class="fas fa-external-link-alt"></i> Goals</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Goals"><i class="fas fa-external-link-alt"></i> Goals</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.61.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.61.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,101 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Health Status Evaluations and Outcomes Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.61, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.61.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Health Status Evaluations and Outcomes Section <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.61, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.61.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents observations regarding the outcome of care from the interventions used to treat the patient. These observations represent status, at points in time, related to established care plan goals and/or interventions.</p></div>
+    <div id="description">
+      <p>This template represents observations regarding the outcome of care from the interventions used to treat the
+        patient. These observations represent status, at points in time, related to established care plan goals and/or
+        interventions.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1098-32821)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29578)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.61"</b><b> (CONF:1098-29579)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29580)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11383-7"</b> Patient Problem Outcome<b> (CONF:1098-29581)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-29582)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-29589)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-29590)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1098-31227)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Outcome Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.144)</b><b> (CONF:1098-31228)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1098-32821)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29578)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.61"</b><b>
+              (CONF:1098-29579)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29580)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11383-7"</b> Patient Problem Outcome<b>
+              (CONF:1098-29581)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-29582)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-29589)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-29590)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1098-31227)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Outcome Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.144)</b><b> (CONF:1098-31228)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Status%20Evaluations%20and%20Outcomes%20Section_2.16.840.1.113883.10.20.22.2.61/Health%20Status%20Evaluations%20and%20Outcomes%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Health Status Evaluations and Outcomes Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Status%20Evaluations%20and%20Outcomes%20Section_2.16.840.1.113883.10.20.22.2.61/Health%20Status%20Evaluations%20and%20Outcomes%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Health Status Evaluations and Outcomes Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.64.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.64.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,88 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Course of Care Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.64, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.64.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Course of Care Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.64, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.64.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Course of Care section describes what happened during the course of an encounter.</p></div>
+    <div id="description">
+      <p>The Course of Care section describes what happened during the course of an encounter.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32640)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.64"</b><b> (CONF:1098-32642)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-32641)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8648-8"</b> Hospital Course Narrative<b> (CONF:1098-32645)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32646)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-32643)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-32644)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32640)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.64"</b><b>
+              (CONF:1098-32642)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-32641)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"8648-8"</b> Hospital Course
+            Narrative<b> (CONF:1098-32645)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32646)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-32643)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-32644)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Course%20of%20Care%20Section_2.16.840.1.113883.10.20.22.2.64/Course%20of%20Care%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Course of Care Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Course%20of%20Care%20Section_2.16.840.1.113883.10.20.22.2.64/Course%20of%20Care%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Course of Care Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.65.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.65.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,73 +24,134 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Notes Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.65, release 2016-11-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.65.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Notes Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.65, release
+        2016-11-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.65.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Notes Section allow for inclusion of clinical documentation which does not fit precisely within any other C-CDA section. Multiple Notes sections may be included in a document provided they each include different types of note content as indicated by a different section.code.The Notes Section SHOULD NOT be used in place of a more specific C-CDA section. For example, notes about procedure should be placed within the Procedures Section, not a Notes Section.When a Notes Section is present, Note Activity entries contain structured information about the note information allowing it to be more machine processable.</p></div>
+    <div id="description">
+      <p>The Notes Section allow for inclusion of clinical documentation which does not fit precisely within any other
+        C-CDA section. Multiple Notes sections may be included in a document provided they each include different types
+        of note content as indicated by a different section.code.The Notes Section SHOULD NOT be used in place of a more
+        specific C-CDA section. For example, notes about procedure should be placed within the Procedures Section, not a
+        Notes Section.When a Notes Section is present, Note Activity entries contain structured information about the
+        note information allowing it to be more machine processable.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.202.html">Note Activity</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.202.html">Note Activity</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:3250-16935)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.65"</b><b> (CONF:3250-16936)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-11-01"</b><b> (CONF:3250-16938)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Note Types<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.68/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.68</a></b><b> DYNAMIC</b><b> (CONF:3250-16892)</b>.</li>
-<li class="list-group-item"> This title should reflect the kind of notes included in this section, corresponding to the code.<br/><b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:3250-16891)</b>.</li>
-<li class="list-group-item"> The narrative SHOULD contain human-readable representations using standard CDA narrative markup of each note to ensure widest compatibility with receivers. While allowed by CDA, the use of &lt;renderMultiMedia&gt; elements, which contain a referencedObject attribute pointing to an &lt;observationMedia&gt; or &lt;regionOfInterest&gt; element in the discrete entries, is discouraged in Note Sections because rendering support for these elements is not widespread <br/><b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:3250-16894)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:3250-16904)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Note Activity<b> (identifier: 2.16.840.1.113883.10.20.22.4.202)</b><b> (CONF:3250-16905)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:3250-16935)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.65"</b><b>
+              (CONF:3250-16936)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-11-01"</b><b> (CONF:3250-16938)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet Note Types<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.68/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.68</a></b><b> DYNAMIC</b><b>
+          (CONF:3250-16892)</b>.</li>
+      <li class="list-group-item"> This title should reflect the kind of notes included in this section, corresponding
+        to the code.<br /><b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:3250-16891)</b>.</li>
+      <li class="list-group-item"> The narrative SHOULD contain human-readable representations using standard CDA
+        narrative markup of each note to ensure widest compatibility with receivers. While allowed by CDA, the use of
+        &lt;renderMultiMedia&gt; elements, which contain a referencedObject attribute pointing to an
+        &lt;observationMedia&gt; or &lt;regionOfInterest&gt; element in the discrete entries, is discouraged in Note
+        Sections because rendering support for these elements is not widespread <br /><b>SHALL</b> contain exactly one
+        [1..1] <b>text</b><b> (CONF:3250-16894)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:3250-16904)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Note Activity<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.202)</b><b> (CONF:3250-16905)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Notes%20Section_2.16.840.1.113883.10.20.22.2.65/Note%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Notes Section</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Notes%20Section_2.16.840.1.113883.10.20.22.2.65/Note%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Notes Section</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Notes"><i class="fas fa-external-link-alt"></i> Notes</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Notes"><i class="fas fa-external-link-alt"></i> Notes</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.7.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.7.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,125 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedures Section (entries required) (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.7.1, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.7.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedures Section (entries required) (V2) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.7.1, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.7.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section describes all interventional, surgical, diagnostic, or therapeutic procedures or treatments pertinent to the patient historically at the time the document is generated. The section should include notable procedures, but can contain all procedures for the period of time being summarized. The common notion of "procedure" is broader than that specified by the HL7 Version 3 Reference Information Model (RIM), therefore this section contains procedure templates represented with three RIM classes: Act. Observation, and Procedure. Procedure act is for procedures that alter the physical condition of a patient (e.g., splenectomy). Observation act is for procedures that result in new information about a patient but do not cause physical alteration (e.g., EEG). Act is for all other types of procedures (e.g., dressing change).</p></div>
+    <div id="description">
+      <p>This section describes all interventional, surgical, diagnostic, or therapeutic procedures or treatments
+        pertinent to the patient historically at the time the document is generated. The section should include notable
+        procedures, but can contain all procedures for the period of time being summarized. The common notion of
+        "procedure" is broader than that specified by the HL7 Version 3 Reference Information Model (RIM), therefore
+        this section contains procedure templates represented with three RIM classes: Act. Observation, and Procedure.
+        Procedure act is for procedures that alter the physical condition of a patient (e.g., splenectomy). Observation
+        act is for procedures that result in new information about a patient but do not cause physical alteration (e.g.,
+        EEG). Act is for all other types of procedures (e.g., dressing change).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.2.html">Continuity of Care Document (CCD)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Procedures Section (entries optional) (V2) template (urn:hl7ii:2.16.840.1.113883.10.20.22.2.7:2014-06-09)</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1098-32876)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7891)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.7.1"</b><b> (CONF:1098-10447)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32533)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15425)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"47519-4"</b> History of Procedures<b> (CONF:1098-15426)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31138)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7893)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7894)</b>.</li>
-<li class="list-group-item"><p>If section/@nullFlavor is not present <br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:1098-7895)</b> such that it<ul><li><b>MAY</b> contain zero or one [0..1]  Procedure Activity Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.12)</b><b> (CONF:1098-32877)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1]  Procedure Activity Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.13)</b><b> (CONF:1098-32878)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1]  Procedure Activity Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-15512)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Procedures Section (entries optional) (V2) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.2.7:2014-06-09)</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"NI"</b> No information
+        (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+          (CONF:1098-32876)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7891)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.7.1"</b><b>
+              (CONF:1098-10447)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32533)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15425)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"47519-4"</b> History of Procedures<b>
+              (CONF:1098-15426)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31138)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-7893)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7894)</b>.</li>
+      <li class="list-group-item">
+        <p>If section/@nullFlavor is not present <br></p> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b>
+          (CONF:1098-7895)</b> such that it<ul>
+          <li><b>MAY</b> contain zero or one [0..1] Procedure Activity Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.12)</b><b> (CONF:1098-32877)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] Procedure Activity Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.13)</b><b> (CONF:1098-32878)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] Procedure Activity Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-15512)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedures%20Section%20(entries%20required)%20(V2)_2.16.840.1.113883.10.20.22.2.7.1/Procedures%20Section%20(entries%20required)%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedures Section (entries required) (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedures%20Section%20(entries%20required)%20(V2)_2.16.840.1.113883.10.20.22.2.7.1/Procedures%20Section%20(entries%20required)%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedures Section (entries required) (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.7.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.7.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,122 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedures Section (entries optional) (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.7, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.7.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedures Section (entries optional) (V2) <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.22.2.7, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.7.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section describes all interventional, surgical, diagnostic, or therapeutic procedures or treatments pertinent to the patient historically at the time the document is generated. The section should include notable procedures, but can contain all procedures for the period of time being summarized. The common notion of "procedure" is broader than that specified by the HL7 Version 3 Reference Information Model (RIM), therefore this section contains procedure templates represented with three RIM classes: Act, Observation, and Procedure. Procedure Activity Procedure (V2) is for procedures that alter the physical condition of a patient (e.g., splenectomy). Procedure Activity Observation (V2) is for procedures that result in new information about a patient but do not cause physical alteration (e.g., EEG). Procedure Activity Act (V2) is for all other types of procedures (e.g., dressing change).</p></div>
+    <div id="description">
+      <p>This section describes all interventional, surgical, diagnostic, or therapeutic procedures or treatments
+        pertinent to the patient historically at the time the document is generated. The section should include notable
+        procedures, but can contain all procedures for the period of time being summarized. The common notion of
+        "procedure" is broader than that specified by the HL7 Version 3 Reference Information Model (RIM), therefore
+        this section contains procedure templates represented with three RIM classes: Act, Observation, and Procedure.
+        Procedure Activity Procedure (V2) is for procedures that alter the physical condition of a patient (e.g.,
+        splenectomy). Procedure Activity Observation (V2) is for procedures that result in new information about a
+        patient but do not cause physical alteration (e.g., EEG). Procedure Activity Act (V2) is for all other types of
+        procedures (e.g., dressing change).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.8.html">Discharge Summary (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-6270)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.7"</b><b> (CONF:1098-6271)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32532)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15423)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"47519-4"</b> History of Procedures<b> (CONF:1098-15424)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31139)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-17184)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-6273)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-6274)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-15509)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-6278)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.13)</b><b> (CONF:1098-15510)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8533)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.12)</b><b> (CONF:1098-15511)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-6270)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.7"</b><b>
+              (CONF:1098-6271)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32532)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15423)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"47519-4"</b> History of Procedures<b>
+              (CONF:1098-15424)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b> (CodeSystem: <b>LOINC
+              2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31139)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:1098-17184)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-6273)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-6274)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-15509)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-6278)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.13)</b><b> (CONF:1098-15510)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-8533)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.12)</b><b> (CONF:1098-15511)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.8.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.8.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,95 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Assessment Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.8, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.8.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Assessment Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.8, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.2.8.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Assessment Section (also referred to as 'impression' or 'diagnoses' outside of the context of CDA) represents the clinician's conclusions and working assumptions that will guide treatment of the patient. The assessment may be a list of specific disease entities or a narrative block.</p></div>
+    <div id="description">
+      <p>The Assessment Section (also referred to as 'impression' or 'diagnoses' outside of the context of CDA)
+        represents the clinician's conclusions and working assumptions that will guide treatment of the patient. The
+        assessment may be a list of specific disease entities or a narrative block.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7711)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.8"</b><b> (CONF:81-10382)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-14757)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"51848-0"</b> Assessments<b> (CONF:81-14758)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26472)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-16774)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7713)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7711)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.8"</b><b>
+              (CONF:81-10382)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-14757)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"51848-0"</b> Assessments<b>
+              (CONF:81-14758)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26472)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-16774)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-7713)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20Section_2.16.840.1.113883.10.20.22.2.8/Assessment%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Assessment Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20Section_2.16.840.1.113883.10.20.22.2.8/Assessment%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Assessment Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.2.9.html
+++ b/templates/2.16.840.1.113883.10.20.22.2.9.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,106 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Assessment and Plan Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.9, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.9.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Assessment and Plan Section (V2) <small class="text-muted">[section, 2.16.840.1.113883.10.20.22.2.9,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.2.9.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This section represents the clinician's conclusions and working assumptions that will guide treatment of the patient. The Assessment and Plan Section may be combined or separated to meet local policy requirements.See also the Assessment Section: templateId 2.16.840.1.113883.10.20.22.2.8 and Plan of Treatment Section (V2): templateId 2.16.840.1.113883.10.20.22.2.10</p></div>
+    <div id="description">
+      <p>This section represents the clinician's conclusions and working assumptions that will guide treatment of the
+        patient. The Assessment and Plan Section may be combined or separated to meet local policy requirements.See also
+        the Assessment Section: templateId 2.16.840.1.113883.10.20.22.2.8 and Plan of Treatment Section (V2): templateId
+        2.16.840.1.113883.10.20.22.2.10</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.13.html">Transfer Summary (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7705)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.9"</b><b> (CONF:1098-10381)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32583)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15353)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"51847-2"</b> Assessment and Plan<b> (CONF:1098-15354)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32141)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7707)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-7708)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.39)</b><b> (CONF:1098-15448)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7705)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.2.9"</b><b>
+              (CONF:1098-10381)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32583)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15353)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"51847-2"</b> Assessment and Plan<b>
+              (CONF:1098-15354)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32141)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:1098-7707)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entry</b><b> (CONF:1098-7708)</b> such that
+        it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.39)</b><b> (CONF:1098-15448)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20and%20Plan%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.9/Assessment%20and%20Plan%20Section%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Assessment and Plan Section (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20and%20Plan%20Section%20(V2)_2.16.840.1.113883.10.20.22.2.9/Assessment%20and%20Plan%20Section%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Assessment and Plan Section (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,150 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Result Organizer (V3) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Result Organizer (V3) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.1, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.1.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template provides a mechanism for grouping result observations. It contains information applicable to all of the contained result observations. The Result Organizer code categorizes the contained results into one of several commonly accepted values (e.g., 'Hematology', 'Chemistry', 'Nuclear Medicine').</p><p>If any Result Observation within the organizer has a statusCode of "active", the Result Organizer must also have a statusCode of "active".</p></div>
+    <div id="description">
+      <p>This template provides a mechanism for grouping result observations. It contains information applicable to all
+        of the contained result observations. The Result Organizer code categorizes the contained results into one of
+        several commonly accepted values (e.g., 'Hematology', 'Chemistry', 'Nuclear Medicine').</p>
+      <p>If any Result Observation within the organizer has a statusCode of "active", the Result Organizer must also
+        have a statusCode of "active".</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.3.html">Results Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.2.html">Result Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.3.html">Results Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.3.1.html">Results Section (entries required) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.2.html">Result Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-7121)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-7122)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7126)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.1"</b><b> (CONF:1198-9134)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32588)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7127)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-7128)</b>.<ul><li><p><strong>SHOULD</strong> be selected from LOINC (codeSystem <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) <strong>OR</strong> SNOMED CT (codeSystem <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be selected from CPT-4 (codeSystem <a href="https://terminology.hl7.org/CodeSystem-CPT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) (CONF:1198-19218).</p></li></ul><ul><li><p>Laboratory results <strong>SHOULD</strong> be from LOINC (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or other constrained terminology named by the US Department of Health and Human Services Office of National Coordinator or other federal agency (CONF:1198-19219).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7123)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Result Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.39/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.39</a></b><b> STATIC</b><b> (CONF:1198-14848)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1198-31865)</b>.<br>Note: The effectiveTime is an interval that spans the effectiveTimes of the contained result observations. Because all contained result observations have a required time stamp, it is not required that this effectiveTime be populated.<ul><li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-32488)</b>.</li></ul><ul><li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1198-32489)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31149)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-7124)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Result Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.2)</b><b> (CONF:1198-14850)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b> (CodeSystem: <b>HL7ActClass
+          <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1198-7121)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-7122)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7126)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.1"</b><b>
+              (CONF:1198-9134)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32588)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7127)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-7128)</b>.<ul>
+          <li>
+            <p><strong>SHOULD</strong> be selected from LOINC (codeSystem <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) <strong>OR</strong> SNOMED CT
+              (codeSystem <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be
+              selected from CPT-4 (codeSystem <a href="https://terminology.hl7.org/CodeSystem-CPT.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) (CONF:1198-19218).
+            </p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>Laboratory results <strong>SHOULD</strong> be from LOINC (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or other constrained terminology
+              named by the US Department of Health and Human Services Office of National Coordinator or other federal
+              agency (CONF:1198-19219).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7123)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet Result Status<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.39/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.39</a></b><b>
+              STATIC</b><b> (CONF:1198-14848)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1198-31865)</b>.<br>Note: The effectiveTime is an interval that spans the effectiveTimes of the
+        contained result observations. Because all contained result observations have a required time stamp, it is not
+        required that this effectiveTime be populated.<ul>
+          <li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>low</b><b>
+              (CONF:1198-32488)</b>.</li>
+        </ul>
+        <ul>
+          <li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>high</b><b>
+              (CONF:1198-32489)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31149)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-7124)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Result Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.2)</b><b> (CONF:1198-14850)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Result%20Organizer%20(V3)_2.16.840.1.113883.10.20.22.4.1/Result%20Organizer%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Result Organizer (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Result%20Organizer%20(V3)_2.16.840.1.113883.10.20.22.4.1/Result%20Organizer%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Result Organizer (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Results"><i class="fas fa-external-link-alt"></i> Results</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Results"><i class="fas fa-external-link-alt"></i> Results</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.108.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.108.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,118 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Advance Directive Organizer (V2) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.108, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.108.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Advance Directive Organizer (V2) <small class="text-muted">[organizer,
+        2.16.840.1.113883.10.20.22.4.108, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.108.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement groups a set of advance directive observations.</p></div>
+    <div id="description">
+      <p>This clinical statement groups a set of advance directive observations.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.21.1.html">Advance Directives Section (entries required) (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries
+              optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.21.1.html">Advance Directives Section (entries
+              required) (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> Cluster (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-28410)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-28411)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28412)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.108"</b><b> (CONF:1198-28413)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32876)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28414)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-28415)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"45473-6"</b> Advance directive - living will <b> (CONF:1198-31230)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-31231)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-28418)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1198-31346)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-32407)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-28420)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Advance Directive Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-28421)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> Cluster
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+          (CONF:1198-28410)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-28411)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28412)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.108"</b><b>
+              (CONF:1198-28413)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32876)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28414)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-28415)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"45473-6"</b> Advance directive - living
+            will <b> (CONF:1198-31230)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-31231)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-28418)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1198-31346)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-32407)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-28420)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Advance Directive Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-28421)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Advance%20Directive%20Organizer%20(V2)_2.16.840.1.113883.10.20.22.4.108/Advance%20Directive%20Organizer%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Advance Directive Organizer (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Advance%20Directive%20Organizer%20(V2)_2.16.840.1.113883.10.20.22.4.108/Advance%20Directive%20Organizer%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Advance Directive Organizer (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.109.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.109.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,113 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Characteristics of Home Environment <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.109, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.109.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Characteristics of Home Environment <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.109, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.109.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the patient's home environment including, but not limited to, type of residence (trailer, single family home, assisted living), living arrangement (e.g., alone, with parents), and housing status (e.g., evicted, homeless, home owner).</p></div>
+    <div id="description">
+      <p>This template represents the patient's home environment including, but not limited to, type of residence
+        (trailer, single family home, assisted living), living arrangement (e.g., alone, with parents), and housing
+        status (e.g., evicted, homeless, home owner).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-27890)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-27891)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-27892)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.109"</b><b> (CONF:1098-27893)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-27894)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31352)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75274-1"</b> Characteristics of residence<b> (CONF:1098-31353)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31354)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-27901)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-27902)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Residence and Accommodation Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.49/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.49</a></b><b> DYNAMIC</b><b> (CONF:1098-28823)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-27890)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-27891)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-27892)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.109"</b><b>
+              (CONF:1098-27893)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-27894)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31352)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75274-1"</b> Characteristics of
+            residence<b> (CONF:1098-31353)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31354)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-27901)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-27902)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet Residence and Accommodation Type<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.49/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.49</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-28823)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Characteristics%20of%20Home%20Environment_2.16.840.1.113883.10.20.22.4.109/Characteristics%20of%20Home%20Environment%20Example.xml"><i class="fab fa-github"></i>&nbsp;Characteristics of Home Environment Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Characteristics%20of%20Home%20Environment_2.16.840.1.113883.10.20.22.4.109/Characteristics%20of%20Home%20Environment%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Characteristics of Home Environment Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.110.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.110.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,117 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Progress Toward Goal Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.110, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.110.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Progress Toward Goal Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.110, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.110.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a patient's progress toward a goal. It can describe whether a goal has been achieved or not and can also describe movement a patient is making toward the achievement of a goal (e.g., "Goal not achieved - no discernible change", "Goal not achieved - progressing toward goal", "Goal not achieved - declining from goal").</p><p>In the Care Planning workflow, the judgment about how well the person is progressing towards the goal is based on the observations made about the status of the patient with respect to interventions performed in the pursuit of achieving that goal.</p><p>For example, an observation outcome of a blood oxygen saturation level of 95% is related to the goal of "Maintain Pulse Ox greater than 92" and in this case the Progress Toward Goal Observation template would record that the related goal has been achieved.</p></div>
+    <div id="description">
+      <p>This template represents a patient's progress toward a goal. It can describe whether a goal has been achieved
+        or not and can also describe movement a patient is making toward the achievement of a goal (e.g., "Goal not
+        achieved - no discernible change", "Goal not achieved - progressing toward goal", "Goal not achieved - declining
+        from goal").</p>
+      <p>In the Care Planning workflow, the judgment about how well the person is progressing towards the goal is based
+        on the observations made about the status of the patient with respect to interventions performed in the pursuit
+        of achieving that goal.</p>
+      <p>For example, an observation outcome of a blood oxygen saturation level of 95% is related to the goal of
+        "Maintain Pulse Ox greater than 92" and in this case the Progress Toward Goal Observation template would record
+        that the related goal has been achieved.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31418)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31419)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31420)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.110"</b><b> (CONF:1098-31421)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31422)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31423)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b> (CONF:1098-31424)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-31425)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31609)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31610)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Goal Achievement<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.55/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.55</a></b><b> DYNAMIC</b><b> (CONF:1098-31426)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31418)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31419)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31420)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.110"</b><b>
+              (CONF:1098-31421)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31422)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31423)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b>
+              (CONF:1098-31424)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:1098-31425)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31609)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31610)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Goal Achievement<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.55/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.55</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-31426)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Progress%20Toward%20Goal%20Observation_2.16.840.1.113883.10.20.22.4.110/Progress%20Toward%20Goal%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Progress Toward Goal Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Progress%20Toward%20Goal%20Observation_2.16.840.1.113883.10.20.22.4.110/Progress%20Toward%20Goal%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Progress Toward Goal Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.111.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.111.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,115 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Cultural and Religious Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.111, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.111.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Cultural and Religious Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.111, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.111.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a patient'??s spiritual, religious, and cultural belief practices, such as a kosher diet or fasting ritual. religiousAffiliationCode in the document header captures only the patient'??s religious affiliation.</p></div>
+    <div id="description">
+      <p>This template represents a patient'??s spiritual, religious, and cultural belief practices, such as a kosher
+        diet or fasting ritual. religiousAffiliationCode in the document header captures only the patient'??s religious
+        affiliation.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-27924)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-27925)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-27926)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.111"</b><b> (CONF:1098-27927)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-27928)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-27929)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75281-6"</b> Personal belief<b> (CONF:1098-27930)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-27931)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-27936)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-27937)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-28442)</b>.<ul><li><p>If xsi:type is CD, <strong>SHALL</strong> contain exactly one [1..1] @codeSystem="2.16.840.1.113883.6.96" (CodeSystem: SNOMED-CT  2.16.840.1.113883.6.96 STATIC) (CONF:1098-32487).</p></li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-27924)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-27925)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-27926)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.111"</b><b>
+              (CONF:1098-27927)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-27928)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-27929)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75281-6"</b> Personal belief<b>
+              (CONF:1098-27930)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-27931)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-27936)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-27937)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-28442)</b>.<ul>
+          <li>
+            <p>If xsi:type is CD, <strong>SHALL</strong> contain exactly one [1..1] @codeSystem="2.16.840.1.113883.6.96"
+              (CodeSystem: SNOMED-CT 2.16.840.1.113883.6.96 STATIC) (CONF:1098-32487).</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Cultural%20and%20Religious%20Observation_2.16.840.1.113883.10.20.22.4.111/Cultural%20and%20Religious%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Cultural and Religious Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Cultural%20and%20Religious%20Observation_2.16.840.1.113883.10.20.22.4.111/Cultural%20and%20Religious%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Cultural and Religious Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.113.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.113.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,110 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Prognosis Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.113, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.113.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Prognosis Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.113, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.22.4.113.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the patient's prognosis, which must be associated with a problem observation. It may serve as an alert to scope intervention plans.The effectiveTime represents the clinically relevant time of the observation. The observation/value is not constrained and can represent the expected life duration in PQ, an anticipated course of the disease in text, or coded term.</p></div>
+    <div id="description">
+      <p>This template represents the patient's prognosis, which must be associated with a problem observation. It may
+        serve as an alert to scope intervention plans.The effectiveTime represents the clinically relevant time of the
+        observation. The observation/value is not constrained and can represent the expected life duration in PQ, an
+        anticipated course of the disease in text, or coded term.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-29035)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-29036)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29037)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.113"</b><b> (CONF:1098-29038)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29039)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75328-5"</b> Prognosis<b> (CONF:1098-29468)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31349)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31350)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31351)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-31123)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-29469)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-29035)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-29036)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29037)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.113"</b><b>
+              (CONF:1098-29038)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29039)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75328-5"</b> Prognosis<b>
+              (CONF:1098-29468)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31349)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31350)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31351)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-31123)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-29469)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Prognosis%20Observation_2.16.840.1.113883.10.20.22.4.113/Prognosis,%20Coded%20Example.xml"><i class="fab fa-github"></i>&nbsp;Prognosis, Coded Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Prognosis%20Observation_2.16.840.1.113883.10.20.22.4.113/Prognosis,%20Free%20Text%20Example.xml"><i class="fab fa-github"></i>&nbsp;Prognosis, Free Text Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Prognosis%20Observation_2.16.840.1.113883.10.20.22.4.113/Prognosis,%20Coded%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Prognosis, Coded Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Prognosis%20Observation_2.16.840.1.113883.10.20.22.4.113/Prognosis,%20Free%20Text%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Prognosis, Free Text Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.114.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.114.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,60 +52,199 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Longitudinal Care Wound Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.114, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.114.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Longitudinal Care Wound Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.114, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.114.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents acquired or surgical wounds and is not intended to encompass all wound types. The template applies to wounds such as pressure ulcers, surgical incisions, and deep tissue injury wounds. Information in this template may include information about the wound measurements characteristics.</p></div>
+    <div id="description">
+      <p>This template represents acquired or surgical wounds and is not intended to encompass all wound types. The
+        template applies to wounds such as pressure ulcers, surgical incisions, and deep tissue injury wounds.
+        Information in this template may include information about the wound measurements characteristics.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.133.html">Wound Measurement Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.134.html">Wound Characteristic</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.76.html">Number of Pressure Ulcers Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.77.html">Highest Pressure Ulcer Stage</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.2.10.html">Physical Exam Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.133.html">Wound Measurement Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.134.html">Wound Characteristic</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.76.html">Number of Pressure Ulcers Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.77.html">Highest Pressure Ulcer Stage</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Problem Observation (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.4.4:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-31012)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1198-31013)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-32947)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.114"</b><b> (CONF:1198-29474)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32913)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-29476)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> assertion<b> (CONF:1198-29477)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1198-31010)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Wound Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.6/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.6</a></b><b> DYNAMIC</b><b> (CONF:1198-29485)</b>.</li>
-<li class="list-group-item"><p>If targetSite/qualifierCode name/value pairs are used, care must be taken to avoid conflict with the SNOMED-CT body structure code used in observation/value.  SNOMED-CT body structure codes are often pre-coordinated with laterality.</p> <b>SHOULD</b> contain zero or one [0..1] <b>targetSiteCode</b>, which <b>SHOULD</b> be selected from ValueSet Body Site Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b> DYNAMIC</b><b> (CONF:1198-29488)</b> such that it<ul><li><b>MAY</b> contain zero or more [0..*] <b>qualifier</b><b> (CONF:1198-29490)</b>.</li><ul><li>The qualifier, if present, <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:1198-29491)</b>.</li><ul><li>This name <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"272741003"</b> laterality<b> (CONF:1198-29492)</b>.</li></ul><ul><li>This name <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-31524)</b>.</li></ul></ul><ul><li>The qualifier, if present, <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1198-29493)</b>.</li><ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet TargetSite Qualifiers<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.37/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.37</a></b><b> DYNAMIC</b><b> (CONF:1198-29494)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31542)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-29495)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-29496)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Wound Measurement Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.133)</b><b> (CONF:1198-29497)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-29503)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b><b> (CONF:1198-29504)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Wound Characteristic<b> (identifier: 2.16.840.1.113883.10.20.22.4.134)</b><b> (CONF:1198-29505)</b>.</li></ul></li>
-<li class="list-group-item"><p>When the wound observed is a type of pressure ulcer, then this template SHOULD contain an entry for the Number of Pressure Ulcers.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31890)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31891)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Number of Pressure Ulcers Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.76)</b><b> (CONF:1198-31892)</b>.</li></ul></li>
-<li class="list-group-item"><p>When the wound observed is a type of pressure ulcer, then this template SHOULD contain an entry for the Highest Pressure Ulcer Stage.<br></p> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1198-31893)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31894)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Highest Pressure Ulcer Stage<b> (identifier: 2.16.840.1.113883.10.20.22.4.77)</b><b> (CONF:1198-31919)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Problem Observation (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.4.4:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-31012)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1198-31013)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-32947)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.114"</b><b>
+              (CONF:1198-29474)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32913)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-29476)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> assertion<b>
+              (CONF:1198-29477)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:1198-31010)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet Wound Type<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.6/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.6</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-29485)</b>.</li>
+      <li class="list-group-item">
+        <p>If targetSite/qualifierCode name/value pairs are used, care must be taken to avoid conflict with the
+          SNOMED-CT body structure code used in observation/value. SNOMED-CT body structure codes are often
+          pre-coordinated with laterality.</p> <b>SHOULD</b> contain zero or one [0..1] <b>targetSiteCode</b>, which
+        <b>SHOULD</b> be selected from ValueSet Body Site Value Set<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b>
+          DYNAMIC</b><b> (CONF:1198-29488)</b> such that it<ul>
+          <li><b>MAY</b> contain zero or more [0..*] <b>qualifier</b><b> (CONF:1198-29490)</b>.</li>
+          <ul>
+            <li>The qualifier, if present, <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:1198-29491)</b>.
+            </li>
+            <ul>
+              <li>This name <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"272741003"</b> laterality<b>
+                  (CONF:1198-29492)</b>.</li>
+            </ul>
+            <ul>
+              <li>This name <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+                (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-31524)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>The qualifier, if present, <b>SHALL</b> contain exactly one [1..1] <b>value</b><b>
+                (CONF:1198-29493)</b>.</li>
+            <ul>
+              <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from
+                ValueSet TargetSite Qualifiers<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.37/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.37</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-29494)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31542)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-29495)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-29496)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Wound Measurement Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.133)</b><b> (CONF:1198-29497)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-29503)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b><b> (CONF:1198-29504)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Wound Characteristic<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.134)</b><b> (CONF:1198-29505)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When the wound observed is a type of pressure ulcer, then this template SHOULD contain an entry for the
+          Number of Pressure Ulcers.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-31890)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31891)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Number of Pressure Ulcers Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.76)</b><b> (CONF:1198-31892)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When the wound observed is a type of pressure ulcer, then this template SHOULD contain an entry for the
+          Highest Pressure Ulcer Stage.<br></p> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1198-31893)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31894)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Highest Pressure Ulcer Stage<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.77)</b><b> (CONF:1198-31919)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Longitudinal%20Care%20Wound%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.114/Longitudinal%20Care%20Wound%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Longitudinal Care Wound Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Longitudinal%20Care%20Wound%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.114/Longitudinal%20Care%20Wound%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Longitudinal Care Wound Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.115.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.115.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,103 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">External Document Reference <small class="text-muted">[externalDocument, 2.16.840.1.113883.10.20.22.4.115, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.115.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">External Document Reference <small class="text-muted">[externalDocument,
+        2.16.840.1.113883.10.20.22.4.115, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.115.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>Where it is necessary to reference an external clinical document, the External Document Reference template can be used to reference this external document. However, if the containing document is appending to or replacing another document in the same set, that relationship is set in the header, using ClinicalDocument/relatedDocument.</p></div>
+    <div id="description">
+      <p>Where it is necessary to reference an external clinical document, the External Document Reference template can
+        be used to reference this external document. However, if the containing document is appending to or replacing
+        another document in the same set, that relationship is set in the header, using
+        ClinicalDocument/relatedDocument.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"DOCCLIN"</b> Clinical Document (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31931)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31932)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32748)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.115"</b><b> (CONF:1098-32750)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32749)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1098-32751)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31933)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>setId</b><b> (CONF:1098-32752)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>versionNumber</b><b> (CONF:1098-32753)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"DOCCLIN"</b> Clinical
+        Document (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+          (CONF:1098-31931)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b>
+          (CONF:1098-31932)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32748)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.115"</b><b>
+              (CONF:1098-32750)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32749)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1098-32751)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31933)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>setId</b><b> (CONF:1098-32752)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>versionNumber</b><b>
+          (CONF:1098-32753)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/External%20Document%20Reference_2.16.840.1.113883.10.20.22.4.115/External%20Document%20Reference%20Example.xml"><i class="fab fa-github"></i>&nbsp;External Document Reference Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/External%20Document%20Reference_2.16.840.1.113883.10.20.22.4.115/External%20Document%20Reference%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;External Document Reference Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.118.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.118.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,104 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Substance Administered Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.118, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.118.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Substance Administered Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.118, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.118.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the administration course in a series. The entryRelationship/sequenceNumber in the containing template shows the order of this particular administration in that medication series.</p></div>
+    <div id="description">
+      <p>This template represents the administration course in a series. The entryRelationship/sequenceNumber in the
+        containing template shows the order of this particular administration in that medication series.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31500)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31501)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31502)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.118"</b><b> (CONF:1098-31503)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31504)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31506)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"416118004"</b> Administration<b> (CONF:1098-31507)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1098-31508)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31505)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-31509)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+          (CONF:1098-31500)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b>
+          (CONF:1098-31501)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31502)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.118"</b><b>
+              (CONF:1098-31503)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31504)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31506)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"416118004"</b> Administration<b>
+              (CONF:1098-31507)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1098-31508)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b>=<b>"completed"</b>
+        Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b>
+          (CONF:1098-31505)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-31509)</b>.
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Substance%20Administered%20Act_2.16.840.1.113883.10.20.22.4.118/Substance%20Administered%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Substance Administered Act Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Substance%20Administered%20Act_2.16.840.1.113883.10.20.22.4.118/Substance%20Administered%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Substance Administered Act Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i> Medications</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i>
+          Medications</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.119.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.119.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,187 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Author Participation <small class="text-muted">[author, 2.16.840.1.113883.10.20.22.4.119, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.119.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Author Participation <small class="text-muted">[author, 2.16.840.1.113883.10.20.22.4.119, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.119.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the Author Participation (including the author timestamp). CDA R2 requires that Author and Author timestamp be asserted in the document header. From there, authorship propagates to contained sections and contained entries, unless explicitly overridden.</p><p>The Author Participation template was added to those templates in scope for analysis in R2. Although it is not explicitly stated in all templates the Author Participation template can be used in any template.</p></div>
+    <div id="description">
+      <p>This template represents the Author Participation (including the author timestamp). CDA R2 requires that Author
+        and Author timestamp be asserted in the document header. From there, authorship propagates to contained sections
+        and contained entries, unless explicitly overridden.</p>
+      <p>The Author Participation template was added to those templates in scope for analysis in R2. Although it is not
+        explicitly stated in all templates the Author Participation template can be used in any template.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.64.html">Comment Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.127.html">Sensory Status</a><br><a href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.138.html">Nutrition Assessment</a><br><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.66.html">Functional Status Organizer (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a href="2.16.840.1.113883.10.20.22.4.140.html">Patient Referral Act</a><br><a href="2.16.840.1.113883.10.20.22.4.78.html">Smoking Status - Meaningful Use (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.27.html">Vital Sign Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.85.html">Tobacco Use (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.129.html">Planned Coverage</a><br><a href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.26.html">Vital Signs Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.2.html">Result Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.38.html">Social History Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.108.html">Advance Directive Organizer (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.30.html">Allergy Concern Act (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.64.html">Comment Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.127.html">Sensory Status</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.138.html">Nutrition Assessment</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.66.html">Functional Status Organizer (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.140.html">Patient Referral Act</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.78.html">Smoking Status - Meaningful Use (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.27.html">Vital Sign Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.85.html">Tobacco Use (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.129.html">Planned Coverage</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.26.html">Vital Signs Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.2.html">Result Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.38.html">Social History Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.108.html">Advance Directive Organizer (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.30.html">Allergy Concern Act (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32017)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.119"</b><b> (CONF:1098-32018)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:1098-31471)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b> (CONF:1098-31472)</b>.<ul><li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31473)</b>.<br>Note: This id may be set equal to (a pointer to) an id on a participant elsewhere in the document (header or entries) or a new author participant can be described here. If the id is pointing to a participant already described elsewhere in the document, assignedAuthor/id is sufficient to identify this participant and none of the remaining details of assignedAuthor are required to be set. Application Software must be responsible for resolving the identifier back to its original object and then rendering the information in the correct place in the containing section's narrative text. This id must be a pointer to another author participant.</li><ul><li><p>If the ID isn't referencing an author described elsewhere in the document, then the author components required in US Realm Header are required here as well (CONF:1098-32628).</p></li></ul></ul><ul><li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1098-31671)</b>.</li><ul><li><p>If the content is patient authored the code <strong>SHOULD</strong> be selected from Personal And Legal Relationship Role Type (2.16.840.1.113883.11.20.12.1) (CONF:1098-32315).</p></li></ul></ul><ul><li>This assignedAuthor <b>MAY</b> contain zero or one [0..1] <b>assignedPerson</b><b> (CONF:1098-31474)</b>.</li><ul><li>The assignedPerson, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b> (CONF:1098-31475)</b>.</li></ul></ul><ul><li>This assignedAuthor <b>MAY</b> contain zero or one [0..1] <b>representedOrganization</b><b> (CONF:1098-31476)</b>.</li><ul><li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>id</b><b> (CONF:1098-31478)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b> (CONF:1098-31479)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1098-31480)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>addr</b><b> (CONF:1098-31481)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32017)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.119"</b><b>
+              (CONF:1098-32018)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:1098-31471)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b>
+          (CONF:1098-31472)</b>.<ul>
+          <li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31473)</b>.<br>Note:
+            This id may be set equal to (a pointer to) an id on a participant elsewhere in the document (header or
+            entries) or a new author participant can be described here. If the id is pointing to a participant already
+            described elsewhere in the document, assignedAuthor/id is sufficient to identify this participant and none
+            of the remaining details of assignedAuthor are required to be set. Application Software must be responsible
+            for resolving the identifier back to its original object and then rendering the information in the correct
+            place in the containing section's narrative text. This id must be a pointer to another author participant.
+          </li>
+          <ul>
+            <li>
+              <p>If the ID isn't referencing an author described elsewhere in the document, then the author components
+                required in US Realm Header are required here as well (CONF:1098-32628).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected
+            from ValueSet Healthcare Provider Taxonomy<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b>
+              (CONF:1098-31671)</b>.</li>
+          <ul>
+            <li>
+              <p>If the content is patient authored the code <strong>SHOULD</strong> be selected from Personal And Legal
+                Relationship Role Type (2.16.840.1.113883.11.20.12.1) (CONF:1098-32315).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This assignedAuthor <b>MAY</b> contain zero or one [0..1] <b>assignedPerson</b><b> (CONF:1098-31474)</b>.
+          </li>
+          <ul>
+            <li>The assignedPerson, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b>
+                (CONF:1098-31475)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This assignedAuthor <b>MAY</b> contain zero or one [0..1] <b>representedOrganization</b><b>
+              (CONF:1098-31476)</b>.</li>
+          <ul>
+            <li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>id</b><b>
+                (CONF:1098-31478)</b>.</li>
+          </ul>
+          <ul>
+            <li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b>
+                (CONF:1098-31479)</b>.</li>
+          </ul>
+          <ul>
+            <li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>telecom</b><b>
+                (CONF:1098-31480)</b>.</li>
+          </ul>
+          <ul>
+            <li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>addr</b><b>
+                (CONF:1098-31481)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Author%20Participation_2.16.840.1.113883.10.20.22.4.119/Existing%20Author%20Reference%20Example.xml"><i class="fab fa-github"></i>&nbsp;Existing Author Reference Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Author%20Participation_2.16.840.1.113883.10.20.22.4.119/New%20Author%20Participant%20Example.xml"><i class="fab fa-github"></i>&nbsp;New Author Participant Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Author%20Participation_2.16.840.1.113883.10.20.22.4.119/Existing%20Author%20Reference%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Existing Author Reference Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Author%20Participation_2.16.840.1.113883.10.20.22.4.119/New%20Author%20Participant%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;New Author Participant Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.12.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.12.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,61 +52,279 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Activity Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.12, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.12.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Activity Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.12, release
+        2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.12.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents any act that cannot be classified as an observation or procedure according to the HL7 RIM. Examples of these acts are a dressing change, teaching or feeding a patient, or providing comfort measures.The common notion of "procedure" is broader than that specified by the HL7 Version 3 Reference Information Model (RIM). Procedure templates can be represented with various RIM classes: act (e.g., dressing change), observation (e.g., EEG), procedure (e.g., splenectomy).</p></div>
+    <div id="description">
+      <p>This template represents any act that cannot be classified as an observation or procedure according to the HL7
+        RIM. Examples of these acts are a dressing change, teaching or feeding a patient, or providing comfort
+        measures.The common notion of "procedure" is broader than that specified by the HL7 Version 3 Reference
+        Information Model (RIM). Procedure templates can be represented with various RIM classes: act (e.g., dressing
+        change), observation (e.g., EEG), procedure (e.g., splenectomy).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.1.html">Procedures Section (entries required) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional)
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.1.html">Procedures Section (entries required)
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8289)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-8290)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8291)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.12"</b><b> (CONF:1098-10519)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32505)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8292)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-8293)</b>.<ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:1098-19186)</b>.</li><ul><li>The originalText, if present, <b>MAY</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1098-19187)</b>.</li><ul><li>The reference, if present, <b>MAY</b> contain zero or one [0..1] <b>@value</b><b> (CONF:1098-19188)</b>.</li><ul><li><p>This reference/@value <strong>SHALL</strong> begin with a '#' and <strong>SHALL</strong> point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:1098-19189).</p></li></ul></ul></ul></ul><ul><li><p>This @code <strong>SHOULD</strong> be selected from LOINC (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or SNOMED CT (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be selected from CPT-4 (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-CPT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) or ICD10 PCS (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-icd10PCS.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.4</a>) or CDT-2 (Code System: <a href="https://terminology.hl7.org/CodeSystem-CDT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.13</a>) (CONF:1098-19190).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-8298)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ProcedureAct statusCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.22/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.22</a></b><b> STATIC</b> 2014-04-23<b> (CONF:1098-32364)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-8299)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>priorityCode</b>, which <b>SHALL</b> be selected from ValueSet ActPriority<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16866/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16866</a></b><b> DYNAMIC</b><b> (CONF:1098-8300)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-8301)</b>.<ul><li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1098-8302)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8303)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>addr</b><b> (CONF:1098-8304)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1098-8305)</b>.</li></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>representedOrganization</b><b> (CONF:1098-8306)</b>.</li><ul><li>The representedOrganization, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1098-8307)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b> (CONF:1098-8308)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1098-8310)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>addr</b><b> (CONF:1098-8309)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32477)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-8311)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1098-8312)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Service Delivery Location<b> (identifier: 2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:1098-15599)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-8314)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-8315)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:1098-8316)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:1098-8317)</b>.</li><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> Encounter (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8318)</b>.</li></ul><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-8319)</b>.</li></ul><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1098-8320)</b>.</li><ul><li><p>Set the encounter ID to the ID of an encounter in another section to signify they are the same encounter (CONF:1098-16849).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-8322)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-8323)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:1098-8324)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31396)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-8326)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-8327)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-15601)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-8329)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-8330)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15602)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-8289)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-8290)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8291)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.12"</b><b>
+              (CONF:1098-10519)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32505)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8292)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-8293)</b>.<ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:1098-19186)</b>.</li>
+          <ul>
+            <li>The originalText, if present, <b>MAY</b> contain zero or one [0..1] <b>reference</b><b>
+                (CONF:1098-19187)</b>.</li>
+            <ul>
+              <li>The reference, if present, <b>MAY</b> contain zero or one [0..1] <b>@value</b><b>
+                  (CONF:1098-19188)</b>.</li>
+              <ul>
+                <li>
+                  <p>This reference/@value <strong>SHALL</strong> begin with a '#' and <strong>SHALL</strong> point to
+                    its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1)
+                    (CONF:1098-19189).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+        <ul>
+          <li>
+            <p>This @code <strong>SHOULD</strong> be selected from LOINC (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or SNOMED CT (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be
+              selected from CPT-4 (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-CPT.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) or ICD10 PCS
+              (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-icd10PCS.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.4</a>) or CDT-2 (Code System: <a
+                href="https://terminology.hl7.org/CodeSystem-CDT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.13</a>) (CONF:1098-19190).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-8298)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ProcedureAct statusCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.22/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.22</a></b><b>
+              STATIC</b> 2014-04-23<b> (CONF:1098-32364)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-8299)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>priorityCode</b>, which <b>SHALL</b> be
+        selected from ValueSet ActPriority<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16866/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16866</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-8300)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-8301)</b>.
+        <ul>
+          <li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+              (CONF:1098-8302)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8303)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>addr</b><b> (CONF:1098-8304)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1098-8305)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>representedOrganization</b><b>
+                (CONF:1098-8306)</b>.</li>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b>
+                  (CONF:1098-8307)</b>.</li>
+            </ul>
+            <ul>
+              <li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b>
+                  (CONF:1098-8308)</b>.</li>
+            </ul>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b>
+                  (CONF:1098-8310)</b>.</li>
+            </ul>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>addr</b><b>
+                  (CONF:1098-8309)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32477)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-8311)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1098-8312)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Service Delivery Location<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:1098-15599)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-8314)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-8315)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:1098-8316)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:1098-8317)</b>.</li>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> Encounter
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+                STATIC</b>)<b> (CONF:1098-8318)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+                (CONF:1098-8319)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1098-8320)</b>.</li>
+            <ul>
+              <li>
+                <p>Set the encounter ID to the ID of an encounter in another section to signify they are the same
+                  encounter (CONF:1098-16849).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-8322)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-8323)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:1098-8324)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31396)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-8326)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-8327)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-15601)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-8329)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-8330)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15602)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Activity%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.12/Procedure%20Activity%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Activity Act Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Activity%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.12/Procedure%20Activity%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Activity Act Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.120.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.120.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,63 +52,193 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Immunization Activity <small class="text-muted">[substanceAdministration, 2.16.840.1.113883.10.20.22.4.120, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.120.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Immunization Activity <small class="text-muted">[substanceAdministration,
+        2.16.840.1.113883.10.20.22.4.120, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.120.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents planned immunizations. Planned Immunization Activity is very similar to Planned Medication Activity with some key differences, for example, the drug code system is constrained to CVX codes.The priority of the immunization activity to the patient and provider is communicated through Priority Preference. The effectiveTime indicates the time when the immunization activity is intended to take place and authorTime indicates when the documentation of the plan occurred.</p></div>
+    <div id="description">
+      <p>This template represents planned immunizations. Planned Immunization Activity is very similar to Planned
+        Medication Activity with some key differences, for example, the drug code system is constrained to CVX codes.The
+        priority of the immunization activity to the patient and provider is communicated through Priority Preference.
+        The effectiveTime indicates the time when the immunization activity is intended to take place and authorTime
+        indicates when the documentation of the plan occurred.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.25.html">Precondition for Substance Administration (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.25.html">Precondition for Substance Administration (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b><b> (CONF:1098-32091)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Planned moodCode (SubstanceAdministration/Supply)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.24/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.24</a></b><b> STATIC</b> 2014-09-01<b> (CONF:1098-32097)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32098)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.120"</b><b> (CONF:1098-32099)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32100)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-32101)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32102)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-32103)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>repeatNumber</b><b> (CONF:1098-32126)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>routeCode</b>, which <b>SHALL</b> be selected from ValueSet SPL Drug Route of Administration Terminology<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.7/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.7</a></b><b> DYNAMIC</b><b> (CONF:1098-32127)</b>.<ul><li>The routeCode, if present, <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which <b>SHALL</b> be selected from ValueSet Medication Route<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.12/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.12</a></b><b> DYNAMIC</b><b> (CONF:1098-32951)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>approachSiteCode</b>, which <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b> DYNAMIC</b><b> (CONF:1098-32128)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>doseQuantity</b><b> (CONF:1098-32129)</b>.<ul><li>The doseQuantity, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b> DYNAMIC</b><b> (CONF:1098-32130)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:1098-32131)</b>.<ul><li>This consumable <b>SHALL</b> contain exactly one [1..1]  Immunization Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1098-32132)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-32104)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32105)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32108)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32109)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-32110)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32114)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32115)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32116)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32117)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32118)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32119)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>precondition</b><b> (CONF:1098-32123)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRCN"</b> Precondition (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32124)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Precondition for Substance Administration (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.25)</b><b> (CONF:1098-32125)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b><b>
+          (CONF:1098-32091)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Planned moodCode (SubstanceAdministration/Supply)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.24/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.24</a></b><b> STATIC</b> 2014-09-01<b>
+          (CONF:1098-32097)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32098)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.120"</b><b>
+              (CONF:1098-32099)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32100)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-32101)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32102)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-32103)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>repeatNumber</b><b> (CONF:1098-32126)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>routeCode</b>, which <b>SHALL</b> be
+        selected from ValueSet SPL Drug Route of Administration Terminology<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.7/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.7</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-32127)</b>.<ul>
+          <li>The routeCode, if present, <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which
+            <b>SHALL</b> be selected from ValueSet Medication Route<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.12/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.12</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32951)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>approachSiteCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Body Site Value Set<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-32128)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>doseQuantity</b><b> (CONF:1098-32129)</b>.
+        <ul>
+          <li>The doseQuantity, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be
+            selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32130)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:1098-32131)</b>.
+        <ul>
+          <li>This consumable <b>SHALL</b> contain exactly one [1..1] Immunization Medication Information (V2)<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1098-32132)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-32104)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32105)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32108)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32109)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-32110)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32114)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32115)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32116)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32117)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32118)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32119)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>precondition</b><b> (CONF:1098-32123)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRCN"</b> Precondition (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32124)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Precondition for Substance Administration (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.25)</b><b> (CONF:1098-32125)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Immunization%20Activity_2.16.840.1.113883.10.20.22.4.120/Planned%20Immunization%20Activity.xml"><i class="fab fa-github"></i>&nbsp;Planned Immunization Activity</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Immunization%20Activity_2.16.840.1.113883.10.20.22.4.120/Planned%20Immunization%20Activity.xml"><i
+            class="fab fa-github"></i>&nbsp;Planned Immunization Activity</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.121.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.121.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,87 +24,275 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Goal Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.121, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.121.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Goal Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.121,
+        release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.121.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a patient health goal. A Goal Observation template may have related components that are acts, encounters, observations, procedures, substance administrations, or supplies. A goal identifies a future desired condition or state. Goals are often related to physical or mental health conditions or diseases, but also may be related to a Social Determinant of Health (SDOH) risks or states. For example, to have adequate quality meals and snacks, gain transportation security - able to access health and social needs). SDOH data relate to conditions in which people live, learn, work, and play and their effects on health risks and outcomes.  A Goal is established by the patient or provider.</p><p>A goal may be a patient or provider goal. If the author is set to the recordTarget (patient), this is a patient goal. If the author is set to a provider, this is a provider goal. If both patient and provider are set as authors, this is a negotiated goal.</p><p>A goal usually has a related health concern and/or risk.</p><p>A goal may have components consisting of other goals (milestones). These milestones are related to the overall goal through entryRelationships.</p></div>
+    <div id="description">
+      <p>This template represents a patient health goal. A Goal Observation template may have related components that
+        are acts, encounters, observations, procedures, substance administrations, or supplies. A goal identifies a
+        future desired condition or state. Goals are often related to physical or mental health conditions or diseases,
+        but also may be related to a Social Determinant of Health (SDOH) risks or states. For example, to have adequate
+        quality meals and snacks, gain transportation security - able to access health and social needs). SDOH data
+        relate to conditions in which people live, learn, work, and play and their effects on health risks and outcomes.
+        A Goal is established by the patient or provider.</p>
+      <p>A goal may be a patient or provider goal. If the author is set to the recordTarget (patient), this is a patient
+        goal. If the author is set to a provider, this is a provider goal. If both patient and provider are set as
+        authors, this is a negotiated goal.</p>
+      <p>A goal usually has a related health concern and/or risk.</p>
+      <p>A goal may have components consisting of other goals (milestones). These milestones are related to the overall
+        goal through entryRelationships.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:4515-30418)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"GOL"</b> Goal (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:4515-30419)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-8583)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.121"</b><b> (CONF:4515-10512)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32886)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-32332)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> (CONF:4515-30784)</b>.<ul><li><p>When the Goal is Social Determinant of Health Goal, the observation/code <strong>SHOULD</strong> contain exactly one [1..1] code, which  <strong>SHOULD</strong> contain exactly one [1..1] @code="8689-2 "History of Social function" This code <strong>SHALL</strong> contain exactly one [1..1] @codeSystem="2.16.840.1.113883.6.1" (CodeSystem: LOINC <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) (CONF:4515-32887).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-32333)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ActStatus<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b> STATIC</b><b> (CONF:4515-32334)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:4515-32335)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>value</b><b> (CONF:4515-32743)</b>.<ul><li><p>When the Goal is Social Determinant of Health Goal, the observation/value <strong>SHOULD</strong> be selected from ValueSet Social Determinant of Health Goals <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1247.71/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i>2.16.840.1.113762.1.4.1247.71</a><strong>DYNAMIC</strong> (CONF:4515-32963).</p></li></ul></li>
-<li class="list-group-item"><p>If the author is the recordTarget (patient), this is a patient goal.  If the author is a provider, this is a provider goal. If both patient and provider are authors, this is a negotiated goal. If no author is present, it is assumed the document or section author(s) is the author of this goal.<br></p> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-30995)</b>.</li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship between a Goal Observation and a Health Concern Act (Goal Observation REFERS TO Health Concern Act). As Health Concern Act is already defined in Health Concerns Section, rather than clone the whole Health Concern Act template, an Entry Reference may be used in entryRelationship to refer the template.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-30701)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-30702)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-30703)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents a planned component of the goal such as Planned Encounter (V2), Planned Observation (V2), Planned Procedure (V2), Planned Medication Activity (V2), Planned Supply (V2), Planned Act (V2) or Planned Immunization Activity. Because these entries are already described in the Interventions Section of the CDA document instance, rather than repeating the full content of the entries, the Entry Reference template may be used to reference the entries.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-30704)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-30705)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32879)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that the patient or a provider puts on the goal.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:4515-30785)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-30786)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:4515-30787)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship between two Goal Observations where the target is a component of the source (Goal Observation HAS COMPONENT Goal Observation). The component goal (target) is a Milestone.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31448)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31449)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Goal Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.121)</b><b> (CONF:4515-32880)</b>.</li></ul></li>
-<li class="list-group-item"><p>Where a Goal Observation needs to reference another entry already described in the CDA document instance, rather than repeating the full content of the entry, the Entry Reference template may be used to reference this entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31559)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31560)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-31588)</b>.</li></ul></li>
-<li class="list-group-item"><p>Where it is necessary to reference an external clinical document such a Referral document, Discharge Summary document etc., the External Document Reference template can be used to reference this document.  However, if this Care Plan document is replacing or appending another Care Plan document in the same set, that relationship is set in the header, using ClinicalDocument/relatedDocument.<br></p> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:4515-32754)</b>.<ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32755)</b>.</li></ul><ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1]  External Document Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:4515-32756)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+          (CONF:4515-30418)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"GOL"</b> Goal
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b>
+          (CONF:4515-30419)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-8583)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.121"</b><b>
+              (CONF:4515-10512)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32886)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-32332)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> (CONF:4515-30784)</b>.<ul>
+          <li>
+            <p>When the Goal is Social Determinant of Health Goal, the observation/code <strong>SHOULD</strong> contain
+              exactly one [1..1] code, which <strong>SHOULD</strong> contain exactly one [1..1] @code="8689-2 "History
+              of Social function" This code <strong>SHALL</strong> contain exactly one [1..1]
+              @codeSystem="2.16.840.1.113883.6.1" (CodeSystem: LOINC <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) (CONF:4515-32887).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-32333)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ActStatus<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b>
+              STATIC</b><b> (CONF:4515-32334)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:4515-32335)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>value</b><b> (CONF:4515-32743)</b>.<ul>
+          <li>
+            <p>When the Goal is Social Determinant of Health Goal, the observation/value <strong>SHOULD</strong> be
+              selected from ValueSet Social Determinant of Health Goals <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1247.71/expansion/Latest"
+                target="_blank"><i
+                  class="fas fa-external-link-alt"></i>2.16.840.1.113762.1.4.1247.71</a><strong>DYNAMIC</strong>
+              (CONF:4515-32963).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>If the author is the recordTarget (patient), this is a patient goal. If the author is a provider, this is a
+          provider goal. If both patient and provider are authors, this is a negotiated goal. If no author is present,
+          it is assumed the document or section author(s) is the author of this goal.<br></p> <b>SHOULD</b> contain zero
+        or more [0..*] Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b>
+          (CONF:4515-30995)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship between a Goal Observation and a Health Concern
+          Act (Goal Observation REFERS TO Health Concern Act). As Health Concern Act is already defined in Health
+          Concerns Section, rather than clone the whole Health Concern Act template, an Entry Reference may be used in
+          entryRelationship to refer the template.<br></p> <b>MAY</b> contain zero or more [0..*]
+        <b>entryRelationship</b><b> (CONF:4515-30701)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-30702)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-30703)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents a planned component of the goal such as Planned Encounter (V2),
+          Planned Observation (V2), Planned Procedure (V2), Planned Medication Activity (V2), Planned Supply (V2),
+          Planned Act (V2) or Planned Immunization Activity. Because these entries are already described in the
+          Interventions Section of the CDA document instance, rather than repeating the full content of the entries, the
+          Entry Reference template may be used to reference the entries.<br></p> <b>MAY</b> contain zero or more [0..*]
+        <b>entryRelationship</b><b> (CONF:4515-30704)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-30705)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32879)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that the patient or a provider puts on the goal.<br>
+        </p> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:4515-30785)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-30786)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:4515-30787)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship between two Goal Observations where the target is
+          a component of the source (Goal Observation HAS COMPONENT Goal Observation). The component goal (target) is a
+          Milestone.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31448)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31449)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Goal Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.121)</b><b> (CONF:4515-32880)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Where a Goal Observation needs to reference another entry already described in the CDA document instance,
+          rather than repeating the full content of the entry, the Entry Reference template may be used to reference
+          this entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31559)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31560)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-31588)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Where it is necessary to reference an external clinical document such a Referral document, Discharge Summary
+          document etc., the External Document Reference template can be used to reference this document. However, if
+          this Care Plan document is replacing or appending another Care Plan document in the same set, that
+          relationship is set in the header, using ClinicalDocument/relatedDocument.<br></p> <b>MAY</b> contain zero or
+        more [0..*] <b>reference</b><b> (CONF:4515-32754)</b>.<ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers
+            to (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32755)</b>.</li>
+        </ul>
+        <ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] External Document Reference<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:4515-32756)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Goal%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.121/Goal%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Goal Observation Example</a></li>
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Goal%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.121/Social%20Determinant%20of%20Health%20Goal%20Example.xml"><i class="fab fa-github"></i>&nbsp;Social Determinant of Health Goal Example</a></li>
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Goal%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.121/Social%20Determinant%20of%20Health%20Text%20Goal%20Example.xml"><i class="fab fa-github"></i>&nbsp;Social Determinant of Health Text Goal Example</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Goal%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.121/Goal%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Goal Observation Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Goal%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.121/Social%20Determinant%20of%20Health%20Goal%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Social Determinant of Health Goal Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Goal%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.121/Social%20Determinant%20of%20Health%20Text%20Goal%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Social Determinant of Health Text Goal Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Goals"><i class="fas fa-external-link-alt"></i> Goals</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Goals"><i class="fas fa-external-link-alt"></i> Goals</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.122.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.122.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,114 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Entry Reference <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.122, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.122.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Entry Reference <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.122, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.122.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the act of referencing another entry in the same CDA document instance. Its purpose is to remove the need to repeat the complete XML representation of the referred entry when relating one entry to another. This template can be used to reference many types of Act class derivations, such as encounters, observations, procedures etc., as it is often necessary when authoring CDA documents to repeatedly reference other Acts of these types. For example, in a Care Plan it is necessary to repeatedly relate Health Concerns, Goals, Interventions and Outcomes.</p><p>The id is required and must be the same id as the entry/id it is referencing. The id cannot be a null value. Act/Code is set to nullFlavor='NP' (Not Present). This means the value is not present in the message (in act/Code).</p></div>
+    <div id="description">
+      <p>This template represents the act of referencing another entry in the same CDA document instance. Its purpose is
+        to remove the need to repeat the complete XML representation of the referred entry when relating one entry to
+        another. This template can be used to reference many types of Act class derivations, such as encounters,
+        observations, procedures etc., as it is often necessary when authoring CDA documents to repeatedly reference
+        other Acts of these types. For example, in a Care Plan it is necessary to repeatedly relate Health Concerns,
+        Goals, Interventions and Outcomes.</p>
+      <p>The id is required and must be the same id as the entry/id it is referencing. The id cannot be a null value.
+        Act/Code is set to nullFlavor='NP' (Not Present). This means the value is not present in the message (in
+        act/Code).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.144.html">Outcome Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31485)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31486)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31487)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.122"</b><b> (CONF:1098-31488)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31489)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31490)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@nullFlavor</b>=<b>"NP"</b> Not Present (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:1098-31491)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31498)</b>.<ul><li>This statusCode <b>MAY</b> contain zero or one [0..1] <b>@code</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31499)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31485)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31486)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31487)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.122"</b><b>
+              (CONF:1098-31488)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31489)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31490)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@nullFlavor</b>=<b>"NP"</b> Not Present (CodeSystem:
+            <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+              (CONF:1098-31491)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31498)</b>.
+        <ul>
+          <li>This statusCode <b>MAY</b> contain zero or one [0..1] <b>@code</b>=<b>"completed"</b> (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31499)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Entry%20Reference_2.16.840.1.113883.10.20.22.4.122/Diagnosis%20Reference%20Example.xml"><i class="fab fa-github"></i>&nbsp;Diagnosis Reference Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Entry%20Reference_2.16.840.1.113883.10.20.22.4.122/Entry%20Reference%20Example.xml"><i class="fab fa-github"></i>&nbsp;Entry Reference Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Entry%20Reference_2.16.840.1.113883.10.20.22.4.122/Diagnosis%20Reference%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Diagnosis Reference Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Entry%20Reference_2.16.840.1.113883.10.20.22.4.122/Entry%20Reference%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Entry Reference Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.123.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.123.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,137 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Drug Monitoring Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.123, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.123.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Drug Monitoring Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.123, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.123.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the act of monitoring the patient's medication and includes a participation to record the person responsible for monitoring the medication. The prescriber of the medication is not necessarily the same person or persons monitoring the drug. The effectiveTime indicates the time when the activity is intended to take place.For example, a cardiologist may prescribe a patient Warfarin. The patient's primary care provider may monitor the patient's INR and adjust the dosing of the Warfarin based on these laboratory results. Here the person designated to monitor the drug is the primary care provider.</p></div>
+    <div id="description">
+      <p>This template represents the act of monitoring the patient's medication and includes a participation to record
+        the person responsible for monitoring the medication. The prescriber of the medication is not necessarily the
+        same person or persons monitoring the drug. The effectiveTime indicates the time when the activity is intended
+        to take place.For example, a cardiologist may prescribe a patient Warfarin. The patient's primary care provider
+        may monitor the patient's INR and adjust the dosing of the Warfarin based on these laboratory results. Here the
+        person designated to monitor the drug is the primary care provider.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-30823)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b><b> (CONF:1098-28656)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-28657)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.123"</b><b> (CONF:1098-28658)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31920)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-28660)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"395170001"</b> medication monitoring (regime/therapy)<b> (CONF:1098-30818)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1098-30819)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31921)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ActStatus<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b> DYNAMIC</b><b> (CONF:1098-32358)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-31922)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>participant</b><b> (CONF:1098-28661)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RESP"</b><b> (CONF:1098-28663)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1098-28662)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b><b> (CONF:1098-28664)</b>.</li></ul><ul><li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-28665)</b>.</li></ul><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b> (CONF:1098-28667)</b>.</li><ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PSN"</b><b> (CONF:1098-28668)</b>.</li></ul><ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1098-28669)</b>.</li></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+          (CONF:1098-30823)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b><b>
+          (CONF:1098-28656)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-28657)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.123"</b><b>
+              (CONF:1098-28658)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31920)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-28660)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"395170001"</b> medication monitoring
+            (regime/therapy)<b> (CONF:1098-30818)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1098-30819)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31921)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ActStatus<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32358)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-31922)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>participant</b><b> (CONF:1098-28661)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RESP"</b><b> (CONF:1098-28663)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1098-28662)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ASSIGNED"</b><b>
+                (CONF:1098-28664)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-28665)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b>
+                (CONF:1098-28667)</b>.</li>
+            <ul>
+              <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PSN"</b><b>
+                  (CONF:1098-28668)</b>.</li>
+            </ul>
+            <ul>
+              <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] US Realm Person Name (PN.US.FIELDED)<b>
+                  (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1098-28669)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Drug%20Monitoring%20Act_2.16.840.1.113883.10.20.22.4.123/Drug%20Monitoring%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Drug Monitoring Act Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Drug%20Monitoring%20Act_2.16.840.1.113883.10.20.22.4.123/Drug%20Monitoring%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Drug Monitoring Act Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.124.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.124.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,124 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Nutritional Status Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.124, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.124.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Nutritional Status Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.124, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.124.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template describes the overall nutritional status of the patient including findings related to nutritional status.</p></div>
+    <div id="description">
+      <p>This template describes the overall nutritional status of the patient including findings related to nutritional
+        status.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.138.html">Nutrition Assessment</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.57.html">Nutrition Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.138.html">Nutrition Assessment</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-29841)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-29842)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29843)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.124"</b><b> (CONF:1098-29844)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-29845)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29846)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75305-3"</b> Nutrition status<b> (CONF:1098-29897)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-29898)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-29852)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-29853)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-31867)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b>, which <b>SHOULD</b> be selected from ValueSet Nutritional Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.7/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.7</a></b><b> DYNAMIC</b><b> (CONF:1098-29854)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1098-30323)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject<b> (CONF:1098-30335)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Assessment<b> (identifier: 2.16.840.1.113883.10.20.22.4.138)</b><b> (CONF:1098-30336)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-29841)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-29842)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29843)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.124"</b><b>
+              (CONF:1098-29844)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-29845)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29846)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75305-3"</b> Nutrition status<b>
+              (CONF:1098-29897)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-29898)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-29852)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-29853)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-31867)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b>, which <b>SHOULD</b> be selected
+        from ValueSet Nutritional Status<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.7/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.7</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-29854)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1098-30323)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject<b>
+              (CONF:1098-30335)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Nutrition Assessment<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.138)</b><b> (CONF:1098-30336)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Nutritional%20Status%20Observation_2.16.840.1.113883.10.20.22.4.124/Nutritional%20Status%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Nutritional Status Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Nutritional%20Status%20Observation_2.16.840.1.113883.10.20.22.4.124/Nutritional%20Status%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Nutritional Status Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.127.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.127.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,126 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Sensory Status <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.127, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.127.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Sensory Status <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.127, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.127.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a patient's sensory or speech ability. It may contain an assessment scale observations related to the sensory or speech ability.</p></div>
+    <div id="description">
+      <p>This template represents a patient's sensory or speech ability. It may contain an assessment scale observations
+        related to the sensory or speech ability.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31017)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31018)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-27959)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.127"</b><b> (CONF:1098-27960)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Sensory Status Problem Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.50/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.50</a></b><b> DYNAMIC</b><b> (CONF:1098-27962)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31437)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31438)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-31441)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-32630)</b>.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-32631)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Mental and Functional Status Response<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.44/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.44</a></b><b> DYNAMIC</b><b> (CONF:1098-27974)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31439)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-27984)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-27985)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1098-27986)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31017)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31018)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-27959)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.127"</b><b>
+              (CONF:1098-27960)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet Sensory Status Problem Type<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.50/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.50</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-27962)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31437)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31438)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-31441)</b>.<ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-32630)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-32631)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet Mental and Functional Status Response<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.44/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.44</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-27974)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31439)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-27984)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-27985)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1098-27986)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Sensory%20Status_2.16.840.1.113883.10.20.22.4.127/Sensory%20and%20Speech%20Status%20Example.xml"><i class="fab fa-github"></i>&nbsp;Sensory and Speech Status Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Sensory%20Status_2.16.840.1.113883.10.20.22.4.127/Sensory%20and%20Speech%20Status%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Sensory and Speech Status Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.128.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.128.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,112 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Self-Care Activities (ADL and IADL) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.128, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.128.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Self-Care Activities (ADL and IADL) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.128, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.128.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a patient's daily self-care ability. These activities are called Activities of Daily Living (ADL) and Instrumental Activities of Daily Living (IADL). ADLs involve caring for and moving of the body (e.g., dressing, bathing, eating). IADLs support an independent life style (e.g., cooking, managing medications, driving, shopping).</p></div>
+    <div id="description">
+      <p>This template represents a patient's daily self-care ability. These activities are called Activities of Daily
+        Living (ADL) and Instrumental Activities of Daily Living (IADL). ADLs involve caring for and moving of the body
+        (e.g., dressing, bathing, eating). IADLs support an independent life style (e.g., cooking, managing medications,
+        driving, shopping).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.66.html">Functional Status Organizer (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.66.html">Functional Status Organizer (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31389)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31390)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-28190)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.128"</b><b> (CONF:1098-28457)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet ADL Result Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.47/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.47</a></b><b> DYNAMIC</b><b> (CONF:1098-28153)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32490)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32491)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-32492)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Ability<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.46/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.46</a></b><b> DYNAMIC</b><b> (CONF:1098-28042)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32469)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31389)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31390)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-28190)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.128"</b><b>
+              (CONF:1098-28457)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet ADL Result Type<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.47/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.47</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-28153)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b> (CodeSystem:
+        <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32490)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32491)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-32492)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet Ability<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.46/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.46</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-28042)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32469)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Self-Care%20Activities%20(ADL%20and%20IADL)_2.16.840.1.113883.10.20.22.4.128/Self-Care%20Activities%20(ADL%20and%20IADL)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Self-Care Activities (ADL and IADL) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Self-Care%20Activities%20(ADL%20and%20IADL)_2.16.840.1.113883.10.20.22.4.128/Self-Care%20Activities%20(ADL%20and%20IADL)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Self-Care Activities (ADL and IADL) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.129.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.129.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,149 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Coverage <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.129, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.129.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Coverage <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.129, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.129.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the insurance coverage intended to cover an act or procedure.</p></div>
+    <div id="description">
+      <p>This template represents the insurance coverage intended to cover an act or procedure.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> act (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-31945)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b> Intent (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31946)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31947)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.129"</b><b> (CONF:1098-31948)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31950)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31951)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48768-6"</b> Payment Sources<b> (CONF:1098-31952)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31953)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31954)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-31955)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32178)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>entryRelationship</b><b> (CONF:1098-31967)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31968)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>act</b><b> (CONF:1098-31969)</b>.</li><ul><li>This act <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> ACT (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31970)</b>.</li></ul><ul><li>This act <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b> intent (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31971)</b>.</li></ul><ul><li>This act <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31972)</b>.</li></ul><ul><li>This act <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Payer<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.3591/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.3591</a></b><b> DYNAMIC</b><b> (CONF:1098-31973)</b>.</li></ul><ul><li>This act <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31974)</b>.</li><ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31975)</b>.</li></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> act
+        (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+          (CONF:1098-31945)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b> Intent
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b>
+          (CONF:1098-31946)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31947)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.129"</b><b>
+              (CONF:1098-31948)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31950)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31951)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48768-6"</b> Payment Sources<b>
+              (CONF:1098-31952)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31953)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31954)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-31955)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32178)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>entryRelationship</b><b>
+          (CONF:1098-31967)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31968)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>act</b><b> (CONF:1098-31969)</b>.</li>
+          <ul>
+            <li>This act <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> ACT (CodeSystem:
+              <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31970)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This act <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b> intent (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31971)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This act <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31972)</b>.</li>
+          </ul>
+          <ul>
+            <li>This act <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from
+              ValueSet Payer<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.3591/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.3591</a></b><b>
+                DYNAMIC</b><b> (CONF:1098-31973)</b>.</li>
+          </ul>
+          <ul>
+            <li>This act <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31974)</b>.</li>
+            <ul>
+              <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active
+                (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b>
+                  (CONF:1098-31975)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Coverage_2.16.840.1.113883.10.20.22.4.129/Planned%20Coverage%20Example.xml"><i class="fab fa-github"></i>&nbsp;Planned Coverage Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Coverage_2.16.840.1.113883.10.20.22.4.129/Planned%20Coverage%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Planned Coverage Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.13.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.13.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,65 +52,311 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Activity Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.13, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.13.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Activity Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.13, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.13.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The common notion of procedure is broader than that specified by the HL7 Version 3 Reference Information Model (RIM). Therefore procedure templates can be represented with various RIM classes: act (e.g., dressing change), observation (e.g., EEG), procedure (e.g., splenectomy).</p><p>This template represents procedures that result in new information about the patient that cannot be classified as a procedure according to the HL7 RIM. Examples of these procedures are diagnostic imaging procedures, EEGs, and EKGs.</p></div>
+    <div id="description">
+      <p>The common notion of procedure is broader than that specified by the HL7 Version 3 Reference Information Model
+        (RIM). Therefore procedure templates can be represented with various RIM classes: act (e.g., dressing change),
+        observation (e.g., EEG), procedure (e.g., splenectomy).</p>
+      <p>This template represents procedures that result in new information about the patient that cannot be classified
+        as a procedure according to the HL7 RIM. Examples of these procedures are diagnostic imaging procedures, EEGs,
+        and EKGs.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.1.html">Procedures Section (entries required) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.7.html">Procedures Section (entries optional)
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.7.1.html">Procedures Section (entries required)
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8282)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-8237)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8238)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.13"</b><b> (CONF:1098-10520)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32507)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8239)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19197)</b>.<ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:1098-19198)</b>.</li><ul><li>The originalText, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1098-19199)</b>.</li><ul><li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:1098-19200)</b>.</li><ul><li><p>This reference/@value <strong>SHALL</strong> begin with a '#' and <strong>SHALL</strong> point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:1098-19201).</p></li></ul></ul></ul></ul><ul><li><p>This @code <strong>SHOULD</strong> be selected from LOINC (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or SNOMED CT (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be selected from CPT-4 (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-CPT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) or ICD10 PCS (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-icd10PCS.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.4</a>) or CDT-2 (Code System: <a href="https://terminology.hl7.org/CodeSystem-CDT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.13</a>) (CONF:1098-19202).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-8245)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ProcedureAct statusCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.22/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.22</a></b><b> STATIC</b> 2014-04-23<b> (CONF:1098-32365)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-8246)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>priorityCode</b>, which <b>SHALL</b> be selected from ValueSet ActPriority<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16866/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16866</a></b><b> DYNAMIC</b><b> (CONF:1098-8247)</b>.</li>
-<li class="list-group-item"><p>If nothing is appropriate for value, use an appropriate nullFlavor.</p> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-16846)</b>.<ul><li>This value <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b><b> (CONF:1098-32778)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1098-8248)</b>.<ul><li><p>MethodCode <strong>SHALL NOT</strong> conflict with the method inherent in Observation / code (CONF:1098-8249).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>targetSiteCode</b>, which <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b> DYNAMIC</b><b> (CONF:1098-8250)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-8251)</b>.<ul><li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1098-8252)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8253)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>addr</b><b> (CONF:1098-8254)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1098-8255)</b>.</li></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>representedOrganization</b><b> (CONF:1098-8256)</b>.</li><ul><li>The representedOrganization, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1098-8257)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b> (CONF:1098-8258)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>telecom</b><b> (CONF:1098-8260)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>addr</b><b> (CONF:1098-8259)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32478)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-8261)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1098-8262)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Service Delivery Location<b> (identifier: 2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:1098-15904)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-8264)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-8265)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:1098-8266)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:1098-8267)</b>.</li><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> Encounter (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8268)</b>.</li></ul><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-8269)</b>.</li></ul><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1098-8270)</b>.</li><ul><li><p>Set encounter/id to the id of an encounter in another section to signify they are the same encounter (CONF:1098-16847).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-8272)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-8273)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:1098-8274)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31394)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-8276)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-8277)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-15906)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-8279)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-8280)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15907)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32470)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32471)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Reaction Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1098-32472)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-8282)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-8237)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8238)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.13"</b><b>
+              (CONF:1098-10520)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32507)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8239)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19197)</b>.<ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:1098-19198)</b>.</li>
+          <ul>
+            <li>The originalText, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b>
+                (CONF:1098-19199)</b>.</li>
+            <ul>
+              <li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b>
+                  (CONF:1098-19200)</b>.</li>
+              <ul>
+                <li>
+                  <p>This reference/@value <strong>SHALL</strong> begin with a '#' and <strong>SHALL</strong> point to
+                    its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1)
+                    (CONF:1098-19201).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+        <ul>
+          <li>
+            <p>This @code <strong>SHOULD</strong> be selected from LOINC (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or SNOMED CT (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be
+              selected from CPT-4 (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-CPT.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) or ICD10 PCS
+              (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-icd10PCS.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.4</a>) or CDT-2 (Code System: <a
+                href="https://terminology.hl7.org/CodeSystem-CDT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.13</a>) (CONF:1098-19202).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-8245)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ProcedureAct statusCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.22/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.22</a></b><b>
+              STATIC</b> 2014-04-23<b> (CONF:1098-32365)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-8246)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>priorityCode</b>, which <b>SHALL</b> be
+        selected from ValueSet ActPriority<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16866/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16866</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-8247)</b>.</li>
+      <li class="list-group-item">
+        <p>If nothing is appropriate for value, use an appropriate nullFlavor.</p> <b>SHALL</b> contain exactly one
+        [1..1] <b>value</b><b> (CONF:1098-16846)</b>.<ul>
+          <li>This value <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b><b> (CONF:1098-32778)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1098-8248)</b>.<ul>
+          <li>
+            <p>MethodCode <strong>SHALL NOT</strong> conflict with the method inherent in Observation / code
+              (CONF:1098-8249).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>targetSiteCode</b>, which <b>SHALL</b>
+        be selected from ValueSet Body Site Value Set<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-8250)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-8251)</b>.
+        <ul>
+          <li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+              (CONF:1098-8252)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8253)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>addr</b><b> (CONF:1098-8254)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:1098-8255)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>representedOrganization</b><b>
+                (CONF:1098-8256)</b>.</li>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b>
+                  (CONF:1098-8257)</b>.</li>
+            </ul>
+            <ul>
+              <li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b>
+                  (CONF:1098-8258)</b>.</li>
+            </ul>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>telecom</b><b>
+                  (CONF:1098-8260)</b>.</li>
+            </ul>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>addr</b><b>
+                  (CONF:1098-8259)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32478)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-8261)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1098-8262)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Service Delivery Location<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:1098-15904)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-8264)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-8265)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:1098-8266)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:1098-8267)</b>.</li>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> Encounter
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+                STATIC</b>)<b> (CONF:1098-8268)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+                (CONF:1098-8269)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:1098-8270)</b>.</li>
+            <ul>
+              <li>
+                <p>Set encounter/id to the id of an encounter in another section to signify they are the same encounter
+                  (CONF:1098-16847).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-8272)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-8273)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:1098-8274)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31394)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-8276)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-8277)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-15906)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-8279)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-8280)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15907)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32470)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32471)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Reaction Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1098-32472)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Activity%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.13/Procedure%20Activity%20Observation%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Activity Observation (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Activity%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.13/Procedure%20Activity%20Observation%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Activity Observation (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.130.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.130.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,60 +52,181 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Nutrition Recommendation <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.130, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.130.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Nutrition Recommendation <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.130, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.130.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents nutrition regimens (e.g., fluid restrictions, calorie minimum), interventions (e.g., NPO, nutritional supplements), and procedures (e.g., G-Tube by bolus, TPN by central line). It may also depict the need for nutrition education.</p></div>
+    <div id="description">
+      <p>This template represents nutrition regimens (e.g., fluid restrictions, calorie minimum), interventions (e.g.,
+        NPO, nutritional supplements), and procedures (e.g., G-Tube by bolus, TPN by central line). It may also depict
+        the need for nutrition education.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-30385)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Planned moodCode (Act/Encounter/Procedure)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.23/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.23</a></b><b> STATIC</b> 2014-09-01<b> (CONF:1098-30386)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30340)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.130"</b><b> (CONF:1098-30341)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Nutrition Recommendations<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.9</a></b><b> DYNAMIC</b><b> (CONF:1098-30342)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31697)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31698)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-31699)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32382)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32928)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Encounter (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.40)</b><b> (CONF:1098-32383)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32384)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32929)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.42)</b><b> (CONF:1098-32385)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32386)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32930)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.44)</b><b> (CONF:1098-32387)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32388)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32931)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.41)</b><b> (CONF:1098-32389)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32390)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32932)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Supply (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.43)</b><b> (CONF:1098-32391)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32632)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32933)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.39)</b><b> (CONF:1098-32633)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+          (CONF:1098-30385)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Planned moodCode (Act/Encounter/Procedure)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.23/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.23</a></b><b> STATIC</b> 2014-09-01<b>
+          (CONF:1098-30386)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30340)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.130"</b><b>
+              (CONF:1098-30341)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet Nutrition Recommendations<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.9/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.9</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-30342)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31697)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31698)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-31699)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32382)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32928)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Encounter (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.40)</b><b> (CONF:1098-32383)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32384)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32929)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.42)</b><b> (CONF:1098-32385)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32386)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32930)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.44)</b><b> (CONF:1098-32387)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32388)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32931)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.41)</b><b> (CONF:1098-32389)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32390)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32932)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Supply (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.43)</b><b> (CONF:1098-32391)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32632)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32933)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.39)</b><b> (CONF:1098-32633)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Nutrition%20Recommendation_2.16.840.1.113883.10.20.22.4.130/Nutrition%20Recommendation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Nutrition Recommendation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Nutrition%20Recommendation_2.16.840.1.113883.10.20.22.4.130/Nutrition%20Recommendation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Nutrition Recommendation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.131.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.131.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,70 +52,341 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Intervention Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.131, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.131.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Intervention Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.131, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.131.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents an Intervention Act. It is a wrapper for intervention-type activities considered to be parts of the same intervention. For example, an activity such as "elevate head of bed" combined with "provide humidified O2 per nasal cannula" may be the interventions performed for a health concern of "respiratory insufficiency" to achieve a goal of "pulse oximetry greater than 92%". These intervention activities may be newly described or derived from a variety of sources within an EHR.</p><p>Interventions are actions taken to increase the likelihood of achieving the patient's or providers' goals. An Intervention Act should contain a reference to a Goal Observation representing the reason for the intervention.</p><p>Intervention Acts can be related to each other, or to Planned Intervention Acts. (E.g., a Planned Intervention Act with moodCode of INT could be related to a series of Intervention Acts with moodCode of EVN, each having an effectiveTime containing the time of the intervention.)</p><p>All interventions referenced in an Intervention Act must have a moodCode of EVN, indicating that they have occurred.</p></div>
+    <div id="description">
+      <p>This template represents an Intervention Act. It is a wrapper for intervention-type activities considered to be
+        parts of the same intervention. For example, an activity such as "elevate head of bed" combined with "provide
+        humidified O2 per nasal cannula" may be the interventions performed for a health concern of "respiratory
+        insufficiency" to achieve a goal of "pulse oximetry greater than 92%". These intervention activities may be
+        newly described or derived from a variety of sources within an EHR.</p>
+      <p>Interventions are actions taken to increase the likelihood of achieving the patient's or providers' goals. An
+        Intervention Act should contain a reference to a Goal Observation representing the reason for the intervention.
+      </p>
+      <p>Intervention Acts can be related to each other, or to Planned Intervention Acts. (E.g., a Planned Intervention
+        Act with moodCode of INT could be related to a series of Intervention Acts with moodCode of EVN, each having an
+        effectiveTime containing the time of the intervention.)</p>
+      <p>All interventions referenced in an Intervention Act must have a moodCode of EVN, indicating that they have
+        occurred.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-30971)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-30972)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-30973)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.131"</b><b> (CONF:1198-30974)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32916)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30975)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-30976)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"362956003"</b> procedure / intervention (navigational concept)<b> (CONF:1198-30977)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-30978)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-30979)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-32316)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1198-31624)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31552)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-30980)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-30981)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Advance Directive Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-30982)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-30984)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-30985)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Immunization Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.52)</b><b> (CONF:1198-30986)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-30988)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-30989)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1198-30990)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-30991)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-30992)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.12)</b><b> (CONF:1198-30993)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship between two Intervention Acts (Intervention RELATES TO Intervention).<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31154)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31155)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Intervention Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.131)</b><b> (CONF:1198-32460)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31164)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31165)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.13)</b><b> (CONF:1198-31166)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31168)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31169)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1198-31170)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31171)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31172)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Encounter Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.49)</b><b> (CONF:1198-31173)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31174)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32956)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1198-31176)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31177)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31178)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Non-Medicinal Supply Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1198-31179)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31413)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Recommendation<b> (identifier: 2.16.840.1.113883.10.20.22.4.130)</b><b> (CONF:1198-31414)</b>.</li></ul></li>
-<li class="list-group-item"><p>Where an Intervention needs to reference another entry already described in the CDA document instance, rather than repeating the full content of the entry, the Entry Reference template may be used to reference this entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31545)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31554)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-31555)</b>.</li></ul></li>
-<li class="list-group-item"><p>An Intervention Act should reference a Goal Observation. Because the Goal Observation is already described in the CDA document instance's Goals section, rather than repeating the full content of the Goal Observation, the Entry Reference template can be used to reference this entry. The following entryRelationship represents an Entry Reference to Goal Observation.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31621)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31622)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-31623)</b>.</li></ul><ul><li><p>This entryReference template <strong>SHALL</strong> reference an instance of a Goal Observation template (CONF:1198-32459).</p></li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32317)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32318)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Handoff Communication Participants<b> (identifier: 2.16.840.1.113883.10.20.22.4.141)</b><b> (CONF:1198-32319)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32914)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32773)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Intervention Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.146)</b><b> (CONF:1198-32915)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:1198-32760)</b>.<ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32761)</b>.</li></ul><ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1]  External Document Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:1198-32762)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-30971)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-30972)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-30973)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.131"</b><b>
+              (CONF:1198-30974)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32916)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-30975)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-30976)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"362956003"</b> procedure / intervention
+            (navigational concept)<b> (CONF:1198-30977)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-30978)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-30979)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-32316)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1198-31624)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31552)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-30980)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-30981)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Advance Directive Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-30982)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-30984)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-30985)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Immunization Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.52)</b><b> (CONF:1198-30986)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-30988)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-30989)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1198-30990)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-30991)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-30992)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.12)</b><b> (CONF:1198-30993)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship between two Intervention Acts (Intervention
+          RELATES TO Intervention).<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-31154)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31155)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Intervention Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.131)</b><b> (CONF:1198-32460)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-31164)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31165)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.13)</b><b> (CONF:1198-31166)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-31168)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31169)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1198-31170)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-31171)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31172)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Encounter Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.49)</b><b> (CONF:1198-31173)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-31174)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32956)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1198-31176)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-31177)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31178)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Non-Medicinal Supply Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1198-31179)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-31413)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Nutrition Recommendation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.130)</b><b> (CONF:1198-31414)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Where an Intervention needs to reference another entry already described in the CDA document instance, rather
+          than repeating the full content of the entry, the Entry Reference template may be used to reference this
+          entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31545)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31554)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-31555)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>An Intervention Act should reference a Goal Observation. Because the Goal Observation is already described in
+          the CDA document instance's Goals section, rather than repeating the full content of the Goal Observation, the
+          Entry Reference template can be used to reference this entry. The following entryRelationship represents an
+          Entry Reference to Goal Observation.<br></p> <b>SHOULD</b> contain zero or more [0..*]
+        <b>entryRelationship</b><b> (CONF:1198-31621)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31622)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-31623)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>This entryReference template <strong>SHALL</strong> reference an instance of a Goal Observation template
+              (CONF:1198-32459).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32317)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32318)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Handoff Communication Participants<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.141)</b><b> (CONF:1198-32319)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32914)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32773)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Intervention Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.146)</b><b> (CONF:1198-32915)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:1198-32760)</b>.<ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers
+            to (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32761)</b>.</li>
+        </ul>
+        <ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] External Document Reference<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:1198-32762)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Intervention%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.131/Intervention%20Act%20(moodCodeINT)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Intervention Act (moodCodeINT) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Intervention%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.131/Intervention%20Act%20(moodCodeINT)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Intervention Act (moodCodeINT) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Interventions"><i class="fas fa-external-link-alt"></i> Interventions</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Interventions"><i class="fas fa-external-link-alt"></i>
+          Interventions</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.132.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.132.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,113 +24,628 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Health Concern Act (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.132, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.132.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Health Concern Act (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.132, release
+        2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.132.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a health concern.</p><p>It is a wrapper for a single health concern which may be derived from a variety of sources within an EHR (such as Problem List, Family History, Social History, Social Worker Note, etc.).</p><p>A Health Concern Act is used to track non-optimal physical or psychological situations drawing the patient to the healthcare system. These may be from the perspective of the care team or from the perspective of the patient.When the underlying condition is of concern (i.e., as long as the condition, whether active or resolved, is of ongoing concern and interest), the statusCode is 'active'. Only when the underlying condition is no longer of concern is the statusCode set to 'completed'. The effectiveTime reflects the time that the underlying condition was felt to be a concern; it may or may not correspond to the effectiveTime of the condition (e.g., even five years later, a prior heart attack may remain a concern).Health concerns require intervention(s) to increase the likelihood of achieving the goals of care for the patient and they specify the condition oriented reasons for creating the plan.</p></div>
+    <div id="description">
+      <p>This template represents a health concern.</p>
+      <p>It is a wrapper for a single health concern which may be derived from a variety of sources within an EHR (such
+        as Problem List, Family History, Social History, Social Worker Note, etc.).</p>
+      <p>A Health Concern Act is used to track non-optimal physical or psychological situations drawing the patient to
+        the healthcare system. These may be from the perspective of the care team or from the perspective of the
+        patient.When the underlying condition is of concern (i.e., as long as the condition, whether active or resolved,
+        is of ongoing concern and interest), the statusCode is 'active'. Only when the underlying condition is no longer
+        of concern is the statusCode set to 'completed'. The effectiveTime reflects the time that the underlying
+        condition was felt to be a concern; it may or may not correspond to the effectiveTime of the condition (e.g.,
+        even five years later, a prior heart attack may remain a concern).Health concerns require intervention(s) to
+        increase the likelihood of achieving the goals of care for the patient and they specify the condition oriented
+        reasons for creating the plan.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.78.html">Smoking Status - Meaningful Use (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.80.html">Encounter Diagnosis (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.45.html">Family History Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.34.html">Hospital Admission Diagnosis (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.138.html">Nutrition Assessment</a><br><a href="2.16.840.1.113883.10.20.22.4.51.html">Postprocedure Diagnosis (V3)</a><br><a href="2.16.840.1.113883.10.20.15.3.8.html">Pregnancy Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.65.html">Preoperative Diagnosis (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.2.html">Result Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.127.html">Sensory Status</a><br><a href="2.16.840.1.113883.10.20.22.4.38.html">Social History Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.85.html">Tobacco Use (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.27.html">Vital Sign Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a href="2.16.840.1.113883.10.20.22.4.111.html">Cultural and Religious Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.109.html">Characteristics of Home Environment</a><br><a href="2.16.840.1.113883.10.20.22.4.124.html">Nutritional Status Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.78.html">Smoking Status - Meaningful Use (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.80.html">Encounter Diagnosis (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.45.html">Family History Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.34.html">Hospital Admission Diagnosis (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.138.html">Nutrition Assessment</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.51.html">Postprocedure Diagnosis (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.15.3.8.html">Pregnancy Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.65.html">Preoperative Diagnosis (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.2.html">Result Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.127.html">Sensory Status</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.38.html">Social History Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.85.html">Tobacco Use (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.27.html">Vital Sign Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.111.html">Cultural and Religious Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.109.html">Characteristics of Home Environment</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.124.html">Nutritional Status Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:4515-30750)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:4515-30751)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-30752)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.132"</b><b> (CONF:4515-30753)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32861)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-30754)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-32310)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75310-3"</b> Health Concern<b> (CONF:4515-32311)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-32312)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-30758)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ProblemAct statusCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.19/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.19</a></b><b> STATIC</b><b> (CONF:4515-32313)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:4515-30759)</b>.</li>
-<li class="list-group-item"><p>A health concern may be a patient or provider concern. If the author is set to the recordTarget (patient), this is a patient concern. If the author is set to a provider, this is a provider concern. If both patient and provider are set as authors, this is a concern of both the patient and the provider.<br></p> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-31546)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-30761)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-30762)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:4515-31001)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31007)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31008)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergy - Intolerance Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.7)</b><b> (CONF:4515-31186)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship between two Health Concern Acts where there is a general relationship between the source and the target (Health Concern REFERS TO Health Concern).  For example, a patient has 2 health concerns identified in a CARE Plan: Failure to Thrive and Poor Feeding, while it could be that one may have caused the other, at the time of care planning and documentation it is not necessary, nor desirable to have to assert what caused what. The Entry Reference template is used here because the target Health Concern Act will be defined elsewhere in the Health Concerns Section and thus a reference to that template is all that is required.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31157)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31158)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32106)</b>.</li><ul><li><p>The Entry Reference template <strong>SHALL</strong> contain an id that references a Health Concern Act (CONF:4515-32860).</p></li></ul></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship between two Health Concern Acts where the target is a component of the source (Health Concern HAS COMPONENT Health Concern). For example, a patient has an Impaired Mobility Health Concern. There may then be the need to document several component health concerns, such as "Unable to Transfer Bed to Chair", "Unable to Rise from Commode", "Short of Breath Walking with Walker". The Entry Reference template is used here because the target Health Concern Act will be defined elsewhere in the Health Concerns Section and thus a reference to that template is all that is required.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31160)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31161)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32107)</b>.</li><ul><li><p>The Entry Reference template <strong>SHALL</strong> contain an id that references a Health Concern Act (CONF:4515-32745).</p></li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31190)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31191)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-31192)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31232)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31264)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Self-Care Activities (ADL and IADL)<b> (identifier: 2.16.840.1.113883.10.20.22.4.128)</b><b> (CONF:4515-31265)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31234)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31268)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:4515-31273)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31235)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31269)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Smoking Status - Meaningful Use (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.78)</b><b> (CONF:4515-31275)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31236)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31270)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Encounter Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.80)</b><b> (CONF:4515-31277)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31237)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers To (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31279)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.45)</b><b> (CONF:4515-31280)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31238)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31282)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.67)</b><b> (CONF:4515-31283)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31241)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31291)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Hospital Admission Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.34)</b><b> (CONF:4515-31292)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31244)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31300)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Assessment<b> (identifier: 2.16.840.1.113883.10.20.22.4.138)</b><b> (CONF:4515-31301)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31246)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31306)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Postprocedure Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.51)</b><b> (CONF:4515-31307)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31247)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31309)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Pregnancy Observation<b> (identifier: 2.16.840.1.113883.10.20.15.3.8)</b><b> (CONF:4515-31310)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31248)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31312)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Preoperative Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.65)</b><b> (CONF:4515-31313)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31250)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31318)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Reaction Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:4515-31319)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31251)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31321)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Result Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.2)</b><b> (CONF:4515-31322)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31252)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31324)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Sensory Status<b> (identifier: 2.16.840.1.113883.10.20.22.4.127)</b><b> (CONF:4515-31325)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31253)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31327)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.38)</b><b> (CONF:4515-31328)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31254)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32961)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Substance or Device Allergy - Intolerance Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.24.3.90)</b><b> (CONF:4515-31331)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31255)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31333)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Tobacco Use (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.85)</b><b> (CONF:4515-31334)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31256)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31336)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Sign Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.27)</b><b> (CONF:4515-31337)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31257)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31339)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Longitudinal Care Wound Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.114)</b><b> (CONF:4515-31340)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship Health Concern HAS SUPPORT Observation.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31365)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31366)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:4515-31367)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31368)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31369)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Caregiver Characteristics<b> (identifier: 2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:4515-31370)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31371)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31372)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Cultural and Religious Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.111)</b><b> (CONF:4515-31373)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31374)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31375)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Characteristics of Home Environment<b> (identifier: 2.16.840.1.113883.10.20.22.4.109)</b><b> (CONF:4515-31376)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31377)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31378)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutritional Status Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.124)</b><b> (CONF:4515-31379)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31380)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31381)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Result Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.1)</b><b> (CONF:4515-31382)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that the patient or a provider puts on the health concern.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31442)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31443)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:4515-31444)</b>.</li></ul></li>
-<li class="list-group-item"><p>Where a Health Concern needs to reference another entry already described in the CDA document instance, rather than repeating the full content of the entry, the Entry Reference template may be used to reference this entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31549)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31550)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-31551)</b>.</li></ul></li>
-<li class="list-group-item"><p>Where it is necessary to reference an external clinical document such as a Referral document, Discharge Summary document etc., the External Document Reference template can be used to reference this document.  However, if this Care Plan document is replacing or appending another Care Plan document in the same set, that relationship is set in the header, using ClinicalDocument/relatedDocument.<br></p> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:4515-32757)</b>.<ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32758)</b>.</li></ul><ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1]  External Document Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:4515-32759)</b>.</li></ul></li>
-<li class="list-group-item"><p>When this Health Concern Act is a Social Determinant of Health Health Concern it <strong>SHOULD</strong> contain one or more [1..*] entryRelationship subentries such that it contains an observation with an observation/value selected from ValueSet Social Determinant of Health Conditions <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.788/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1196.788</a> DYNAMIC (CONF:4515-32962).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:4515-30750)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:4515-30751)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-30752)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.132"</b><b>
+              (CONF:4515-30753)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32861)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-30754)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-32310)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75310-3"</b> Health Concern<b>
+              (CONF:4515-32311)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-32312)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-30758)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ProblemAct statusCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.19/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.19</a></b><b>
+              STATIC</b><b> (CONF:4515-32313)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:4515-30759)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>A health concern may be a patient or provider concern. If the author is set to the recordTarget (patient),
+          this is a patient concern. If the author is set to a provider, this is a provider concern. If both patient and
+          provider are set as authors, this is a concern of both the patient and the provider.<br></p> <b>SHOULD</b>
+        contain zero or more [0..*] Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b>
+          (CONF:4515-31546)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-30761)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-30762)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:4515-31001)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31007)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31008)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Allergy - Intolerance Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.7)</b><b> (CONF:4515-31186)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship between two Health Concern Acts where there is a
+          general relationship between the source and the target (Health Concern REFERS TO Health Concern). For example,
+          a patient has 2 health concerns identified in a CARE Plan: Failure to Thrive and Poor Feeding, while it could
+          be that one may have caused the other, at the time of care planning and documentation it is not necessary, nor
+          desirable to have to assert what caused what. The Entry Reference template is used here because the target
+          Health Concern Act will be defined elsewhere in the Health Concerns Section and thus a reference to that
+          template is all that is required.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31157)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31158)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32106)</b>.</li>
+          <ul>
+            <li>
+              <p>The Entry Reference template <strong>SHALL</strong> contain an id that references a Health Concern Act
+                (CONF:4515-32860).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship between two Health Concern Acts where the target
+          is a component of the source (Health Concern HAS COMPONENT Health Concern). For example, a patient has an
+          Impaired Mobility Health Concern. There may then be the need to document several component health concerns,
+          such as "Unable to Transfer Bed to Chair", "Unable to Rise from Commode", "Short of Breath Walking with
+          Walker". The Entry Reference template is used here because the target Health Concern Act will be defined
+          elsewhere in the Health Concerns Section and thus a reference to that template is all that is required.<br>
+        </p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31160)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31161)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32107)</b>.</li>
+          <ul>
+            <li>
+              <p>The Entry Reference template <strong>SHALL</strong> contain an id that references a Health Concern Act
+                (CONF:4515-32745).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31190)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31191)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-31192)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31232)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31264)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Self-Care Activities (ADL and IADL)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.128)</b><b> (CONF:4515-31265)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31234)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31268)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Mental Status Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:4515-31273)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31235)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31269)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Smoking Status - Meaningful Use (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.78)</b><b> (CONF:4515-31275)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31236)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31270)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Encounter Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.80)</b><b> (CONF:4515-31277)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31237)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers To (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31279)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Family History Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.45)</b><b> (CONF:4515-31280)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31238)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31282)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Functional Status Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.67)</b><b> (CONF:4515-31283)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31241)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31291)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Hospital Admission Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.34)</b><b> (CONF:4515-31292)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31244)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31300)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Nutrition Assessment<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.138)</b><b> (CONF:4515-31301)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31246)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31306)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Postprocedure Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.51)</b><b> (CONF:4515-31307)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31247)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31309)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Pregnancy Observation<b> (identifier:
+              2.16.840.1.113883.10.20.15.3.8)</b><b> (CONF:4515-31310)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31248)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31312)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Preoperative Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.65)</b><b> (CONF:4515-31313)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31250)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31318)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Reaction Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:4515-31319)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31251)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31321)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Result Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.2)</b><b> (CONF:4515-31322)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31252)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31324)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Sensory Status<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.127)</b><b> (CONF:4515-31325)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31253)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31327)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Social History Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.38)</b><b> (CONF:4515-31328)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31254)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-32961)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Substance or Device Allergy - Intolerance Observation (V2)<b>
+              (identifier: 2.16.840.1.113883.10.20.24.3.90)</b><b> (CONF:4515-31331)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31255)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31333)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Tobacco Use (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.85)</b><b> (CONF:4515-31334)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31256)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31336)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Vital Sign Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.27)</b><b> (CONF:4515-31337)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31257)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31339)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Longitudinal Care Wound Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.114)</b><b> (CONF:4515-31340)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship Health Concern HAS SUPPORT Observation.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31365)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31366)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:4515-31367)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31368)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31369)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Caregiver Characteristics<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:4515-31370)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31371)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31372)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Cultural and Religious Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.111)</b><b> (CONF:4515-31373)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31374)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31375)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Characteristics of Home Environment<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.109)</b><b> (CONF:4515-31376)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31377)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31378)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Nutritional Status Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.124)</b><b> (CONF:4515-31379)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31380)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31381)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Result Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.1)</b><b> (CONF:4515-31382)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that the patient or a provider puts on the health
+          concern.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31442)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31443)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:4515-31444)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Where a Health Concern needs to reference another entry already described in the CDA document instance,
+          rather than repeating the full content of the entry, the Entry Reference template may be used to reference
+          this entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31549)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31550)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-31551)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Where it is necessary to reference an external clinical document such as a Referral document, Discharge
+          Summary document etc., the External Document Reference template can be used to reference this document.
+          However, if this Care Plan document is replacing or appending another Care Plan document in the same set, that
+          relationship is set in the header, using ClinicalDocument/relatedDocument.<br></p> <b>MAY</b> contain zero or
+        more [0..*] <b>reference</b><b> (CONF:4515-32757)</b>.<ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers
+            to (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32758)</b>.</li>
+        </ul>
+        <ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] External Document Reference<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:4515-32759)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When this Health Concern Act is a Social Determinant of Health Health Concern it <strong>SHOULD</strong>
+          contain one or more [1..*] entryRelationship subentries such that it contains an observation with an
+          observation/value selected from ValueSet Social Determinant of Health Conditions <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.788/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1196.788</a> DYNAMIC (CONF:4515-32962).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Concern%20Act%20(V3)_2.16.840.1.113883.10.20.22.4.132/Health%20Concern%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Health Concern Act Example</a></li>
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Concern%20Act%20(V3)_2.16.840.1.113883.10.20.22.4.132/Health%20Concern%20Act%20wrapping%20Social%20Determinant%20of%20Health%20Problem%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Health Concern Act wrapping Social Determinant of Health Problem Observation Example</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Concern%20Act%20(V3)_2.16.840.1.113883.10.20.22.4.132/Health%20Concern%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Health Concern Act Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Concern%20Act%20(V3)_2.16.840.1.113883.10.20.22.4.132/Health%20Concern%20Act%20wrapping%20Social%20Determinant%20of%20Health%20Problem%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Health Concern Act wrapping Social Determinant of Health Problem Observation
+          Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Health%20Concerns"><i class="fas fa-external-link-alt"></i> Health Concerns</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Health%20Concerns"><i class="fas fa-external-link-alt"></i> Health
+          Concerns</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.133.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.133.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,105 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Wound Measurement Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.133, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.133.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Wound Measurement Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.133, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.133.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the Wound Measurement Observations of wound width, depth and length.</p></div>
+    <div id="description">
+      <p>This template represents the Wound Measurement Observations of wound width, depth and length.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation
+              (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-29926)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-29927)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29928)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.133"</b><b> (CONF:1098-29929)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-29930)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Wound Measurements<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.5/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.5</a></b><b> DYNAMIC</b><b> (CONF:1098-29931)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-29933)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-29934)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-29935)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b> (CONF:1098-29936)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-29926)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-29927)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29928)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.133"</b><b>
+              (CONF:1098-29929)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-29930)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected
+        from ValueSet Wound Measurements<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2.5/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2.5</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-29931)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-29933)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-29934)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-29935)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b>
+          (CONF:1098-29936)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Wound%20Measurement%20Observation_2.16.840.1.113883.10.20.22.4.133/Wound%20Measurement%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Wound Measurement Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Wound%20Measurement%20Observation_2.16.840.1.113883.10.20.22.4.133/Wound%20Measurement%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Wound Measurement Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.134.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.134.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,109 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Wound Characteristic <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.134, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.134.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Wound Characteristic <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.134, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.22.4.134.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents characteristics of a wound (e.g., integrity of suture line, odor, erythema).</p></div>
+    <div id="description">
+      <p>This template represents characteristics of a wound (e.g., integrity of suture line, odor, erythema).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation
+              (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-29938)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-29939)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29940)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.134"</b><b> (CONF:1098-29941)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-29942)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29943)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> assertion<b> (CONF:1098-31540)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-31541)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-29944)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-29946)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Wound Characteristic<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.58/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.58</a></b><b> DYNAMIC</b><b> (CONF:1098-29947)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-29938)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-29939)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-29940)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.134"</b><b>
+              (CONF:1098-29941)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-29942)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-29943)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> assertion<b>
+              (CONF:1098-31540)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:1098-31541)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b>=<b>"completed"</b>
+        (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b>
+          (CONF:1098-29944)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-29946)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Wound Characteristic<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.58/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.58</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-29947)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Wound%20Characteristic_2.16.840.1.113883.10.20.22.4.134/Wound%20Characteristic%20Example.xml"><i class="fab fa-github"></i>&nbsp;Wound Characteristic Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Wound%20Characteristic_2.16.840.1.113883.10.20.22.4.134/Wound%20Characteristic%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Wound Characteristic Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.135.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.135.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,129 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medical Equipment Organizer <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.135, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.135.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medical Equipment Organizer <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.135,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.135.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a set of current or historical medical devices, supplies, aids and equipment used by the patient. Examples are hearing aids, orthotic devices, ostomy supplies, visual aids, diabetic supplies such as syringes and pumps, and wheelchairs.Devices that are applied during a procedure (e.g., cardiac pacemaker, gastrosomy tube, port catheter), whether permanent or temporary, are represented within the Procedure Activity Procedure (V2) template (templateId: 2.16.840.1.113883.10.20.22.4.14.2).</p></div>
+    <div id="description">
+      <p>This template represents a set of current or historical medical devices, supplies, aids and equipment used by
+        the patient. Examples are hearing aids, orthotic devices, ostomy supplies, visual aids, diabetic supplies such
+        as syringes and pumps, and wheelchairs.Devices that are applied during a procedure (e.g., cardiac pacemaker,
+        gastrosomy tube, port catheter), whether permanent or temporary, are represented within the Procedure Activity
+        Procedure (V2) template (templateId: 2.16.840.1.113883.10.20.22.4.14.2).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-31020)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-31021)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31022)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.135"</b><b> (CONF:1098-31023)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31024)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1098-31025)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31026)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Result Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.39/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.39</a></b><b> STATIC</b> 2014-09-01<b> (CONF:1098-31029)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-32136)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-32378)</b>.</li></ul><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1098-32379)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1098-31027)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Non-Medicinal Supply Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1098-31862)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1098-31887)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-31888)</b>.</li></ul></li>
-<li class="list-group-item"> <p>Either Non-Medicinal Supply Activity (V2) (templateId:2.16.840.1.113883.10.20.22.4.50) <strong>OR</strong> Procedure Activity Procedure (V2) (templateId:2.16.840.1.113883.10.20.22.4.14) <strong>SHALL</strong> be present (CONF:1098-32380).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b>
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-31020)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-31021)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31022)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.135"</b><b>
+              (CONF:1098-31023)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31024)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1098-31025)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31026)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet Result Status<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.39/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.39</a></b><b>
+              STATIC</b> 2014-09-01<b> (CONF:1098-31029)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-32136)</b>.<ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-32378)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1098-32379)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1098-31027)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Non-Medicinal Supply Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1098-31862)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:1098-31887)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-31888)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Either Non-Medicinal Supply Activity (V2) (templateId:2.16.840.1.113883.10.20.22.4.50) <strong>OR</strong>
+          Procedure Activity Procedure (V2) (templateId:2.16.840.1.113883.10.20.22.4.14) <strong>SHALL</strong> be
+          present (CONF:1098-32380).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medical%20Equipment%20Organizer_2.16.840.1.113883.10.20.22.4.135/Medical%20Equipment%20Organizer%20Example.xml"><i class="fab fa-github"></i>&nbsp;Medical Equipment Organizer Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medical%20Equipment%20Organizer_2.16.840.1.113883.10.20.22.4.135/Medical%20Equipment%20Organizer%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Medical Equipment Organizer Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.136.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.136.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,92 +52,592 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Risk Concern Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.136, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.136.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Risk Concern Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.136, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.136.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a risk concern.</p><p>It is a wrapper for a single risk concern which may be derived from a variety of sources within an EHR (such as Problem List, Family History, Social History, Social Worker Note, etc.).</p><p>A Risk Concern Act represents a health concern that is a risk. A risk is a clinical or socioeconomic condition that the patient does not currently have, but the probability of developing that condition rises to the level of concern such that an intervention and/or monitoring is needed.</p></div>
+    <div id="description">
+      <p>This template represents a risk concern.</p>
+      <p>It is a wrapper for a single risk concern which may be derived from a variety of sources within an EHR (such as
+        Problem List, Family History, Social History, Social Worker Note, etc.).</p>
+      <p>A Risk Concern Act represents a health concern that is a risk. A risk is a clinical or socioeconomic condition
+        that the patient does not currently have, but the probability of developing that condition rises to the level of
+        concern such that an intervention and/or monitoring is needed.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.58.html">Health Concerns Section (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a href="2.16.840.1.113883.10.20.22.4.78.html">Smoking Status - Meaningful Use (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.80.html">Encounter Diagnosis (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.45.html">Family History Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.34.html">Hospital Admission Diagnosis (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.138.html">Nutrition Assessment</a><br><a href="2.16.840.1.113883.10.20.22.4.51.html">Postprocedure Diagnosis (V3)</a><br><a href="2.16.840.1.113883.10.20.15.3.8.html">Pregnancy Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.65.html">Preoperative Diagnosis (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.2.html">Result Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.127.html">Sensory Status</a><br><a href="2.16.840.1.113883.10.20.22.4.38.html">Social History Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.85.html">Tobacco Use (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.27.html">Vital Sign Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a href="2.16.840.1.113883.10.20.22.4.111.html">Cultural and Religious Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.109.html">Characteristics of Home Environment</a><br><a href="2.16.840.1.113883.10.20.22.4.124.html">Nutritional Status Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.58.html">Health Concerns Section (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.78.html">Smoking Status - Meaningful Use (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.80.html">Encounter Diagnosis (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.45.html">Family History Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.34.html">Hospital Admission Diagnosis (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.138.html">Nutrition Assessment</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.51.html">Postprocedure Diagnosis (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.15.3.8.html">Pregnancy Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.65.html">Preoperative Diagnosis (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.2.html">Result Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.127.html">Sensory Status</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.38.html">Social History Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.85.html">Tobacco Use (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.27.html">Vital Sign Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.111.html">Cultural and Religious Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.109.html">Characteristics of Home Environment</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.124.html">Nutritional Status Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-32220)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1198-32221)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-32180)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.136"</b><b> (CONF:1198-32222)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32910)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-32223)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-32305)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"281694009"</b> At risk for<b> (CONF:1198-32306)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-32307)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32225)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ProblemAct statusCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.19/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.19</a></b><b> STATIC</b><b> (CONF:1198-32314)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1198-32226)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-32300)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32179)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32227)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-32219)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32181)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32228)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergy - Intolerance Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.7)</b><b> (CONF:1198-32229)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship between two Health Concern Acts where there is a general relationship between the source and the target (Health Concern RELATES TO Health Concern). The Entry Reference template is used here because the target Health Concern Act will be defined elsewhere in the Health Concerns Section and thus a reference to that template is all that is required.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32182)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32230)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32231)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship between two Health Concern Acts where the target is a component of the source (Health Concern HAS COMPONENT Health Concern). The Enry Reference template is used here because the target Health Concern Act will be defined elsewhere in the Health Concerns Section and thus a reference to that template is all that is required.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32183)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32232)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32233)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32184)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32234)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1198-32235)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32185)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32236)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:1198-32237)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32186)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32238)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Self-Care Activities (ADL and IADL)<b> (identifier: 2.16.840.1.113883.10.20.22.4.128)</b><b> (CONF:1198-32239)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32188)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32242)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:1198-32243)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32189)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32244)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Smoking Status - Meaningful Use (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.78)</b><b> (CONF:1198-32245)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32190)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32246)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Encounter Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.80)</b><b> (CONF:1198-32247)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32191)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers To (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32248)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.45)</b><b> (CONF:1198-32249)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32192)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32250)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.67)</b><b> (CONF:1198-32251)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32193)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32252)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Hospital Admission Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.34)</b><b> (CONF:1198-32253)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32195)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32256)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Assessment<b> (identifier: 2.16.840.1.113883.10.20.22.4.138)</b><b> (CONF:1198-32257)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32197)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32260)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Postprocedure Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.51)</b><b> (CONF:1198-32261)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32198)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32262)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Pregnancy Observation<b> (identifier: 2.16.840.1.113883.10.20.15.3.8)</b><b> (CONF:1198-32263)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32199)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32264)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Preoperative Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.65)</b><b> (CONF:1198-32265)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32200)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32266)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Reaction Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1198-32267)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32201)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32268)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Result Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.2)</b><b> (CONF:1198-32269)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32202)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32270)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Sensory Status<b> (identifier: 2.16.840.1.113883.10.20.22.4.127)</b><b> (CONF:1198-32271)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32203)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32272)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Social History Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.38)</b><b> (CONF:1198-32273)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32204)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32958)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Substance or Device Allergy - Intolerance Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.24.3.90)</b><b> (CONF:1198-32275)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32205)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32276)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Tobacco Use (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.85)</b><b> (CONF:1198-32277)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32206)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32278)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Sign Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.27)</b><b> (CONF:1198-32279)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32207)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32280)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Longitudinal Care Wound Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.114)</b><b> (CONF:1198-32281)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship Health Concern HAS SUPPORT Observation.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32208)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32282)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-32283)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32209)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32284)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Caregiver Characteristics<b> (identifier: 2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:1198-32285)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32210)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32286)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Cultural and Religious Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.111)</b><b> (CONF:1198-32287)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32211)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32288)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Characteristics of Home Environment<b> (identifier: 2.16.840.1.113883.10.20.22.4.109)</b><b> (CONF:1198-32289)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32212)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32290)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Nutritional Status Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.124)</b><b> (CONF:1198-32291)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32213)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32292)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Result Organizer (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.1)</b><b> (CONF:1198-32293)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that the patient puts on the health concern.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32214)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32294)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1198-32295)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that the provider puts on the health concern.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32215)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32296)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1198-32297)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32216)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32298)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Concern Act (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.3)</b><b> (CONF:1198-32299)</b>.</li></ul></li>
-<li class="list-group-item"><p>Where a Health Concern needs to reference another entry already described in the CDA document instance, rather than repeating the full content of the entry, the Entry Reference template may be used to reference this entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32217)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32301)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32302)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:1198-32769)</b>.<ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32908)</b>.</li></ul><ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1]  External Document Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:1198-32909)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-32220)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1198-32221)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-32180)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.136"</b><b>
+              (CONF:1198-32222)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32910)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-32223)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-32305)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"281694009"</b> At risk for<b>
+              (CONF:1198-32306)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-32307)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32225)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ProblemAct statusCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.19/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.19</a></b><b>
+              STATIC</b><b> (CONF:1198-32314)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1198-32226)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-32300)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32179)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32227)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-32219)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32181)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32228)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Allergy - Intolerance Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.7)</b><b> (CONF:1198-32229)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship between two Health Concern Acts where there is a
+          general relationship between the source and the target (Health Concern RELATES TO Health Concern). The Entry
+          Reference template is used here because the target Health Concern Act will be defined elsewhere in the Health
+          Concerns Section and thus a reference to that template is all that is required.<br></p> <b>MAY</b> contain
+        zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32182)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32230)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32231)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship between two Health Concern Acts where the target
+          is a component of the source (Health Concern HAS COMPONENT Health Concern). The Enry Reference template is
+          used here because the target Health Concern Act will be defined elsewhere in the Health Concerns Section and
+          thus a reference to that template is all that is required.<br></p> <b>MAY</b> contain zero or more [0..*]
+        <b>entryRelationship</b><b> (CONF:1198-32183)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32232)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32233)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32184)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32234)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1198-32235)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32185)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32236)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Mental Status Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:1198-32237)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32186)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32238)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Self-Care Activities (ADL and IADL)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.128)</b><b> (CONF:1198-32239)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32188)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32242)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Mental Status Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:1198-32243)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32189)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32244)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Smoking Status - Meaningful Use (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.78)</b><b> (CONF:1198-32245)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32190)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32246)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Encounter Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.80)</b><b> (CONF:1198-32247)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32191)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers To (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32248)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Family History Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.45)</b><b> (CONF:1198-32249)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32192)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32250)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Functional Status Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.67)</b><b> (CONF:1198-32251)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32193)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32252)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Hospital Admission Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.34)</b><b> (CONF:1198-32253)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32195)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32256)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Nutrition Assessment<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.138)</b><b> (CONF:1198-32257)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32197)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32260)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Postprocedure Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.51)</b><b> (CONF:1198-32261)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32198)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32262)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Pregnancy Observation<b> (identifier:
+              2.16.840.1.113883.10.20.15.3.8)</b><b> (CONF:1198-32263)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32199)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32264)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Preoperative Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.65)</b><b> (CONF:1198-32265)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32200)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32266)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Reaction Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1198-32267)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32201)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32268)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Result Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.2)</b><b> (CONF:1198-32269)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32202)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32270)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Sensory Status<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.127)</b><b> (CONF:1198-32271)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32203)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32272)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Social History Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.38)</b><b> (CONF:1198-32273)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32204)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32958)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Substance or Device Allergy - Intolerance Observation (V2)<b>
+              (identifier: 2.16.840.1.113883.10.20.24.3.90)</b><b> (CONF:1198-32275)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32205)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32276)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Tobacco Use (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.85)</b><b> (CONF:1198-32277)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32206)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32278)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Vital Sign Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.27)</b><b> (CONF:1198-32279)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32207)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32280)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Longitudinal Care Wound Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.114)</b><b> (CONF:1198-32281)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship Health Concern HAS SUPPORT Observation.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32208)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32282)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-32283)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32209)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32284)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Caregiver Characteristics<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:1198-32285)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32210)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32286)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Cultural and Religious Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.111)</b><b> (CONF:1198-32287)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32211)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32288)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Characteristics of Home Environment<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.109)</b><b> (CONF:1198-32289)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32212)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32290)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Nutritional Status Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.124)</b><b> (CONF:1198-32291)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32213)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32292)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Result Organizer (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.1)</b><b> (CONF:1198-32293)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that the patient puts on the health concern.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32214)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32294)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1198-32295)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that the provider puts on the health concern.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32215)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32296)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1198-32297)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32216)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32298)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Concern Act (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.3)</b><b> (CONF:1198-32299)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Where a Health Concern needs to reference another entry already described in the CDA document instance,
+          rather than repeating the full content of the entry, the Entry Reference template may be used to reference
+          this entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32217)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32301)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32302)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:1198-32769)</b>.<ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers
+            to (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32908)</b>.</li>
+        </ul>
+        <ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] External Document Reference<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:1198-32909)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Risk%20Concern%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.136/Risk%20Concern%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Risk Concern Act Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Risk%20Concern%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.136/Risk%20Concern%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Risk Concern Act Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.138.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.138.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,118 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Nutrition Assessment <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.138, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.138.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Nutrition Assessment <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.138, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.22.4.138.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the patient's nutrition abilities and habits including intake, diet requirements or diet followed.</p></div>
+    <div id="description">
+      <p>This template represents the patient's nutrition abilities and habits including intake, diet requirements or
+        diet followed.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.124.html">Nutritional Status Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.124.html">Nutritional Status Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-32914)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-32915)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32916)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.138"</b><b> (CONF:1098-32917)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32918)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-32919)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75303-8"</b> Nutrition assessment<b> (CONF:1098-32926)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32927)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-32920)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-32921)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-32923)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-32922)</b>.<ul><li><p>If xsi:type="CD", <strong>SHOULD</strong> contain a code from SNOMED CT (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1098-32925).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32924)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-32914)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-32915)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-32916)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.138"</b><b>
+              (CONF:1098-32917)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32918)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-32919)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75303-8"</b> Nutrition assessment<b>
+              (CONF:1098-32926)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32927)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-32920)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-32921)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-32923)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-32922)</b>.<ul>
+          <li>
+            <p>If xsi:type="CD", <strong>SHOULD</strong> contain a code from SNOMED CT (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1098-32925).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32924)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Nutrition%20Assessment_2.16.840.1.113883.10.20.22.4.138/Nutrition%20Assessment%20Example.xml"><i class="fab fa-github"></i>&nbsp;Nutrition Assessment Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Nutrition%20Assessment_2.16.840.1.113883.10.20.22.4.138/Nutrition%20Assessment%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Nutrition Assessment Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.14.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.14.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,90 +24,416 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Activity Procedure (V3) <small class="text-muted">[procedure, 2.16.840.1.113883.10.20.22.4.14, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.14.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Activity Procedure (V3) <small class="text-muted">[procedure,
+        2.16.840.1.113883.10.20.22.4.14, release 2022-06-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.14.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The common notion of "procedure" is broader than that specified by the HL7 Version 3 Reference Information Model (RIM). Therefore procedure templates can be represented with various RIM classes: act (e.g., dressing change), observation (e.g., EEG), procedure (e.g., splenectomy).This template represents procedures whose immediate and primary outcome (post-condition) is the alteration of the physical condition of the patient. Examples of these procedures are an appendectomy, hip replacement, and a creation of a gastrostomy.This template can be used with a contained Product Instance template to represent a device in or on a patient. In this case, targetSiteCode is used to record the location of the device in or on the patient's body. Equipment supplied to the patient (e.g., pumps, inhalers, wheelchairs) is represented by the Non-Medicinal Supply Activity (V2) template.Procedure Activity Procedure V3 Usage Note: Common practice in the industry has shown that Procedure Activity Procedure is the usually implemented CDA template for any type of intervention or procedure regardless of if the "immediate and primary outcome (post-condition) is the alteration of the physical condition of the patient" or not. As a result, it is recommended to use Procedure Activity Procedure when sending procedures also thought of as "interventions" such as "Home Environment Evaluation" or "Assessment of nutritional status".</p></div>
+    <div id="description">
+      <p>The common notion of "procedure" is broader than that specified by the HL7 Version 3 Reference Information
+        Model (RIM). Therefore procedure templates can be represented with various RIM classes: act (e.g., dressing
+        change), observation (e.g., EEG), procedure (e.g., splenectomy).This template represents procedures whose
+        immediate and primary outcome (post-condition) is the alteration of the physical condition of the patient.
+        Examples of these procedures are an appendectomy, hip replacement, and a creation of a gastrostomy.This template
+        can be used with a contained Product Instance template to represent a device in or on a patient. In this case,
+        targetSiteCode is used to record the location of the device in or on the patient's body. Equipment supplied to
+        the patient (e.g., pumps, inhalers, wheelchairs) is represented by the Non-Medicinal Supply Activity (V2)
+        template.Procedure Activity Procedure V3 Usage Note: Common practice in the industry has shown that Procedure
+        Activity Procedure is the usually implemented CDA template for any type of intervention or procedure regardless
+        of if the "immediate and primary outcome (post-condition) is the alteration of the physical condition of the
+        patient" or not. As a result, it is recommended to use Procedure Activity Procedure when sending procedures also
+        thought of as "interventions" such as "Home Environment Evaluation" or "Assessment of nutritional status".</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.37.html">Product Instance</a><br><a href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.37.html">Product Instance</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PROC"</b> Procedure (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-7652)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-7653)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-7654)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.14"</b><b> (CONF:4515-10521)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32506)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-7655)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-7656)</b>.<ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:4515-19203)</b>.</li><ul><li>The originalText, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:4515-19204)</b>.</li><ul><li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:4515-19205)</b>.</li><ul><li><p>This reference/@value <strong>SHALL</strong> begin with a '#' and <strong>SHALL</strong> point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:4515-19206).</p></li></ul></ul></ul></ul><ul><li><p>This @code <strong>SHOULD</strong> be selected from LOINC (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or SNOMED CT (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be selected from CPT-4 (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-CPT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) or ICD10 PCS (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-icd10PCS.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.4</a>) or HCPCS (Code System: <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1247.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1247.9</a>) or CDT-2 (Code System: <a href="https://terminology.hl7.org/CodeSystem-CDT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.13</a>) (CONF:4515-19207).</p></li></ul><ul><li><p>If the Intervention Procedure is a Social Determinant of Health Intervention, the procedure code <strong>SHOULD</strong> be selected from ValueSet Social Determinant of Health Procedures <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.789/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i>2.16.840.1.113762.1.4.1196.789</a><strong>DYNAMIC</strong> (CONF:4515-32984).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-7661)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ProcedureAct statusCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.22/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.22</a></b><b> STATIC</b> 2014-04-23<b> (CONF:4515-32366)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:4515-7662)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>priorityCode</b>, which <b>SHALL</b> be selected from ValueSet ActPriority<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16866/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16866</a></b><b> DYNAMIC</b><b> (CONF:4515-7668)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:4515-7670)</b>.<ul><li><p>MethodCode <strong>SHALL NOT</strong> conflict with the method inherent in Procedure / code (CONF:4515-7890).</p></li></ul></li>
-<li class="list-group-item"><p>In the case of an implanted medical device, targetSiteCode is used to record the location of the device, in or on the patient's body.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>targetSiteCode</b>, which <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b> DYNAMIC</b><b> (CONF:4515-7683)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>specimen</b><b> (CONF:4515-7697)</b>.<ul><li>The specimen, if present, <b>SHALL</b> contain exactly one [1..1] <b>specimenRole</b><b> (CONF:4515-7704)</b>.</li><ul><li>This specimenRole <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:4515-7716)</b>.</li><ul><li><p>If you want to indicate that the Procedure and the Results are referring to the same specimen, the Procedure/specimen/specimenRole/id <strong>SHOULD</strong> be set to equal an Organizer/specimen/ specimenRole/id (CONF:4515-29744).</p></li></ul></ul></ul><ul><li><p>This specimen is for representing specimens obtained from a procedure (CONF:4515-16842).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:4515-7718)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:4515-7720)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-7722)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>addr</b><b> (CONF:4515-7731)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:4515-7732)</b>.</li></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>representedOrganization</b><b> (CONF:4515-7733)</b>.</li><ul><li>The representedOrganization, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:4515-7734)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b> (CONF:4515-7735)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>telecom</b><b> (CONF:4515-7737)</b>.</li></ul><ul><li>The representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>addr</b><b> (CONF:4515-7736)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-32479)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-7751)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"DEV"</b> Device (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:4515-7752)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Product Instance<b> (identifier: 2.16.840.1.113883.10.20.22.4.37)</b><b> (CONF:4515-15911)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-7765)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:4515-7766)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Service Delivery Location<b> (identifier: 2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:4515-15912)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-7768)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:4515-7769)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:4515-8009)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:4515-7770)</b>.</li><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> Encounter (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-7771)</b>.</li></ul><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-7772)</b>.</li></ul><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:4515-7773)</b>.</li><ul><li><p>Set the encounter ID to the ID of an encounter in another section to signify they are the same encounter (CONF:4515-16843).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:4515-7775)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:4515-7776)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:4515-7777)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:4515-31395)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-7779)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:4515-7780)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:4515-15914)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-7886)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:4515-7887)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:4515-15915)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32473)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32474)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Reaction Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:4515-32475)</b>.</li></ul></li>
-<li class="list-group-item"><p>When an Assessment Scale Observation is contained in a Procedure Template instance that is a Social Determinant of Health intervention procedure, that Assessment scale <b>MAY</b> contain Assessment Scale observations that represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32985)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32987)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-32986)</b>.</li></ul></li>
-<li class="list-group-item"><p>When an Entry Reference Template is contained in a Procedure Template instance that is a Social Determinant of Health procedure, that Entry Reference <b>MAY</b> refer to Assessment Scale Observation in the same document that represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32988)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32990)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32989)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PROC"</b> Procedure
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:4515-7652)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4515-7653)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-7654)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.14"</b><b>
+              (CONF:4515-10521)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32506)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-7655)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-7656)</b>.<ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:4515-19203)</b>.</li>
+          <ul>
+            <li>The originalText, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b>
+                (CONF:4515-19204)</b>.</li>
+            <ul>
+              <li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b>
+                  (CONF:4515-19205)</b>.</li>
+              <ul>
+                <li>
+                  <p>This reference/@value <strong>SHALL</strong> begin with a '#' and <strong>SHALL</strong> point to
+                    its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1)
+                    (CONF:4515-19206).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+        <ul>
+          <li>
+            <p>This @code <strong>SHOULD</strong> be selected from LOINC (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or SNOMED CT (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be
+              selected from CPT-4 (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-CPT.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) or ICD10 PCS
+              (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-icd10PCS.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.4</a>) or HCPCS (Code System: <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1247.9/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1247.9</a>) or CDT-2
+              (Code System: <a href="https://terminology.hl7.org/CodeSystem-CDT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.13</a>) (CONF:4515-19207).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>If the Intervention Procedure is a Social Determinant of Health Intervention, the procedure code
+              <strong>SHOULD</strong> be selected from ValueSet Social Determinant of Health Procedures <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.789/expansion/Latest"
+                target="_blank"><i
+                  class="fas fa-external-link-alt"></i>2.16.840.1.113762.1.4.1196.789</a><strong>DYNAMIC</strong>
+              (CONF:4515-32984).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-7661)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ProcedureAct statusCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.22/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.22</a></b><b>
+              STATIC</b> 2014-04-23<b> (CONF:4515-32366)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:4515-7662)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>priorityCode</b>, which <b>SHALL</b> be
+        selected from ValueSet ActPriority<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16866/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16866</a></b><b> DYNAMIC</b><b>
+          (CONF:4515-7668)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:4515-7670)</b>.<ul>
+          <li>
+            <p>MethodCode <strong>SHALL NOT</strong> conflict with the method inherent in Procedure / code
+              (CONF:4515-7890).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>In the case of an implanted medical device, targetSiteCode is used to record the location of the device, in
+          or on the patient's body.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>targetSiteCode</b>, which
+        <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b>
+          DYNAMIC</b><b> (CONF:4515-7683)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>specimen</b><b> (CONF:4515-7697)</b>.<ul>
+          <li>The specimen, if present, <b>SHALL</b> contain exactly one [1..1] <b>specimenRole</b><b>
+              (CONF:4515-7704)</b>.</li>
+          <ul>
+            <li>This specimenRole <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:4515-7716)</b>.</li>
+            <ul>
+              <li>
+                <p>If you want to indicate that the Procedure and the Results are referring to the same specimen, the
+                  Procedure/specimen/specimenRole/id <strong>SHOULD</strong> be set to equal an Organizer/specimen/
+                  specimenRole/id (CONF:4515-29744).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+        <ul>
+          <li>
+            <p>This specimen is for representing specimens obtained from a procedure (CONF:4515-16842).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:4515-7718)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:4515-7720)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-7722)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>addr</b><b> (CONF:4515-7731)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>telecom</b><b> (CONF:4515-7732)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>representedOrganization</b><b>
+                (CONF:4515-7733)</b>.</li>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b>
+                  (CONF:4515-7734)</b>.</li>
+            </ul>
+            <ul>
+              <li>The representedOrganization, if present, <b>MAY</b> contain zero or more [0..*] <b>name</b><b>
+                  (CONF:4515-7735)</b>.</li>
+            </ul>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>telecom</b><b>
+                  (CONF:4515-7737)</b>.</li>
+            </ul>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>addr</b><b>
+                  (CONF:4515-7736)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-32479)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-7751)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"DEV"</b> Device (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:4515-7752)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Product Instance<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.37)</b><b> (CONF:4515-15911)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-7765)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:4515-7766)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Service Delivery Location<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:4515-15912)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-7768)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:4515-7769)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:4515-8009)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:4515-7770)</b>.</li>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> Encounter
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+                STATIC</b>)<b> (CONF:4515-7771)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+                (CONF:4515-7772)</b>.</li>
+          </ul>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:4515-7773)</b>.</li>
+            <ul>
+              <li>
+                <p>Set the encounter ID to the ID of an encounter in another section to signify they are the same
+                  encounter (CONF:4515-16843).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:4515-7775)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:4515-7776)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> true<b> (CONF:4515-7777)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:4515-31395)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-7779)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:4515-7780)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:4515-15914)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-7886)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:4515-7887)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:4515-15915)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-32473)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-32474)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Reaction Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:4515-32475)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When an Assessment Scale Observation is contained in a Procedure Template instance that is a Social
+          Determinant of Health intervention procedure, that Assessment scale <b>MAY</b> contain Assessment Scale
+          observations that represent LOINC question and answer pairs from SDOH screening instruments.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32985)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-32987)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-32986)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When an Entry Reference Template is contained in a Procedure Template instance that is a Social Determinant
+          of Health procedure, that Entry Reference <b>MAY</b> refer to Assessment Scale Observation in the same
+          document that represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b>
+        contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32988)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-32990)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32989)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Activity%20Procedure%20(V3)_2.16.840.1.113883.10.20.22.4.14/Procedure%20Activity%20Procedure%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Activity Procedure Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Activity%20Procedure%20(V3)_2.16.840.1.113883.10.20.22.4.14/Procedure%20Activity%20Procedure%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Activity Procedure Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.140.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.140.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,60 +52,200 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Patient Referral Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.140, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.140.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Patient Referral Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.140, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.140.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the type of referral (e.g., for dental care, to a specialist, for aging problems) and represents whether the referral is for full care or shared care. It may contain a reference to another act in the document instance representing the clinical reason for the referral (e.g., problem, concern, procedure).</p></div>
+    <div id="description">
+      <p>This template represents the type of referral (e.g., for dental care, to a specialist, for aging problems) and
+        represents whether the referral is for full care or shared care. It may contain a reference to another act in
+        the document instance representing the clinical reason for the referral (e.g., problem, concern, procedure).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="1.3.6.1.4.1.19376.1.5.3.1.3.1.html">Reason for Referral Section (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="1.3.6.1.4.1.19376.1.5.3.1.3.1.html">Reason for Referral Section (V2)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> provision of care (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-30884)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Patient Referral Act moodCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.66/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.66</a></b><b> STATIC</b> 2014-09-01<b> (CONF:1098-30885)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30886)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.140"</b><b> (CONF:1098-30887)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-30888)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Referral Types<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.56/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.56</a></b><b> DYNAMIC</b><b> (CONF:1098-30889)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30892)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31598)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-30893)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>priorityCode</b><b> (CONF:1098-32623)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31612)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-32635)</b>.<ul><li>The participant, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFT"</b> Referred to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32638)</b>.</li></ul><ul><li>The participant, if present, <b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1098-32636)</b>.</li><ul><li>This participantRole <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1098-32637)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31604)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31613)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1098-31605)</b>.</li><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31606)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"RQO"</b> request (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31607)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31608)</b>.</li><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> assertion<b> (CONF:1098-31619)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4 "</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-31620)</b>.</li></ul></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31614)</b>.</li><ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31615)</b>.</li></ul></ul><ul><li>This observation <b>SHOULD</b> contain zero or one [0..1] <b>priorityCode</b>, which <b>SHOULD</b> be selected from ValueSet ActPriority<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16866/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16866</a></b><b> DYNAMIC</b><b> (CONF:1098-32443)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Care Model<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.61/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.61</a></b><b> DYNAMIC</b><b> (CONF:1098-31611)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31635)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> has reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31636)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32634)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> provision of
+        care (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-30884)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Patient Referral Act moodCode<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.66/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.66</a></b><b> STATIC</b> 2014-09-01<b>
+          (CONF:1098-30885)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30886)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.140"</b><b>
+              (CONF:1098-30887)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-30888)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected
+        from ValueSet Referral Types<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.56/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.56</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-30889)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30892)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31598)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-30893)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>priorityCode</b><b>
+          (CONF:1098-32623)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31612)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-32635)</b>.
+        <ul>
+          <li>The participant, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFT"</b>
+            Referred to (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32638)</b>.</li>
+        </ul>
+        <ul>
+          <li>The participant, if present, <b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b>
+              (CONF:1098-32636)</b>.</li>
+          <ul>
+            <li>This participantRole <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected
+              from ValueSet Healthcare Provider Taxonomy<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b>
+                DYNAMIC</b><b> (CONF:1098-32637)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-31604)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31613)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1098-31605)</b>.</li>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> observation
+              (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+                (CONF:1098-31606)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"RQO"</b> request
+              (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b>
+                (CONF:1098-31607)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31608)</b>.</li>
+            <ul>
+              <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> assertion<b>
+                  (CONF:1098-31619)</b>.</li>
+            </ul>
+            <ul>
+              <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4 "</b>
+                (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+                  (CONF:1098-31620)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31614)</b>.
+            </li>
+            <ul>
+              <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+                (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b>
+                  (CONF:1098-31615)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This observation <b>SHOULD</b> contain zero or one [0..1] <b>priorityCode</b>, which <b>SHOULD</b> be
+              selected from ValueSet ActPriority<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.16866/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.16866</a></b><b>
+                DYNAMIC</b><b> (CONF:1098-32443)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+              code <b>SHOULD</b> be selected from ValueSet Care Model<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.61/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.61</a></b><b>
+                DYNAMIC</b><b> (CONF:1098-31611)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-31635)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> has reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31636)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32634)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Patient%20Referral%20Act_2.16.840.1.113883.10.20.22.4.140/Patient%20Referral%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Referral Act Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Patient%20Referral%20Act_2.16.840.1.113883.10.20.22.4.140/Patient%20Referral%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Referral Act Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.141.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.141.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,143 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Handoff Communication Participants <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.141, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.141.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Handoff Communication Participants <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.141,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.141.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the sender (author) and receivers (participants) of a handoff communication in a plan of treatment. It does not convey details about the communication. The "handoff" process involves senders, those transmitting the patient's information and releasing the care of that patient to the next clinician, and receivers, those who accept the patient information and care of that patient.</p></div>
+    <div id="description">
+      <p>This template represents the sender (author) and receivers (participants) of a handoff communication in a plan
+        of treatment. It does not convey details about the communication. The "handoff" process involves senders, those
+        transmitting the patient's information and releasing the care of that patient to the next clinician, and
+        receivers, those who accept the patient information and care of that patient.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-30832)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-30833)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30834)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.141"</b><b> (CONF:1098-30835)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-30836)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"432138007"</b> handoff communication (procedure)<b> (CONF:1098-30837)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1098-30838)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31668)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31669)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-31670)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31672)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>participant</b><b> (CONF:1098-31673)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IRCP"</b> Information Recipient (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b>)<b> (CONF:1098-31674)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1098-31675)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32422)</b>.</li></ul><ul><li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1098-31676)</b>.</li></ul><ul><li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>addr</b><b> (CONF:1098-32392)</b>.</li></ul><ul><li>This participantRole <b>MAY</b> contain zero or one [0..1] <b>playingEntity</b><b> (CONF:1098-32393)</b>.</li><ul><li>The playingEntity, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1098-32394)</b>.</li></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-30832)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-30833)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30834)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.141"</b><b>
+              (CONF:1098-30835)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-30836)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"432138007"</b> handoff communication
+            (procedure)<b> (CONF:1098-30837)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1098-30838)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-31668)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b>
+              (CONF:1098-31669)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-31670)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31672)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>participant</b><b> (CONF:1098-31673)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IRCP"</b> Information Recipient (CodeSystem:
+            <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b>)<b> (CONF:1098-31674)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1098-31675)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32422)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be
+              selected from ValueSet Healthcare Provider Taxonomy<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b>
+                DYNAMIC</b><b> (CONF:1098-31676)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>addr</b><b> (CONF:1098-32392)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>MAY</b> contain zero or one [0..1] <b>playingEntity</b><b>
+                (CONF:1098-32393)</b>.</li>
+            <ul>
+              <li>The playingEntity, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b>
+                  (CONF:1098-32394)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Handoff%20Communication%20Participants_2.16.840.1.113883.10.20.22.4.141/Handoff%20Communication%20Example.xml"><i class="fab fa-github"></i>&nbsp;Handoff Communication Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Handoff%20Communication%20Participants_2.16.840.1.113883.10.20.22.4.141/Handoff%20Communication%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Handoff Communication Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.143.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.143.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,116 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Priority Preference <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.143, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.143.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Priority Preference <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.143, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.22.4.143.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents priority preferences chosen by a patient or a care provider. Priority preferences are choices made by care providers or patients or both relative to options for care or treatment (including scheduling, care experience, and meeting of personal health goals), the sharing and disclosure of health information, and the prioritization of concerns and problems.</p></div>
+    <div id="description">
+      <p>This template represents priority preferences chosen by a patient or a care provider. Priority preferences are
+        choices made by care providers or patients or both relative to options for care or treatment (including
+        scheduling, care experience, and meeting of personal health goals), the sharing and disclosure of health
+        information, and the prioritization of concerns and problems.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.3.html">Problem Concern Act (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-30949)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-30950)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30951)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.143"</b><b> (CONF:1098-30952)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-30953)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-30954)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"225773000"</b> Preference<b> (CONF:1098-30955)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1098-30956)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-32327)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Priority Level<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.60/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.60</a></b><b> DYNAMIC</b><b> (CONF:1098-30957)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-30958)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-30949)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-30950)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30951)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.143"</b><b>
+              (CONF:1098-30952)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-30953)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-30954)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"225773000"</b> Preference<b>
+              (CONF:1098-30955)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1098-30956)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-32327)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Priority Level<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.60/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.60</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-30957)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-30958)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Priority%20Preference_2.16.840.1.113883.10.20.22.4.143/Priority%20Preference%20Example.xml"><i class="fab fa-github"></i>&nbsp;Priority Preference Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Priority%20Preference_2.16.840.1.113883.10.20.22.4.143/Priority%20Preference%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Priority Preference Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.144.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.144.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,60 +52,168 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Outcome Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.144, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.144.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Outcome Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.144, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.22.4.144.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the outcome of care resulting from the interventions used to treat the patient. In the Care Planning workflow, the judgment about how well the person is progressing towards the goal is based on the observations made about the status of the patient with respect to interventions performed in the pursuit of achieving that goal.</p><p>Often thought of as an "actual outcome", the Outcome Observation may be related to goals, progression toward goals, and the associated interventions. For example, an observation outcome of a blood oxygen saturation level of 95% is related to the goal of "Maintain Pulse Ox greater than 92", which in turn is related to the health concern of respiratory insufficiency and the problem of pneumonia. The template makes use of the Entry Reference (templateId:2.16.840.1.113883.10.20.22.4.122) to reference the interventions and goals defined elsewhere in the Care Plan CDA instance.</p></div>
+    <div id="description">
+      <p>This template represents the outcome of care resulting from the interventions used to treat the patient. In the
+        Care Planning workflow, the judgment about how well the person is progressing towards the goal is based on the
+        observations made about the status of the patient with respect to interventions performed in the pursuit of
+        achieving that goal.</p>
+      <p>Often thought of as an "actual outcome", the Outcome Observation may be related to goals, progression toward
+        goals, and the associated interventions. For example, an observation outcome of a blood oxygen saturation level
+        of 95% is related to the goal of "Maintain Pulse Ox greater than 92", which in turn is related to the health
+        concern of respiratory insufficiency and the problem of pneumonia. The template makes use of the Entry Reference
+        (templateId:2.16.840.1.113883.10.20.22.4.122) to reference the interventions and goals defined elsewhere in the
+        Care Plan CDA instance.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.61.html">Health Status Evaluations and Outcomes Section</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.110.html">Progress Toward Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.61.html">Health Status Evaluations and Outcomes
+              Section</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.110.html">Progress Toward Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31219)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31220)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31221)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.144"</b><b> (CONF:1098-31222)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31223)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> (CONF:1098-32746)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>value</b><b> (CONF:1098-32747)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31553)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31224)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"GEVL"</b> Evaluates goal (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31225)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1098-32465)</b>.</li></ul><ul><li><p>This entryReference template <strong>SHALL</strong> reference an instance of a Goal Observation template (CONF:1098-32461).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-31427)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31428)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b><b> (CONF:1098-31429)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Progress Toward Goal Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.110)</b><b> (CONF:1098-31430)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31688)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31689)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1098-31690)</b>.</li></ul><ul><li><p>This entryReference template <strong>SHALL</strong> reference an instance of a Intervention Act template (CONF:1098-32462).</p></li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:1098-32763)</b>.<ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32764)</b>.</li></ul><ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1]  External Document Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:1098-32765)</b>.</li></ul></li>
-<li class="list-group-item"> <p>SHALL contain at least one [1..*] entryRelationships (CONF:1098-32782).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-31219)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:1098-31220)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-31221)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.144"</b><b>
+              (CONF:1098-31222)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-31223)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> (CONF:1098-32746)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>value</b><b> (CONF:1098-32747)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31553)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-31224)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"GEVL"</b> Evaluates goal (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31225)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1098-32465)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>This entryReference template <strong>SHALL</strong> reference an instance of a Goal Observation template
+              (CONF:1098-32461).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-31427)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31428)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b><b> (CONF:1098-31429)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Progress Toward Goal Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.110)</b><b> (CONF:1098-31430)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-31688)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31689)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1098-31690)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>This entryReference template <strong>SHALL</strong> reference an instance of a Intervention Act template
+              (CONF:1098-32462).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:1098-32763)</b>.<ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers
+            to (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32764)</b>.</li>
+        </ul>
+        <ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] External Document Reference<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:1098-32765)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>SHALL contain at least one [1..*] entryRelationships (CONF:1098-32782).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Outcome%20Observation_2.16.840.1.113883.10.20.22.4.144/Outcome%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Outcome Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Outcome%20Observation_2.16.840.1.113883.10.20.22.4.144/Outcome%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Outcome Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.145.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.145.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,112 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Criticality Observation  <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.145, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.145.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Criticality Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.145,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.145.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This observation represents the gravity of the potential risk for future life-threatening adverse reactions when exposed to a substance known to cause an adverse reaction in that individual. When the worst case result is assessed to have a life-threatening or organ system threatening potential, it is considered to be of high criticality.</p></div>
+    <div id="description">
+      <p>This observation represents the gravity of the potential risk for future life-threatening adverse reactions
+        when exposed to a substance known to cause an adverse reaction in that individual. When the worst case result is
+        assessed to have a life-threatening or organ system threatening potential, it is considered to be of high
+        criticality.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance
+              Observation (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-32921)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-32922)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-32918)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.145"</b><b> (CONF:81-32923)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-32919)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"82606-5"</b> Criticality<b> (CONF:81-32925)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-32926)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-32920)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:81-32927)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Criticality Observation<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20549/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20549</a></b><b> DYNAMIC</b><b> (CONF:81-32928)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-32921)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-32922)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-32918)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.145"</b><b>
+              (CONF:81-32923)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-32919)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"82606-5"</b> Criticality<b>
+              (CONF:81-32925)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-32926)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-32920)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:81-32927)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Criticality Observation<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20549/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20549</a></b><b> DYNAMIC</b><b>
+          (CONF:81-32928)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Criticality%20Observation%20_2.16.840.1.113883.10.20.22.4.145/Criticality%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Criticality Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Criticality%20Observation%20_2.16.840.1.113883.10.20.22.4.145/Criticality%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Criticality Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.146.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.146.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,76 +52,415 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Intervention Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.146, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.146.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Intervention Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.146,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.146.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a Planned Intervention Act. It is a wrapper for planned intervention-type activities considered to be parts of the same intervention. For example, an activity such as "elevate head of bed" combined with "provide humidified O2 per nasal cannula" may be the interventions planned for a health concern of "respiratory insufficiency" in order to attempt to achieve a goal of "pulse oximetry greater than 92%". These intervention activities may be newly described or derived from a variety of sources within an EHR.</p><p>Interventions are actions taken to increase the likelihood of achieving the patient's or providers' goals. An Intervention Act should contain a reference to a Goal Observation representing the reason for the intervention.</p><p>Planned Intervention Acts can be related to each other or to Intervention Acts. (E.g., a Planned Intervention Act with moodCode of INT could be related to a series of Intervention Acts with moodCode of EVN, each having an effectiveTime containing the time of the intervention.)</p><p>All interventions referenced in a Planned Intervention Act must have moodCodes indicating that that are planned (have not yet occurred).</p></div>
+    <div id="description">
+      <p>This template represents a Planned Intervention Act. It is a wrapper for planned intervention-type activities
+        considered to be parts of the same intervention. For example, an activity such as "elevate head of bed" combined
+        with "provide humidified O2 per nasal cannula" may be the interventions planned for a health concern of
+        "respiratory insufficiency" in order to attempt to achieve a goal of "pulse oximetry greater than 92%". These
+        intervention activities may be newly described or derived from a variety of sources within an EHR.</p>
+      <p>Interventions are actions taken to increase the likelihood of achieving the patient's or providers' goals. An
+        Intervention Act should contain a reference to a Goal Observation representing the reason for the intervention.
+      </p>
+      <p>Planned Intervention Acts can be related to each other or to Intervention Acts. (E.g., a Planned Intervention
+        Act with moodCode of INT could be related to a series of Intervention Acts with moodCode of EVN, each having an
+        effectiveTime containing the time of the intervention.)</p>
+      <p>All interventions referenced in a Planned Intervention Act must have moodCodes indicating that that are planned
+        (have not yet occurred).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.21.2.3.html">Interventions Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.141.html">Handoff Communication Participants</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.115.html">External Document Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-32678)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Planned Intervention moodCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.54/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.54</a></b><b> DYNAMIC</b><b> (CONF:1198-32679)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-32653)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.146"</b><b> (CONF:1198-32680)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32912)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-32681)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-32654)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"362956003"</b> procedure / intervention (navigational concept)<b> (CONF:1198-32682)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-32683)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32655)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-32684)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1198-32723)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-32719)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32652)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32685)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Advance Directive Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-32677)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32656)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32686)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Immunization Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.52)</b><b> (CONF:1198-32687)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32657)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32688)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1198-32689)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32658)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32690)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.12)</b><b> (CONF:1198-32691)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the relationship between two Intervention Acts (Intervention RELATES TO Intervention).<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32659)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32692)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Intervention Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.131)</b><b> (CONF:1198-32693)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32660)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32694)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.13)</b><b> (CONF:1198-32695)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32661)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32696)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1198-32697)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32662)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32698)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Encounter Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.49)</b><b> (CONF:1198-32699)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32663)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32957)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1198-32701)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32664)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32702)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Non-Medicinal Supply Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1198-32703)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32665)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32704)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.39)</b><b> (CONF:1198-32705)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32666)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32706)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Encounter (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.40)</b><b> (CONF:1198-32707)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32667)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32708)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.44)</b><b> (CONF:1198-32709)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32668)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32710)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.41)</b><b> (CONF:1198-32711)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32669)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32712)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.42)</b><b> (CONF:1198-32713)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32670)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32714)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Supply (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.43)</b><b> (CONF:1198-32715)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32671)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Nutrition Recommendation<b> (identifier: 2.16.840.1.113883.10.20.22.4.130)</b><b> (CONF:1198-32716)</b>.</li></ul></li>
-<li class="list-group-item"><p>Where an Intervention needs to reference another entry already described in the CDA document instance, rather than repeating the full content of the entry, the Entry Reference template may be used to reference this entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32672)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32717)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32718)</b>.</li></ul></li>
-<li class="list-group-item"><p>An Intervention Act SHALL reference a Goal Observation. Because the Goal Observation is already described in the CDA document instance's Goals section, rather than repeating the full content of the Goal Observation, the Entry Reference template can be used to reference this entry. The following entryRelationship represents an Entry Reference to Goal Observation.<br></p> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-32673)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32720)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32721)</b>.</li></ul><ul><li><p>This entryReference template <strong>SHALL</strong> reference an instance of a Goal Observation template (CONF:1198-32722).</p></li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32675)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32726)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Handoff Communication Participants<b> (identifier: 2.16.840.1.113883.10.20.22.4.141)</b><b> (CONF:1198-32727)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32676)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32728)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Immunization Activity<b> (identifier: 2.16.840.1.113883.10.20.22.4.120)</b><b> (CONF:1198-32729)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:1198-32766)</b>.<ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32767)</b>.</li></ul><ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1]  External Document Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:1198-32768)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-32678)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Planned Intervention moodCode<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.54/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.54</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-32679)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-32653)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.146"</b><b>
+              (CONF:1198-32680)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32912)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-32681)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-32654)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"362956003"</b> procedure / intervention
+            (navigational concept)<b> (CONF:1198-32682)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-32683)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32655)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b>
+              (CONF:1198-32684)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1198-32723)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-32719)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32652)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32685)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Advance Directive Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.48)</b><b> (CONF:1198-32677)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32656)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32686)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Immunization Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.52)</b><b> (CONF:1198-32687)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32657)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32688)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1198-32689)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32658)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32690)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.12)</b><b> (CONF:1198-32691)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the relationship between two Intervention Acts (Intervention
+          RELATES TO Intervention).<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32659)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32692)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Intervention Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.131)</b><b> (CONF:1198-32693)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32660)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32694)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.13)</b><b> (CONF:1198-32695)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32661)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32696)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1198-32697)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32662)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32698)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Encounter Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.49)</b><b> (CONF:1198-32699)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32663)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32957)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1198-32701)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32664)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32702)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Non-Medicinal Supply Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1198-32703)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32665)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32704)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.39)</b><b> (CONF:1198-32705)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32666)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32706)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Encounter (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.40)</b><b> (CONF:1198-32707)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32667)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32708)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.44)</b><b> (CONF:1198-32709)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32668)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32710)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.41)</b><b> (CONF:1198-32711)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32669)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32712)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.42)</b><b> (CONF:1198-32713)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32670)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32714)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Supply (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.43)</b><b> (CONF:1198-32715)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32671)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Nutrition Recommendation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.130)</b><b> (CONF:1198-32716)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Where an Intervention needs to reference another entry already described in the CDA document instance, rather
+          than repeating the full content of the entry, the Entry Reference template may be used to reference this
+          entry.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-32672)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32717)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32718)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>An Intervention Act SHALL reference a Goal Observation. Because the Goal Observation is already described in
+          the CDA document instance's Goals section, rather than repeating the full content of the Goal Observation, the
+          Entry Reference template can be used to reference this entry. The following entryRelationship represents an
+          Entry Reference to Goal Observation.<br></p> <b>SHALL</b> contain at least one [1..*]
+        <b>entryRelationship</b><b> (CONF:1198-32673)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32720)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:1198-32721)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>This entryReference template <strong>SHALL</strong> reference an instance of a Goal Observation template
+              (CONF:1198-32722).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32675)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32726)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Handoff Communication Participants<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.141)</b><b> (CONF:1198-32727)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-32676)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-32728)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Immunization Activity<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.120)</b><b> (CONF:1198-32729)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:1198-32766)</b>.<ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers
+            to (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-32767)</b>.</li>
+        </ul>
+        <ul>
+          <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] External Document Reference<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.115)</b><b> (CONF:1198-32768)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.147.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.147.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,125 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medication Free Text Sig <small class="text-muted">[substanceAdministration, 2.16.840.1.113883.10.20.22.4.147, closed] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.147.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medication Free Text Sig <small class="text-muted">[substanceAdministration,
+        2.16.840.1.113883.10.20.22.4.147, closed] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.147.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The template is available to explicitly identify the free text Sig within each medication.</p><p>An example free text sig: Thyroxin 150 ug, take one tab by mouth every morning.</p></div>
+    <div id="description">
+      <p>The template is available to explicitly identify the free text Sig within each medication.</p>
+      <p>An example free text sig: Thyroxin 150 ug, take one tab by mouth every morning.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-32770)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet MoodCodeEvnInt<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.18/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.18</a></b><b> STATIC</b> 2011-04-03<b> (CONF:81-32771)</b>.<br>Note: moodCode must match the parent substanceAdministration EVN or INT </li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-32753)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.147"</b><b> (CONF:81-32772)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-32775)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"76662-6"</b> Instructions Medication<b> (CONF:81-32780)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:81-32781)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-32754)</b>.<ul><li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:81-32755)</b>.</li><ul><li>This reference <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:81-32756)</b>.</li><ul><li><p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:81-32774).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:81-32776)</b>.<ul><li>This consumable <b>SHALL</b> contain exactly one [1..1] <b>manufacturedProduct</b><b> (CONF:81-32777)</b>.</li><ul><li>This manufacturedProduct <b>SHALL</b> contain exactly one [1..1] <b>manufacturedLabeledDrug</b><b> (CONF:81-32778)</b>.</li><ul><li>This manufacturedLabeledDrug <b>SHALL</b> contain exactly one [1..1] <b>@nullFlavor</b>=<b>"NA"</b> Not Applicable<b> (CONF:81-32779)</b>.</li></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:81-32770)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet MoodCodeEvnInt<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.18/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.18</a></b><b> STATIC</b> 2011-04-03<b>
+          (CONF:81-32771)</b>.<br>Note: moodCode must match the parent substanceAdministration EVN or INT </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-32753)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.147"</b><b>
+              (CONF:81-32772)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b> (CodeSystem: <b>LOINC
+          2.16.840.1.113883.6.1</b>)<b> (CONF:81-32775)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"76662-6"</b> Instructions Medication<b>
+              (CONF:81-32780)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:81-32781)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-32754)</b>.<ul>
+          <li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:81-32755)</b>.</li>
+          <ul>
+            <li>This reference <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:81-32756)</b>.</li>
+            <ul>
+              <li>
+                <p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using
+                  the approach defined in CDA Release 2, section 4.3.5.1) (CONF:81-32774).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:81-32776)</b>.<ul>
+          <li>This consumable <b>SHALL</b> contain exactly one [1..1] <b>manufacturedProduct</b><b> (CONF:81-32777)</b>.
+          </li>
+          <ul>
+            <li>This manufacturedProduct <b>SHALL</b> contain exactly one [1..1] <b>manufacturedLabeledDrug</b><b>
+                (CONF:81-32778)</b>.</li>
+            <ul>
+              <li>This manufacturedLabeledDrug <b>SHALL</b> contain exactly one [1..1] <b>@nullFlavor</b>=<b>"NA"</b>
+                Not Applicable<b> (CONF:81-32779)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Free%20Text%20Sig_2.16.840.1.113883.10.20.22.4.147/Medication%20Free%20Text%20Sig%20Example.xml"><i class="fab fa-github"></i>&nbsp;Medication Free Text Sig Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Free%20Text%20Sig_2.16.840.1.113883.10.20.22.4.147/Medication%20Free%20Text%20Sig%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Medication Free Text Sig Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i> Medications</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i>
+          Medications</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.16.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.16.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,75 +52,400 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medication Activity (V2) <small class="text-muted">[substanceAdministration, 2.16.840.1.113883.10.20.22.4.16, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.16.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medication Activity (V2) <small class="text-muted">[substanceAdministration,
+        2.16.840.1.113883.10.20.22.4.16, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.16.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Medication Activity describes substance administrations that have actually occurred (e.g., pills ingested or injections given) or are intended to occur (e.g., "take 2 tablets twice a day for the next 10 days"). Medication activities in "INT" mood are reflections of what a clinician intends a patient to be taking. For example, a clinician may intend that a patient be administered Lisinopril 20 mg PO for blood pressure control. If what was actually administered was Lisinopril 10 mg., then the Medication activities in the "EVN" mood would reflect actual use.</p><p>A moodCode of INT is allowed, but it is recommended that the Planned Medication Activity (V2) template be used for moodCodes other than EVN if the document type contains a section that includes Planned Medication Activity (V2) (for example a Care Plan document with Plan of Treatment, Intervention, or Goal sections).At a minimum, a Medication Activity shall include an effectiveTime indicating the duration of the administration (or single-administration timestamp). Ambulatory medication lists generally provide a summary of use for a given medication over time - a medication activity in event mood with the duration reflecting when the medication started and stopped. Ongoing medications will not have a stop date (or will have a stop date with a suitable NULL value). Ambulatory medication lists will generally also have a frequency (e.g., a medication is being taken twice a day). Inpatient medications generally record each administration as a separate act.</p><p>The dose (doseQuantity) represents how many of the consumables are to be administered at each administration event. As a result, the dose is always relative to the consumable and the interval of administration. Thus, a patient consuming a single "metoprolol 25mg tablet" per administration will have a doseQuantity of "1", whereas a patient consuming "metoprolol" will have a dose of "25 mg".</p></div>
+    <div id="description">
+      <p>A Medication Activity describes substance administrations that have actually occurred (e.g., pills ingested or
+        injections given) or are intended to occur (e.g., "take 2 tablets twice a day for the next 10 days"). Medication
+        activities in "INT" mood are reflections of what a clinician intends a patient to be taking. For example, a
+        clinician may intend that a patient be administered Lisinopril 20 mg PO for blood pressure control. If what was
+        actually administered was Lisinopril 10 mg., then the Medication activities in the "EVN" mood would reflect
+        actual use.</p>
+      <p>A moodCode of INT is allowed, but it is recommended that the Planned Medication Activity (V2) template be used
+        for moodCodes other than EVN if the document type contains a section that includes Planned Medication Activity
+        (V2) (for example a Care Plan document with Plan of Treatment, Intervention, or Goal sections).At a minimum, a
+        Medication Activity shall include an effectiveTime indicating the duration of the administration (or
+        single-administration timestamp). Ambulatory medication lists generally provide a summary of use for a given
+        medication over time - a medication activity in event mood with the duration reflecting when the medication
+        started and stopped. Ongoing medications will not have a stop date (or will have a stop date with a suitable
+        NULL value). Ambulatory medication lists will generally also have a frequency (e.g., a medication is being taken
+        twice a day). Inpatient medications generally record each administration as a separate act.</p>
+      <p>The dose (doseQuantity) represents how many of the consumables are to be administered at each administration
+        event. As a result, the dose is always relative to the consumable and the interval of administration. Thus, a
+        patient consuming a single "metoprolol 25mg tablet" per administration will have a doseQuantity of "1", whereas
+        a patient consuming "metoprolol" will have a dose of "25 mg".</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries required) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.1.html">Medications Section (entries optional) (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.36.html">Admission Medication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.38.html">Medications Administered Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.25.html">Anesthesia Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.35.html">Discharge Medication (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.24.html">Drug Vehicle</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.123.html">Drug Monitoring Act</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.118.html">Substance Administered Act</a><br><a href="2.16.840.1.113883.10.20.22.4.25.html">Precondition for Substance Administration (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.147.html">Medication Free Text Sig</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.1.1.html">Medications Section (entries required)
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.1.html">Medications Section (entries optional)
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.36.html">Admission Medication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.38.html">Medications Administered Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.25.html">Anesthesia Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.35.html">Discharge Medication (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.24.html">Drug Vehicle</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.123.html">Drug Monitoring Act</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.118.html">Substance Administered Act</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.25.html">Precondition for Substance Administration (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.147.html">Medication Free Text Sig</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7496)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet MoodCodeEvnInt<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.18/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.18</a></b><b> STATIC</b> 2011-04-03<b> (CONF:1098-7497)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7499)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.16"</b><b> (CONF:1098-10504)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32498)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7500)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1098-7506)</b>.<br>Note: SubstanceAdministration.code is an optional field. Per HL7 Pharmacy Committee, "this is intended to further specify the nature of the substance administration act. To date the committee has made no use of this attribute". Because the type of substance administration is generally implicit in the routeCode, in the consumable participant, etc., the field is generally not used, and there is no defined value set.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7507)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Medication Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.11/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.11</a></b><b> DYNAMIC</b><b> (CONF:1098-32360)</b>.</li></ul></li>
-<li class="list-group-item"><p>The substance administration effectiveTime field can repeat, in order to represent varying levels of complex dosing. effectiveTime can be used to represent the duration of administration (e.g., "10 days"), the frequency of administration (e.g., "every 8 hours"), and more. Here, we require that there <b>SHALL</b> be an effectiveTime documentation of the duration (or single-administration timestamp), and that there <b>SHOULD</b> be an effectiveTime documentation of the frequency. Other timing nuances, supported by the base CDA R2 standard, may also be included.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-7508)</b> such that it<br>Note: This effectiveTime represents either the medication duration (i.e., the time the medication was started and stopped) or the single-administration timestamp.<ul><li><b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:1098-32775)</b>.<br>Note: indicates a single-administration timestamp</li></ul><ul><li><b>SHOULD</b> contain zero or one [0..1] <b>low</b><b> (CONF:1098-32776)</b>.<br>Note: indicates when medication started</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-32777)</b>.<br>Note: indicates when medication stopped</li></ul><ul><li><p>This effectiveTime <strong>SHALL</strong> contain either a low or a @value but not both (CONF:1098-32890).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-7513)</b> such that it<br>Note: This effectiveTime represents the medication frequency (e.g., administration times per day).<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@operator</b>=<b>"A"</b><b> (CONF:1098-9106)</b>.</li></ul><ul><li><p><strong>SHALL</strong> contain exactly one [1..1] @xsi:type="PIVL_TS" or "EIVL_TS" (CONF:1098-28499).</p></li></ul></li>
-<li class="list-group-item"><p>In "INT" (intent) mood, the repeatNumber defines the number of allowed administrations. For example, a repeatNumber of "3" means that the substance can be administered up to 3 times. In "EVN" (event) mood, the repeatNumber is the number of occurrences. For example, a repeatNumber of "3" in a substance administration event means that the current administration is the 3rd in a series.<br></p> <b>MAY</b> contain zero or one [0..1] <b>repeatNumber</b><b> (CONF:1098-7555)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>routeCode</b>, which <b>SHALL</b> be selected from ValueSet SPL Drug Route of Administration Terminology<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.7/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.7</a></b><b> DYNAMIC</b><b> (CONF:1098-7514)</b>.<ul><li>The routeCode, if present, <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which <b>SHALL</b> be selected from ValueSet Medication Route<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.12/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.12</a></b><b> DYNAMIC</b><b> (CONF:1098-32950)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>approachSiteCode</b>, where the code <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b> DYNAMIC</b><b> (CONF:1098-7515)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>doseQuantity</b><b> (CONF:1098-7516)</b>.<ul><li>This doseQuantity <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b> DYNAMIC</b><b> (CONF:1098-7526)</b>.</li></ul><ul><li><p>Pre-coordinated consumable: If the consumable code is a pre-coordinated unit dose (e.g., "metoprolol 25mg tablet") then doseQuantity is a unitless number that indicates the number of products given per administration (e.g., "2", meaning 2 x "metoprolol 25mg tablet" per administration) (CONF:1098-16878).</p></li></ul><ul><li><p>Not pre-coordinated consumable: If the consumable code is not pre-coordinated (e.g., is simply "metoprolol"), then doseQuantity must represent a physical quantity with @unit, e.g., "25" and "mg", specifying the amount of product given per administration (CONF:1098-16879).</p></li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>rateQuantity</b><b> (CONF:1098-7517)</b>.<ul><li>The rateQuantity, if present, <b>SHALL</b> contain exactly one [1..1] <b>@unit</b>, which <b>SHALL</b> be selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b> DYNAMIC</b><b> (CONF:1098-7525)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>maxDoseQuantity</b><b> (CONF:1098-7518)</b>.</li>
-<li class="list-group-item"><p>administrationUnitCode@code describes the units of medication administration for an item using a code that is pre-coordinated to include a physical unit form (ointment, powder, solution, etc.) which differs from the units used in administering the consumable (capful, spray, drop, etc.). For example when recording medication administrations, 'metric drop (C48491)' would be appropriate to accompany the RxNorm code of 198283 (Timolol 0.25% Ophthalmic Solution) where the number of drops would be specified in doseQuantity@value.<br></p> <b>MAY</b> contain zero or one [0..1] <b>administrationUnitCode</b>, which <b>SHALL</b> be selected from ValueSet AdministrationUnitDoseForm<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.30/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.30</a></b><b> DYNAMIC</b><b> (CONF:1098-7519)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:1098-7520)</b>.<ul><li>This consumable <b>SHALL</b> contain exactly one [1..1]  Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-16085)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>performer</b><b> (CONF:1098-7522)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31150)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-7523)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CSM"</b> (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1098-7524)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Drug Vehicle<b> (identifier: 2.16.840.1.113883.10.20.22.4.24)</b><b> (CONF:1098-16086)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-7536)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7537)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-16087)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-7539)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7540)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7542)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31387)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-7543)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7547)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Supply Order (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.17)</b><b> (CONF:1098-16089)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-7549)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7553)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Dispense (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.18)</b><b> (CONF:1098-16090)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-7552)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CAUS"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7544)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Reaction Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1098-16091)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-30820)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component<b> (CONF:1098-30821)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Drug Monitoring Act<b> (identifier: 2.16.840.1.113883.10.20.22.4.123)</b><b> (CONF:1098-30822)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship is used to indicate a given medication's order in a series. The nested Substance Administered Act identifies an administration in the series. The entryRelationship/sequenceNumber shows the order of this particular administration in that series.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31515)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31516)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b><b> (CONF:1098-31517)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>sequenceNumber</b><b> (CONF:1098-31518)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Substance Administered Act<b> (identifier: 2.16.840.1.113883.10.20.22.4.118)</b><b> (CONF:1098-31519)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32907)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32908)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Free Text Sig<b> (identifier: 2.16.840.1.113883.10.20.22.4.147)</b><b> (CONF:1098-32909)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>precondition</b><b> (CONF:1098-31520)</b>.<ul><li>The precondition, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRCN"</b><b> (CONF:1098-31882)</b>.</li></ul><ul><li>The precondition, if present, <b>SHALL</b> contain exactly one [1..1]  Precondition for Substance Administration (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.25)</b><b> (CONF:1098-31883)</b>.</li></ul></li>
-<li class="list-group-item"> <p>Medication Activity <strong>SHOULD</strong> include doseQuantity <strong>OR</strong> rateQuantity (CONF:1098-30800).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-7496)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet MoodCodeEvnInt<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.18/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.18</a></b><b> STATIC</b> 2011-04-03<b>
+          (CONF:1098-7497)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7499)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.16"</b><b>
+              (CONF:1098-10504)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32498)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7500)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1098-7506)</b>.<br>Note:
+        SubstanceAdministration.code is an optional field. Per HL7 Pharmacy Committee, "this is intended to further
+        specify the nature of the substance administration act. To date the committee has made no use of this
+        attribute". Because the type of substance administration is generally implicit in the routeCode, in the
+        consumable participant, etc., the field is generally not used, and there is no defined value set.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7507)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet Medication Status<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.11/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.11</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32360)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The substance administration effectiveTime field can repeat, in order to represent varying levels of complex
+          dosing. effectiveTime can be used to represent the duration of administration (e.g., "10 days"), the frequency
+          of administration (e.g., "every 8 hours"), and more. Here, we require that there <b>SHALL</b> be an
+          effectiveTime documentation of the duration (or single-administration timestamp), and that there <b>SHOULD</b>
+          be an effectiveTime documentation of the frequency. Other timing nuances, supported by the base CDA R2
+          standard, may also be included.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-7508)</b> such that it<br>Note: This effectiveTime represents either the medication duration (i.e.,
+        the time the medication was started and stopped) or the single-administration timestamp.<ul>
+          <li><b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:1098-32775)</b>.<br>Note: indicates a
+            single-administration timestamp</li>
+        </ul>
+        <ul>
+          <li><b>SHOULD</b> contain zero or one [0..1] <b>low</b><b> (CONF:1098-32776)</b>.<br>Note: indicates when
+            medication started</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-32777)</b>.<br>Note: indicates when
+            medication stopped</li>
+        </ul>
+        <ul>
+          <li>
+            <p>This effectiveTime <strong>SHALL</strong> contain either a low or a @value but not both
+              (CONF:1098-32890).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-7513)</b>
+        such that it<br>Note: This effectiveTime represents the medication frequency (e.g., administration times per
+        day).<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@operator</b>=<b>"A"</b><b> (CONF:1098-9106)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p><strong>SHALL</strong> contain exactly one [1..1] @xsi:type="PIVL_TS" or "EIVL_TS" (CONF:1098-28499).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>In "INT" (intent) mood, the repeatNumber defines the number of allowed administrations. For example, a
+          repeatNumber of "3" means that the substance can be administered up to 3 times. In "EVN" (event) mood, the
+          repeatNumber is the number of occurrences. For example, a repeatNumber of "3" in a substance administration
+          event means that the current administration is the 3rd in a series.<br></p> <b>MAY</b> contain zero or one
+        [0..1] <b>repeatNumber</b><b> (CONF:1098-7555)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>routeCode</b>, which <b>SHALL</b> be
+        selected from ValueSet SPL Drug Route of Administration Terminology<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.7/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.7</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-7514)</b>.<ul>
+          <li>The routeCode, if present, <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which
+            <b>SHALL</b> be selected from ValueSet Medication Route<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.12/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.12</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32950)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>approachSiteCode</b>, where the code
+        <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-7515)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>doseQuantity</b><b> (CONF:1098-7516)</b>.
+        <ul>
+          <li>This doseQuantity <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be selected
+            from ValueSet UnitsOfMeasureCaseSensitive<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-7526)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>Pre-coordinated consumable: If the consumable code is a pre-coordinated unit dose (e.g., "metoprolol 25mg
+              tablet") then doseQuantity is a unitless number that indicates the number of products given per
+              administration (e.g., "2", meaning 2 x "metoprolol 25mg tablet" per administration) (CONF:1098-16878).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>Not pre-coordinated consumable: If the consumable code is not pre-coordinated (e.g., is simply
+              "metoprolol"), then doseQuantity must represent a physical quantity with @unit, e.g., "25" and "mg",
+              specifying the amount of product given per administration (CONF:1098-16879).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>rateQuantity</b><b> (CONF:1098-7517)</b>.
+        <ul>
+          <li>The rateQuantity, if present, <b>SHALL</b> contain exactly one [1..1] <b>@unit</b>, which <b>SHALL</b> be
+            selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-7525)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>maxDoseQuantity</b><b> (CONF:1098-7518)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>administrationUnitCode@code describes the units of medication administration for an item using a code that is
+          pre-coordinated to include a physical unit form (ointment, powder, solution, etc.) which differs from the
+          units used in administering the consumable (capful, spray, drop, etc.). For example when recording medication
+          administrations, 'metric drop (C48491)' would be appropriate to accompany the RxNorm code of 198283 (Timolol
+          0.25% Ophthalmic Solution) where the number of drops would be specified in doseQuantity@value.<br></p>
+        <b>MAY</b> contain zero or one [0..1] <b>administrationUnitCode</b>, which <b>SHALL</b> be selected from
+        ValueSet AdministrationUnitDoseForm<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.30/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.30</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-7519)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:1098-7520)</b>.
+        <ul>
+          <li>This consumable <b>SHALL</b> contain exactly one [1..1] Medication Information (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-16085)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>performer</b><b> (CONF:1098-7522)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31150)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-7523)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CSM"</b> (CodeSystem: <b>HL7ParticipationType
+              <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b>
+              (CONF:1098-7524)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Drug Vehicle<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.24)</b><b> (CONF:1098-16086)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-7536)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7537)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-16087)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-7539)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7540)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7542)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31387)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-7543)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7547)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Supply Order (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.17)</b><b> (CONF:1098-16089)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-7549)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7553)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Dispense (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.18)</b><b> (CONF:1098-16090)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-7552)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CAUS"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7544)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Reaction Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1098-16091)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-30820)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component<b>
+              (CONF:1098-30821)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Drug Monitoring Act<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.123)</b><b> (CONF:1098-30822)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship is used to indicate a given medication's order in a series. The nested
+          Substance Administered Act identifies an administration in the series. The entryRelationship/sequenceNumber
+          shows the order of this particular administration in that series.<br></p> <b>MAY</b> contain zero or more
+        [0..*] <b>entryRelationship</b><b> (CONF:1098-31515)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31516)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b><b> (CONF:1098-31517)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>sequenceNumber</b><b> (CONF:1098-31518)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Substance Administered Act<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.118)</b><b> (CONF:1098-31519)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-32907)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32908)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Free Text Sig<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.147)</b><b> (CONF:1098-32909)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>precondition</b><b> (CONF:1098-31520)</b>.
+        <ul>
+          <li>The precondition, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRCN"</b><b>
+              (CONF:1098-31882)</b>.</li>
+        </ul>
+        <ul>
+          <li>The precondition, if present, <b>SHALL</b> contain exactly one [1..1] Precondition for Substance
+            Administration (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.25)</b><b> (CONF:1098-31883)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Medication Activity <strong>SHOULD</strong> include doseQuantity <strong>OR</strong> rateQuantity
+          (CONF:1098-30800).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Activity%20(V2)_2.16.840.1.113883.10.20.22.4.16/Medication%20Activity%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Medication Activity (V2) Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Activity%20(V2)_2.16.840.1.113883.10.20.22.4.16/No%20Known%20Medications%20Example.xml"><i class="fab fa-github"></i>&nbsp;No Known Medications Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Activity%20(V2)_2.16.840.1.113883.10.20.22.4.16/Medication%20Activity%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Medication Activity (V2) Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Activity%20(V2)_2.16.840.1.113883.10.20.22.4.16/No%20Known%20Medications%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;No Known Medications Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i> Medications</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i>
+          Medications</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.17.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.17.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,58 +52,155 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medication Supply Order (V2) <small class="text-muted">[supply, 2.16.840.1.113883.10.20.22.4.17, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.17.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medication Supply Order (V2) <small class="text-muted">[supply, 2.16.840.1.113883.10.20.22.4.17,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.17.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template records the intent to supply a patient with medications.</p></div>
+    <div id="description">
+      <p>This template records the intent to supply a patient with medications.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SPLY"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7427)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-7428)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7429)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.17"</b><b> (CONF:1098-10507)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32578)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7430)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7432)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ActStatus<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b> DYNAMIC</b><b> (CONF:1098-32362)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-15143)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1098-15144)</b>.</li></ul></li>
-<li class="list-group-item"><p>In "INT" (intent) mood, the repeatNumber defines the number of allowed administrations. For example, a repeatNumber of "3" means that the substance can be administered up to 3 times. In "EVN" (event) mood, the repeatNumber is the number of occurrences. For example, a repeatNumber of "3" in a substance administration event means that the current administration is the 3rd in a series.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>repeatNumber</b><b> (CONF:1098-7434)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>quantity</b><b> (CONF:1098-7436)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-7439)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-16093)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-9334)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Immunization Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1098-31695)</b>.</li><ul><li><p>A supply act <strong>SHALL</strong> contain one product/Medication Information <em>OR</em> one product/Immunization Medication Information template (CONF:1098-16870).</p></li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>author</b><b> (CONF:1098-7438)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-7442)</b>.<ul><li>The entryRelationship, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7444)</b>.</li></ul><ul><li>The entryRelationship, if present, <b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7445)</b>.</li></ul><ul><li>The entryRelationship, if present, <b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31391)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SPLY"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-7427)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7428)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7429)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.17"</b><b>
+              (CONF:1098-10507)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32578)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7430)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7432)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ActStatus<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32362)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-15143)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1098-15144)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>In "INT" (intent) mood, the repeatNumber defines the number of allowed administrations. For example, a
+          repeatNumber of "3" means that the substance can be administered up to 3 times. In "EVN" (event) mood, the
+          repeatNumber is the number of occurrences. For example, a repeatNumber of "3" in a substance administration
+          event means that the current administration is the 3rd in a series.<br></p> <b>SHOULD</b> contain zero or one
+        [0..1] <b>repeatNumber</b><b> (CONF:1098-7434)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>quantity</b><b> (CONF:1098-7436)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-7439)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Information (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-16093)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-9334)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Immunization Medication Information (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1098-31695)</b>.</li>
+          <ul>
+            <li>
+              <p>A supply act <strong>SHALL</strong> contain one product/Medication Information <em>OR</em> one
+                product/Immunization Medication Information template (CONF:1098-16870).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>author</b><b> (CONF:1098-7438)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-7442)</b>.<ul>
+          <li>The entryRelationship, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b>
+            (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b>
+              (CONF:1098-7444)</b>.</li>
+        </ul>
+        <ul>
+          <li>The entryRelationship, if present, <b>SHALL</b> contain exactly one [1..1]
+            <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7445)</b>.</li>
+        </ul>
+        <ul>
+          <li>The entryRelationship, if present, <b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31391)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Supply%20Order%20(V2)_2.16.840.1.113883.10.20.22.4.17/Medication%20Supply%20Order%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Medication Supply Order (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Supply%20Order%20(V2)_2.16.840.1.113883.10.20.22.4.17/Medication%20Supply%20Order%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Medication Supply Order (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i> Medications</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i>
+          Medications</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.18.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.18.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,59 +52,159 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medication Dispense (V2) <small class="text-muted">[supply, 2.16.840.1.113883.10.20.22.4.18, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.18.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medication Dispense (V2) <small class="text-muted">[supply, 2.16.840.1.113883.10.20.22.4.18, release
+        2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.18.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template records the act of supplying medications (i.e., dispensing).</p></div>
+    <div id="description">
+      <p>This template records the act of supplying medications (i.e., dispensing).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information (V2)</a><br><a href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address (AD.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address (AD.US.FIELDED)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SPLY"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7451)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-7452)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7453)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.18"</b><b> (CONF:1098-10505)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32580)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7454)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7455)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Medication Fill Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.64/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.64</a></b><b> STATIC</b> 2014-04-23<b> (CONF:1098-32361)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-7456)</b>.</li>
-<li class="list-group-item"><p>In "INT" (intent) mood, the repeatNumber defines the number of allowed administrations. For example, a repeatNumber of "3" means that the substance can be administered up to 3 times. In "EVN" (event) mood, the repeatNumber is the number of occurrences. For example, a repeatNumber of "3" in a substance administration event means that the current administration is the 3rd in a series.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>repeatNumber</b><b> (CONF:1098-7457)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>quantity</b><b> (CONF:1098-7458)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-7459)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-15607)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-9331)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Immunization Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1098-31696)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>performer</b><b> (CONF:1098-7461)</b>.<ul><li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1098-7467)</b>.</li><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1098-7468)</b>.</li><ul><li><p>The content of addr <strong>SHALL</strong> be a conformant US Realm Address (AD.US.FIELDED) (2.16.840.1.113883.10.20.22.5.2) (CONF:1098-10565).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-7473)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7474)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Supply Order (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.17)</b><b> (CONF:1098-15606)</b>.</li></ul></li>
-<li class="list-group-item"> <p>A supply act  <strong>SHALL</strong> contain one product/Medication Information <em>OR</em> one product/Immunization Medication Information template (CONF:1098-9333).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SPLY"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-7451)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7452)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7453)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.18"</b><b>
+              (CONF:1098-10505)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32580)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7454)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7455)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet Medication Fill Status<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.64/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.64</a></b><b>
+              STATIC</b> 2014-04-23<b> (CONF:1098-32361)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-7456)</b>.</li>
+      <li class="list-group-item">
+        <p>In "INT" (intent) mood, the repeatNumber defines the number of allowed administrations. For example, a
+          repeatNumber of "3" means that the substance can be administered up to 3 times. In "EVN" (event) mood, the
+          repeatNumber is the number of occurrences. For example, a repeatNumber of "3" in a substance administration
+          event means that the current administration is the 3rd in a series.<br></p> <b>SHOULD</b> contain zero or one
+        [0..1] <b>repeatNumber</b><b> (CONF:1098-7457)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>quantity</b><b> (CONF:1098-7458)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-7459)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Information (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-15607)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-9331)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Immunization Medication Information (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1098-31696)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>performer</b><b> (CONF:1098-7461)</b>.<ul>
+          <li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+              (CONF:1098-7467)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1098-7468)</b>.</li>
+            <ul>
+              <li>
+                <p>The content of addr <strong>SHALL</strong> be a conformant US Realm Address (AD.US.FIELDED)
+                  (2.16.840.1.113883.10.20.22.5.2) (CONF:1098-10565).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-7473)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7474)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Supply Order (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.17)</b><b> (CONF:1098-15606)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>A supply act <strong>SHALL</strong> contain one product/Medication Information <em>OR</em> one
+          product/Immunization Medication Information template (CONF:1098-9333).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Dispense%20(V2)_2.16.840.1.113883.10.20.22.4.18/Medication%20Dispense%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Medication Dispense (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Dispense%20(V2)_2.16.840.1.113883.10.20.22.4.18/Medication%20Dispense%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Medication Dispense (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i> Medications</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i>
+          Medications</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.19.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.19.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,137 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Indication (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.19, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.19.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Indication (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.19, release
+        2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.19.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the rationale for an action such as an encounter, a medication administration, or a procedure. The id element can be used to reference a problem recorded elsewhere in the document, or can be used with a code and value to record the problem. Indications for treatment are not laboratory results; rather the problem associated with the laboratory result should be cited (e.g., hypokalemia instead of a laboratory result of Potassium 2.0 mEq/L). Use the Drug Monitoring Act [templateId 2.16.840.1.113883.10.20.22.4.123] to indicate if a particular drug needs special monitoring (e.g., anticoagulant therapy). Use Precondition for Substance Administration (V2) [templateId 2.16.840.1.113883.10.20.22.4.25.2] to represent that a medication is to be administered only when the associated criteria are met.</p></div>
+    <div id="description">
+      <p>This template represents the rationale for an action such as an encounter, a medication administration, or a
+        procedure. The id element can be used to reference a problem recorded elsewhere in the document, or can be used
+        with a code and value to record the problem. Indications for treatment are not laboratory results; rather the
+        problem associated with the laboratory result should be cited (e.g., hypokalemia instead of a laboratory result
+        of Potassium 2.0 mEq/L). Use the Drug Monitoring Act [templateId 2.16.840.1.113883.10.20.22.4.123] to indicate
+        if a particular drug needs special monitoring (e.g., anticoagulant therapy). Use Precondition for Substance
+        Administration (V2) [templateId 2.16.840.1.113883.10.20.22.4.25.2] to represent that a medication is to be
+        administered only when the associated criteria are met.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.29.html">Procedure Indications Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.140.html">Patient Referral Act</a><br><a href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.29.html">Procedure Indications Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.140.html">Patient Referral Act</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7480)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-7481)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7482)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.19"</b><b> (CONF:1098-10502)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32570)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7483)</b>.<br>Note: If the id element is used to reference a problem recorded elsewhere in the document then this id must equal another entry/id in the same document instance. Application Software must be responsible for resolving the identifier back to its original object and then rendering the information in the correct place in the containing section's narrative text. Its purpose is to obviate the need to repeat the complete XML representation of the referred to entry when relating one entry to another.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>MAY</b> be selected from ValueSet Problem Type (SNOMEDCT)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.2/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.2</a></b><b> DYNAMIC</b><b> (CONF:1098-31229)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7487)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19105)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-7488)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Problem<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b> DYNAMIC</b><b> (CONF:1098-7489)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-7480)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7481)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7482)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.19"</b><b>
+              (CONF:1098-10502)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32570)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7483)</b>.<br>Note:
+        If the id element is used to reference a problem recorded elsewhere in the document then this id must equal
+        another entry/id in the same document instance. Application Software must be responsible for resolving the
+        identifier back to its original object and then rendering the information in the correct place in the containing
+        section's narrative text. Its purpose is to obviate the need to repeat the complete XML representation of the
+        referred to entry when relating one entry to another.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>MAY</b> be selected
+        from ValueSet Problem Type (SNOMEDCT)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.2/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.2</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-31229)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7487)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19105)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-7488)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet Problem<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-7489)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Indication%20(V2)_2.16.840.1.113883.10.20.22.4.19/Indication%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Indication (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Indication%20(V2)_2.16.840.1.113883.10.20.22.4.19/Indication%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Indication (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.2.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.2.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,59 +52,167 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Result Observation (V3) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.2, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Result Observation (V3) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.2,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.2.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the results of a laboratory, radiology, or other study performed on a patient.</p><p>The result observation includes a statusCode to allow recording the status of an observation. 'Pending' results (e.g., a test has been run but results have not been reported yet) should be represented as 'active' ActStatus.</p></div>
+    <div id="description">
+      <p>This template represents the results of a laboratory, radiology, or other study performed on a patient.</p>
+      <p>The result observation includes a statusCode to allow recording the status of an observation. 'Pending' results
+        (e.g., a test has been run but results have not been reported yet) should be represented as 'active' ActStatus.
+      </p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.1.html">Result Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-7130)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-7131)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7136)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.2"</b><b> (CONF:1198-9138)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32575)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7137)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> (CONF:1198-7133)</b>.<ul><li><p>This code <strong>SHOULD</strong> be a code from the LOINC that identifies the result observation. If an appropriate LOINC code does not exist, then the local code for this result <strong>SHALL</strong> be sent (CONF:1198-19212).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7134)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Result Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.39/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.39</a></b><b> STATIC</b><b> (CONF:1198-14849)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-7140)</b>.<br>Note: Represents the biologically relevant time of the measurement (e.g., the time a blood pressure reading is obtained, the time the blood sample was obtained for a chemistry test).</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1198-7143)</b>.<ul><li><p>If Observation/value is a physical quantity (<strong>xsi:type="PQ"</strong>), the unit of measure <strong>SHALL</strong> be selected from ValueSet UnitsOfMeasureCaseSensitive <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839 </a><strong>DYNAMIC</strong> (CONF:1198-31484).</p></li></ul><ul><li><p>A coded or physical quantity value <strong>MAY</strong> contain zero or more [0..*] translations, which can be used to represent the original results as output by the lab (CONF:1198-31866).</p></li></ul><ul><li><p>If Observation/value is a CD (<strong>xsi:type="CD"</strong>) the value <strong>SHOULD</strong> be SNOMED-CT (CONF:1198-32610).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>interpretationCode</b><b> (CONF:1198-7147)</b>.<ul><li>The interpretationCode, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Observation Interpretation (HL7)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.78/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.78</a></b><b> DYNAMIC</b><b> (CONF:1198-32476)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1198-7148)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>targetSiteCode</b><b> (CONF:1198-7153)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-7149)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>referenceRange</b><b> (CONF:1198-7150)</b>.<ul><li>The referenceRange, if present, <b>SHALL</b> contain exactly one [1..1] <b>observationRange</b><b> (CONF:1198-7151)</b>.</li><ul><li>This observationRange <b>SHALL NOT</b> contain [0..0] <b>code</b><b> (CONF:1198-7152)</b>.</li></ul><ul><li>This observationRange <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1198-32175)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-7130)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-7131)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7136)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.2"</b><b>
+              (CONF:1198-9138)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32575)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7137)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> (CONF:1198-7133)</b>.<ul>
+          <li>
+            <p>This code <strong>SHOULD</strong> be a code from the LOINC that identifies the result observation. If an
+              appropriate LOINC code does not exist, then the local code for this result <strong>SHALL</strong> be sent
+              (CONF:1198-19212).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7134)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet Result Status<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.39/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.39</a></b><b>
+              STATIC</b><b> (CONF:1198-14849)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1198-7140)</b>.<br>Note: Represents the biologically relevant time of the measurement (e.g., the time a
+        blood pressure reading is obtained, the time the blood sample was obtained for a chemistry test).</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1198-7143)</b>.<ul>
+          <li>
+            <p>If Observation/value is a physical quantity (<strong>xsi:type="PQ"</strong>), the unit of measure
+              <strong>SHALL</strong> be selected from ValueSet UnitsOfMeasureCaseSensitive <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839
+              </a><strong>DYNAMIC</strong> (CONF:1198-31484).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>A coded or physical quantity value <strong>MAY</strong> contain zero or more [0..*] translations, which
+              can be used to represent the original results as output by the lab (CONF:1198-31866).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>If Observation/value is a CD (<strong>xsi:type="CD"</strong>) the value <strong>SHOULD</strong> be
+              SNOMED-CT (CONF:1198-32610).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>interpretationCode</b><b>
+          (CONF:1198-7147)</b>.<ul>
+          <li>The interpretationCode, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which
+            <b>SHALL</b> be selected from ValueSet Observation Interpretation (HL7)<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.78/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.78</a></b><b> DYNAMIC</b><b>
+              (CONF:1198-32476)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1198-7148)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>targetSiteCode</b><b> (CONF:1198-7153)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-7149)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>referenceRange</b><b>
+          (CONF:1198-7150)</b>.<ul>
+          <li>The referenceRange, if present, <b>SHALL</b> contain exactly one [1..1] <b>observationRange</b><b>
+              (CONF:1198-7151)</b>.</li>
+          <ul>
+            <li>This observationRange <b>SHALL NOT</b> contain [0..0] <b>code</b><b> (CONF:1198-7152)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observationRange <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1198-32175)</b>.
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Result%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.2/Result%20Observation%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Result Observation (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Result%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.2/Result%20Observation%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Result Observation (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Results"><i class="fas fa-external-link-alt"></i> Results</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Results"><i class="fas fa-external-link-alt"></i> Results</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.20.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.20.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,125 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Instruction (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.20, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.20.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Instruction (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.20, release 2014-06-09,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.20.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Instruction template can be used in several ways, such as to record patient instructions within a Medication Activity or to record fill instructions within a supply order. The template's moodCode can only be INT. If an instruction was already given, the Procedure Activity Act template (instead of this template) should be used to represent the already occurred instruction. The act/code defines the type of instruction. Though not defined in this template, a Vaccine Information Statement (VIS) document could be referenced through act/reference/externalDocument, and patient awareness of the instructions can be represented with the generic participant and the participant/awarenessCode.</p></div>
+    <div id="description">
+      <p>The Instruction template can be used in several ways, such as to record patient instructions within a
+        Medication Activity or to record fill instructions within a supply order. The template's moodCode can only be
+        INT. If an instruction was already given, the Procedure Activity Act template (instead of this template) should
+        be used to represent the already occurred instruction. The act/code defines the type of instruction. Though not
+        defined in this template, a Vaccine Information Statement (VIS) document could be referenced through
+        act/reference/externalDocument, and patient awareness of the instructions can be represented with the generic
+        participant and the participant/awarenessCode.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.45.html">Instructions Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.39.html">Planned Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.41.html">Planned Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.44.html">Planned Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.45.html">Instructions Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7391)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-7392)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7393)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.20"</b><b> (CONF:1098-10503)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32598)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Patient Education<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.34/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.34</a></b><b> DYNAMIC</b><b> (CONF:1098-16884)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7396)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19106)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-7391)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"INT"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7392)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7393)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.20"</b><b>
+              (CONF:1098-10503)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32598)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet Patient Education<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.34/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.34</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-16884)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7396)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19106)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Instruction%20(V2)_2.16.840.1.113883.10.20.22.4.20/Instruction%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Instruction (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Instruction%20(V2)_2.16.840.1.113883.10.20.22.4.20/Instruction%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Instruction (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.200.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.200.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,74 +24,151 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Birth Sex Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.200, release 2016-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.200.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Birth Sex Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.200,
+        release 2016-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.200.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This observation represents the sex of the patient at birth. It is the sex that is entered on the person's birth certificate at time of birth.</p><p>This observation is not appropriate for recording patient gender (administrativeGender).</p></div>
+    <div id="description">
+      <p>This observation represents the sex of the patient at birth. It is the sex that is entered on the person's
+        birth certificate at time of birth.</p>
+      <p>This observation is not appropriate for recording patient gender (administrativeGender).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:3250-18230)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:3250-18231)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:3250-18232)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.200"</b><b> (CONF:3250-18233)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-06-01"</b><b> (CONF:3250-32949)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:3250-18234)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"76689-9"</b> Sex Assigned At Birth<b> (CONF:3250-18235)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:3250-21163)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:3250-18124)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:3250-18125)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet ONC Administrative Sex<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1</a></b><b> STATIC</b> 2016-06-01<b> (CONF:3250-32947)</b>.<ul><li><p>If value/@code not from value set ONC Administrative Sex <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1 </a>STATIC 2016-06-01, then value/@nullFlavor SHALL be 'UNK' (CONF:3250-32948).</p></li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:3250-18230)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:3250-18231)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:3250-18232)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.200"</b><b>
+              (CONF:3250-18233)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-06-01"</b><b> (CONF:3250-32949)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:3250-18234)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"76689-9"</b> Sex Assigned At Birth<b>
+              (CONF:3250-18235)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:3250-21163)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:3250-18124)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:3250-18125)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet ONC Administrative Sex<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1</a></b><b> STATIC</b> 2016-06-01<b>
+          (CONF:3250-32947)</b>.<ul>
+          <li>
+            <p>If value/@code not from value set ONC Administrative Sex <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1 </a>STATIC 2016-06-01, then
+              value/@nullFlavor SHALL be 'UNK' (CONF:3250-32948).</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Birth%20Sex%20Observation_2.16.840.1.113883.10.20.22.4.200/Birth%20Sex%20Example.xml"><i class="fab fa-github"></i>&nbsp;Birth Sex Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Birth%20Sex%20Observation_2.16.840.1.113883.10.20.22.4.200/Birth%20Sex%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Birth Sex Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social History</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social
+          History</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.201.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.201.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,77 +24,151 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Section Time Range Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.201, release 2016-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.201.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Section Time Range Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.201, release 2016-06-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.201.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This observation represents the date and time range of the information contained in a section. It is an optional entry and may be used in any section.</p></div>
+    <div id="description">
+      <p>This observation represents the date and time range of the information contained in a section. It is an
+        optional entry and may be used in any section.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:3250-32960)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:3250-32961)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:3250-32951)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.201"</b><b> (CONF:3250-32955)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-06-01"</b><b> (CONF:3250-32956)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:3250-32952)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"82607-3"</b> Section Time Range (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:3250-32957)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:3250-32958)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:3250-32962)</b>.<ul><li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:3250-32963)</b>.</li><ul><li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:3250-32964)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:3250-32950)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:3250-32954)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="IVL_TS"<b> (CONF:3250-32953)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:3250-32965)</b>.</li></ul><ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:3250-32966)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:3250-32960)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:3250-32961)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:3250-32951)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.201"</b><b>
+              (CONF:3250-32955)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-06-01"</b><b> (CONF:3250-32956)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:3250-32952)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"82607-3"</b> Section Time Range
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:3250-32957)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:3250-32958)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:3250-32962)</b>.<ul>
+          <li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:3250-32963)</b>.</li>
+          <ul>
+            <li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:3250-32964)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:3250-32950)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:3250-32954)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="IVL_TS"<b>
+          (CONF:3250-32953)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:3250-32965)</b>.</li>
+        </ul>
+        <ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:3250-32966)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Section%20Time%20Range%20Observation_2.16.840.1.113883.10.20.22.4.201/Section%20Time%20Range%20Example.xml"><i class="fab fa-github"></i>&nbsp;Section Time Range Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Section%20Time%20Range%20Observation_2.16.840.1.113883.10.20.22.4.201/Section%20Time%20Range%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Section Time Range Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.202.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.202.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,83 +24,282 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Note Activity <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.202, release 2016-11-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.202.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Note Activity <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.202, release 2016-11-01,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.202.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Note Activity represents a clinical note. Notes require authorship, authentication, timing information, and references to other discrete data such as encounters. Similar to the Comment Activity, the Note Activity permits a more specific code to characterize the type of information available in the note. The Note Activity template SHOULD NOT be used in place of a more specific C-CDA entry. Note information included needs to be relevant and pertinent to the information being communicated in the document.When the note information augments data represented in a more specific entry template, the Note Activity can be used in an entryRelationship to the associated standard C-CDA entry. For example, a Procedure Note added as an entryRelationship to a Procedure Activity Procedure entry).The Note Activity template can be used as a standalone entry within a standard C-CDA section (e.g., a note about various procedures which have occurred during a visit as an entry in the Procedures Section) when it does not augment another standard entry. It may also be used to provide additional data about the source of a currently narrative-only section, such as Hospital Course.Finally, if the type of data in the note is not known or no single C-CDA section is appropriate enough, the Note Activity should be placed in a Notes Section. (e.g., a free-text consultation note or a note which includes subjective, objective, assessment, and plan information combined).An alternative is to place the Note Activity as an entryRelationship to an Encounter Activity entry in the Encounters Section, but implementers may wish to group notes categorically into a separate location in CDA documents rather than overloading the Encounters Section.</p></div>
+    <div id="description">
+      <p>The Note Activity represents a clinical note. Notes require authorship, authentication, timing information, and
+        references to other discrete data such as encounters. Similar to the Comment Activity, the Note Activity permits
+        a more specific code to characterize the type of information available in the note. The Note Activity template
+        SHOULD NOT be used in place of a more specific C-CDA entry. Note information included needs to be relevant and
+        pertinent to the information being communicated in the document.When the note information augments data
+        represented in a more specific entry template, the Note Activity can be used in an entryRelationship to the
+        associated standard C-CDA entry. For example, a Procedure Note added as an entryRelationship to a Procedure
+        Activity Procedure entry).The Note Activity template can be used as a standalone entry within a standard C-CDA
+        section (e.g., a note about various procedures which have occurred during a visit as an entry in the Procedures
+        Section) when it does not augment another standard entry. It may also be used to provide additional data about
+        the source of a currently narrative-only section, such as Hospital Course.Finally, if the type of data in the
+        note is not known or no single C-CDA section is appropriate enough, the Note Activity should be placed in a
+        Notes Section. (e.g., a free-text consultation note or a note which includes subjective, objective, assessment,
+        and plan information combined).An alternative is to place the Note Activity as an entryRelationship to an
+        Encounter Activity entry in the Encounters Section, but implementers may wish to group notes categorically into
+        a separate location in CDA documents rather than overloading the Encounters Section.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.65.html">Notes Section</a><br><a href="2.16.840.1.113883.10.20.22.4.500.1.html">Care Team Member Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.500.html">Care Team Organizer (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.65.html">Notes Section</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.500.1.html">Care Team Member Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.500.html">Care Team Organizer (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br><a
+              href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act<b> (CONF:3250-16899)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event<b> (CONF:3250-16900)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:3250-16933)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.202"</b><b> (CONF:3250-16934)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-11-01"</b><b> (CONF:3250-16937)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:3250-16895)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"34109-9"</b> Note (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:3250-16940)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC<b> (CONF:3250-16941)</b>.</li></ul><ul><li>This code <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which <b>SHOULD</b> be selected from ValueSet Note Types<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.68/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.68</a></b><b> DYNAMIC</b><b> (CONF:3250-16939)</b>.</li><ul><li>If the Note Activity is within a Note Section, the translation SHOULD match or specialize the section code (CONF:3250-16942).<br>Note: For example, a cardiologist consult note may specialize a consult note but not a progress note.</li></ul><ul><li><p>If the Note Activity is within a narrative-only section (e.g. Hospital Course), the translation MAY match the section code (CONF:3250-16943).</p></li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:3250-16896)</b>.<ul><li>This text <b>MAY</b> contain zero or one [0..1] <b>@mediaType</b>, which <b>SHOULD</b> be selected from ValueSet SupportedFileFormats<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.7.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.7.1</a></b><b> DYNAMIC</b><b> (CONF:3250-16906)</b>.</li><ul><li><p>If @mediaType is present, the text SHALL contain exactly one [1..1] @representation="B64" and mixed content corresponding to the contents of the note (CONF:3250-16912).</p></li></ul></ul><ul><li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:3250-16897)</b>.</li><ul><li>The note activity must reference human-readable content in the narrative, so this reference must not be null. <br/>This reference <b>SHALL NOT</b> contain [0..0] <b>@nullFlavor</b><b> (CONF:3250-16920)</b>.</li></ul><ul><li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:3250-16898)</b>.</li><ul><li><p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:3250-16902).</p></li></ul></ul></ul></li>
-<li class="list-group-item">Indicates the status of the note. The most common statusCode is completed indicating the note is signed and finalized<br /> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:3250-16916)</b>.</li>
-<li class="list-group-item">The effectiveTime represents the clinically relevant time of the note. The precise timestamp of creation / updating should be conveyed in author/time. <br/> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:3250-16903)</b>.<ul><li>This effectiveTime <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:3250-16917)</b>.</li></ul></li>
-<li class="list-group-item">Represents the person(s) who wrote the note<br/><b>SHALL</b> contain at least one [1..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:3250-16913)</b>.</li>
-<li class="list-group-item">Represents the person(s) legally responsible for the contents of the note<br/> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:3250-16923)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LA"</b> Legal Authenticator<b> (CONF:3250-16925)</b>.</li></ul><ul><li>Indicates the time of signing the note<br/><b>SHALL</b> contain exactly one [1..1]  US Realm Date and Time (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:3250-16926)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:3250-16924)</b>.</li><ul><li>This may be the ID of the note author. If so, no additional information in this participant is required.<br/>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:3250-16927)</b>.</li></ul><ul><li>This participantRole <b>MAY</b> contain zero or one [0..1] <b>playingEntity</b><b> (CONF:3250-16928)</b>.</li><ul><li>The playingEntity, if present, <b>SHALL</b> contain at least one [1..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:3250-16929)</b>.</li></ul></ul><ul><li><p>If no id matches an author or participant elsewhere in the document, then playingEntity SHALL be present (CONF:3250-16930).</p></li></ul></ul></li>
-<li class="list-group-item">Links the note to an encounter. If the Note Activity is present within a document containing an encompassingEncounter, then this entryRelationship is optional and the note is associated with the encounter represented by the encompassingEncounter.<br/> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:3250-16907)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b><b> (CONF:3250-16921)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b><b> (CONF:3250-16922)</b>.</li></ul><ul><li>To communicate that the note is not associated with any encounter, this entryRelationship MAY be included with @negationInd="true" and encounter/id/@nullFlavor="NA". The negationInd + encounter indicate this note is not associated with any encounter<br/><b>MAY</b> contain zero or one [0..1] <b>@negationInd</b><b> (CONF:3250-16931)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:3250-16908)</b>.</li><ul><li>This encounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:3250-16909)</b>.</li><ul><li><p>If the id does not match an encounter/id from the Encounters Section or encompassingEncounter within the same document and the id does not contain @nullFlavor="NA", then this entry SHALL conform to the Encounter Activity (V3) (identifier: 2.16.840.1.113883.10.20.22.4.49) (CONF:3250-16914).</p></li></ul></ul></ul></li>
-<li class="list-group-item">Represents an unstructured C-CDA document containing the original contents of the note in the original format <br/><b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:3250-16910)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>externalDocument</b><b> (CONF:3250-16911)</b>.</li><ul><li>This externalDocument <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:3250-16915)</b>.</li></ul><ul><li>This externalDocument <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:3250-16918)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act<b>
+          (CONF:3250-16899)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event<b>
+          (CONF:3250-16900)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:3250-16933)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.202"</b><b>
+              (CONF:3250-16934)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-11-01"</b><b> (CONF:3250-16937)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:3250-16895)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"34109-9"</b> Note (CodeSystem: <b>LOINC
+              2.16.840.1.113883.6.1</b>)<b> (CONF:3250-16940)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            LOINC<b> (CONF:3250-16941)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which <b>SHOULD</b> be selected
+            from ValueSet Note Types<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.68/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.68</a></b><b>
+              DYNAMIC</b><b> (CONF:3250-16939)</b>.</li>
+          <ul>
+            <li>If the Note Activity is within a Note Section, the translation SHOULD match or specialize the section
+              code (CONF:3250-16942).<br>Note: For example, a cardiologist consult note may specialize a consult note
+              but not a progress note.</li>
+          </ul>
+          <ul>
+            <li>
+              <p>If the Note Activity is within a narrative-only section (e.g. Hospital Course), the translation MAY
+                match the section code (CONF:3250-16943).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:3250-16896)</b>.<ul>
+          <li>This text <b>MAY</b> contain zero or one [0..1] <b>@mediaType</b>, which <b>SHOULD</b> be selected from
+            ValueSet SupportedFileFormats<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.7.1/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.7.1</a></b><b> DYNAMIC</b><b>
+              (CONF:3250-16906)</b>.</li>
+          <ul>
+            <li>
+              <p>If @mediaType is present, the text SHALL contain exactly one [1..1] @representation="B64" and mixed
+                content corresponding to the contents of the note (CONF:3250-16912).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:3250-16897)</b>.</li>
+          <ul>
+            <li>The note activity must reference human-readable content in the narrative, so this reference must not be
+              null. <br />This reference <b>SHALL NOT</b> contain [0..0] <b>@nullFlavor</b><b> (CONF:3250-16920)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:3250-16898)</b>.</li>
+            <ul>
+              <li>
+                <p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using
+                  the approach defined in CDA Release 2, section 4.3.5.1) (CONF:3250-16902).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">Indicates the status of the note. The most common statusCode is completed indicating
+        the note is signed and finalized<br /> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b>
+          (CONF:3250-16916)</b>.</li>
+      <li class="list-group-item">The effectiveTime represents the clinically relevant time of the note. The precise
+        timestamp of creation / updating should be conveyed in author/time. <br /> <b>SHALL</b> contain exactly one
+        [1..1] <b>effectiveTime</b><b> (CONF:3250-16903)</b>.<ul>
+          <li>This effectiveTime <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:3250-16917)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">Represents the person(s) who wrote the note<br /><b>SHALL</b> contain at least one
+        [1..*] Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:3250-16913)</b>.</li>
+      <li class="list-group-item">Represents the person(s) legally responsible for the contents of the note<br />
+        <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:3250-16923)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LA"</b> Legal Authenticator<b>
+              (CONF:3250-16925)</b>.</li>
+        </ul>
+        <ul>
+          <li>Indicates the time of signing the note<br /><b>SHALL</b> contain exactly one [1..1] US Realm Date and Time
+            (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:3250-16926)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:3250-16924)</b>.</li>
+          <ul>
+            <li>This may be the ID of the note author. If so, no additional information in this participant is
+              required.<br />This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b>
+                (CONF:3250-16927)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>MAY</b> contain zero or one [0..1] <b>playingEntity</b><b>
+                (CONF:3250-16928)</b>.</li>
+            <ul>
+              <li>The playingEntity, if present, <b>SHALL</b> contain at least one [1..*] US Realm Person Name
+                (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:3250-16929)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>
+              <p>If no id matches an author or participant elsewhere in the document, then playingEntity SHALL be
+                present (CONF:3250-16930).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">Links the note to an encounter. If the Note Activity is present within a document
+        containing an encompassingEncounter, then this entryRelationship is optional and the note is associated with the
+        encounter represented by the encompassingEncounter.<br /> <b>SHOULD</b> contain zero or more [0..*]
+        <b>entryRelationship</b><b> (CONF:3250-16907)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b><b> (CONF:3250-16921)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b><b> (CONF:3250-16922)</b>.</li>
+        </ul>
+        <ul>
+          <li>To communicate that the note is not associated with any encounter, this entryRelationship MAY be included
+            with @negationInd="true" and encounter/id/@nullFlavor="NA". The negationInd + encounter indicate this note
+            is not associated with any encounter<br /><b>MAY</b> contain zero or one [0..1] <b>@negationInd</b><b>
+              (CONF:3250-16931)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:3250-16908)</b>.</li>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:3250-16909)</b>.</li>
+            <ul>
+              <li>
+                <p>If the id does not match an encounter/id from the Encounters Section or encompassingEncounter within
+                  the same document and the id does not contain @nullFlavor="NA", then this entry SHALL conform to the
+                  Encounter Activity (V3) (identifier: 2.16.840.1.113883.10.20.22.4.49) (CONF:3250-16914).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">Represents an unstructured C-CDA document containing the original contents of the note
+        in the original format <br /><b>MAY</b> contain zero or more [0..*] <b>reference</b><b> (CONF:3250-16910)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>externalDocument</b><b> (CONF:3250-16911)</b>.</li>
+          <ul>
+            <li>This externalDocument <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:3250-16915)</b>.</li>
+          </ul>
+          <ul>
+            <li>This externalDocument <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:3250-16918)</b>.
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Note%20Activity_2.16.840.1.113883.10.20.22.4.202/Note%20Activity%20as%20entryRelationship%20to%20C-CDA%20Entry.xml"><i class="fab fa-github"></i>&nbsp;Note Activity as entryRelationship to C-CDA Entry</a></li>
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Note%20Activity_2.16.840.1.113883.10.20.22.4.202/Note%20Activity%20as%20Standalone%20Entry.xml"><i class="fab fa-github"></i>&nbsp;Note Activity as Standalone Entry</a></li>
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Note%20Activity_2.16.840.1.113883.10.20.22.4.202/RTF%20Example.xml"><i class="fab fa-github"></i>&nbsp;RTF Example</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Note%20Activity_2.16.840.1.113883.10.20.22.4.202/Note%20Activity%20as%20entryRelationship%20to%20C-CDA%20Entry.xml"><i
+            class="fab fa-github"></i>&nbsp;Note Activity as entryRelationship to C-CDA Entry</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Note%20Activity_2.16.840.1.113883.10.20.22.4.202/Note%20Activity%20as%20Standalone%20Entry.xml"><i
+            class="fab fa-github"></i>&nbsp;Note Activity as Standalone Entry</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Note%20Activity_2.16.840.1.113883.10.20.22.4.202/RTF%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;RTF Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Notes"><i class="fas fa-external-link-alt"></i> Notes</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Notes"><i class="fas fa-external-link-alt"></i> Notes</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.23.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.23.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,119 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Medication Information (V2) <small class="text-muted">[manufacturedProduct, 2.16.840.1.113883.10.20.22.4.23, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.23.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Medication Information (V2) <small class="text-muted">[manufacturedProduct,
+        2.16.840.1.113883.10.20.22.4.23, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.23.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A medication should be recorded as a pre-coordinated ingredient + strength + dose form (e.g., 'metoprolol 25mg tablet', 'amoxicillin 400mg/5mL suspension') where possible. This includes RxNorm codes whose Term Type is SCD (semantic clinical drug), SBD (semantic brand drug), GPCK (generic pack), BPCK (brand pack).</p><p>The dose (doseQuantity) represents how many of the consumables are to be administered at each administration event. As a result, the dose is always relative to the consumable. Thus, a patient consuming a single "metoprolol 25mg tablet" per administration will have a doseQuantity of "1", whereas a patient consuming "metoprolol" will have a dose of "25 mg".</p></div>
+    <div id="description">
+      <p>A medication should be recorded as a pre-coordinated ingredient + strength + dose form (e.g., 'metoprolol 25mg
+        tablet', 'amoxicillin 400mg/5mL suspension') where possible. This includes RxNorm codes whose Term Type is SCD
+        (semantic clinical drug), SBD (semantic brand drug), GPCK (generic pack), BPCK (brand pack).</p>
+      <p>The dose (doseQuantity) represents how many of the consumables are to be administered at each administration
+        event. As a result, the dose is always relative to the consumable. Thus, a patient consuming a single
+        "metoprolol 25mg tablet" per administration will have a doseQuantity of "1", whereas a patient consuming
+        "metoprolol" will have a dose of "25 mg".</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b> (CONF:1098-7408)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7409)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.23"</b><b> (CONF:1098-10506)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32579)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>id</b><b> (CONF:1098-7410)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>manufacturedMaterial</b><b> (CONF:1098-7411)</b>.<br>Note: A medication should be recorded as a pre-coordinated ingredient + strength + dose form (e.g., metoprolol 25mg tablet, amoxicillin 400mg/5mL suspension) where possible. This includes RxNorm codes whose Term Type is SCD (semantic clinical drug), SBD (semantic brand drug), GPCK (generic pack), BPCK (brand pack).<ul><li>This manufacturedMaterial <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Medication Clinical Drug<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.4/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.4</a></b><b> DYNAMIC</b><b> (CONF:1098-7412)</b>.</li><ul><li>This code <b>MAY</b> contain zero or more [0..*] <b>translation</b>, which <b>MAY</b> be selected from ValueSet Clinical Substance<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.2/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.2</a></b><b> DYNAMIC</b><b> (CONF:1098-31884)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>manufacturerOrganization</b><b> (CONF:1098-7416)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> (CodeSystem:
+        <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7408)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7409)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.23"</b><b>
+              (CONF:1098-10506)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32579)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>id</b><b> (CONF:1098-7410)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>manufacturedMaterial</b><b>
+          (CONF:1098-7411)</b>.<br>Note: A medication should be recorded as a pre-coordinated ingredient + strength +
+        dose form (e.g., metoprolol 25mg tablet, amoxicillin 400mg/5mL suspension) where possible. This includes RxNorm
+        codes whose Term Type is SCD (semantic clinical drug), SBD (semantic brand drug), GPCK (generic pack), BPCK
+        (brand pack).<ul>
+          <li>This manufacturedMaterial <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be
+            selected from ValueSet Medication Clinical Drug<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.4/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.4</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-7412)</b>.</li>
+          <ul>
+            <li>This code <b>MAY</b> contain zero or more [0..*] <b>translation</b>, which <b>MAY</b> be selected from
+              ValueSet Clinical Substance<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.2/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.2</a></b><b>
+                DYNAMIC</b><b> (CONF:1098-31884)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>manufacturerOrganization</b><b>
+          (CONF:1098-7416)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Information%20(V2)_2.16.840.1.113883.10.20.22.4.23/Medication%20Information%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Medication Information (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Medication%20Information%20(V2)_2.16.840.1.113883.10.20.22.4.23/Medication%20Information%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Medication Information (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i> Medications</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medications"><i class="fas fa-external-link-alt"></i>
+          Medications</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.24.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.24.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,105 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Drug Vehicle <small class="text-muted">[participantRole, 2.16.840.1.113883.10.20.22.4.24, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.24.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Drug Vehicle <small class="text-muted">[participantRole, 2.16.840.1.113883.10.20.22.4.24, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.24.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the vehicle (e.g., saline, dextrose) for administering a medication.</p></div>
+    <div id="description">
+      <p>This template represents the vehicle (e.g., saline, dextrose) for administering a medication.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b> (CONF:81-7490)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7495)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.24"</b><b> (CONF:81-10493)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19137)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"412307009"</b> Drug Vehicle<b> (CONF:81-19138)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:81-26502)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b> (CONF:81-7492)</b>.<ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-7493)</b>.</li></ul><ul><li>This playingEntity <b>MAY</b> contain zero or one [0..1] <b>name</b><b> (CONF:81-7494)</b>.</li><ul><li><p>This playingEntity/name MAY be used for the vehicle name in text, such as Normal Saline (CONF:81-10087).</p></li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> (CodeSystem:
+        <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b>
+          (CONF:81-7490)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7495)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.24"</b><b>
+              (CONF:81-10493)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19137)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"412307009"</b> Drug Vehicle<b>
+              (CONF:81-19138)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:81-26502)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b> (CONF:81-7492)</b>.
+        <ul>
+          <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-7493)</b>.</li>
+        </ul>
+        <ul>
+          <li>This playingEntity <b>MAY</b> contain zero or one [0..1] <b>name</b><b> (CONF:81-7494)</b>.</li>
+          <ul>
+            <li>
+              <p>This playingEntity/name MAY be used for the vehicle name in text, such as Normal Saline
+                (CONF:81-10087).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Drug%20Vehicle_2.16.840.1.113883.10.20.22.4.24/Drug%20Vehicle%20Example.xml"><i class="fab fa-github"></i>&nbsp;Drug Vehicle Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Drug%20Vehicle_2.16.840.1.113883.10.20.22.4.24/Drug%20Vehicle%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Drug Vehicle Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.25.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.25.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,103 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Precondition for Substance Administration (V2) <small class="text-muted">[criterion, 2.16.840.1.113883.10.20.22.4.25, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.25.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Precondition for Substance Administration (V2) <small class="text-muted">[criterion,
+        2.16.840.1.113883.10.20.22.4.25, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.25.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A criterion for administration can be used to record that the medication is to be administered only when the associated criteria are met.</p></div>
+    <div id="description">
+      <p>A criterion for administration can be used to record that the medication is to be administered only when the
+        associated criteria are met.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.42.html">Planned Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7372)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.25"</b><b> (CONF:1098-10517)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32603)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b> with @xsi:type="CD"<b> (CONF:1098-32396)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b> (CONF:1098-32397)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-32398)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Problem<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b> DYNAMIC</b><b> (CONF:1098-7369)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7372)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.25"</b><b>
+              (CONF:1098-10517)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32603)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b> with @xsi:type="CD"<b>
+          (CONF:1098-32396)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b>
+              (CONF:1098-32397)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:1098-32398)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Problem<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-7369)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Precondition%20for%20Substance%20Administration%20(V2)_2.16.840.1.113883.10.20.22.4.25/Precondition%20for%20Substance%20Administration%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Precondition for Substance Administration (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Precondition%20for%20Substance%20Administration%20(V2)_2.16.840.1.113883.10.20.22.4.25/Precondition%20for%20Substance%20Administration%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Precondition for Substance Administration (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.26.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.26.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,141 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Vital Signs Organizer (V3) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.26, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.26.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Vital Signs Organizer (V3) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.26,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.26.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template provides a mechanism for grouping vital signs (e.g., grouping systolic blood pressure and diastolic blood pressure).</p></div>
+    <div id="description">
+      <p>This template provides a mechanism for grouping vital signs (e.g., grouping systolic blood pressure and
+        diastolic blood pressure).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.4.html">Vital Signs Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required) (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.27.html">Vital Sign Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.4.html">Vital Signs Section (entries optional)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.4.1.html">Vital Signs Section (entries required)
+              (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.27.html">Vital Sign Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> CLUSTER (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-7279)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-7280)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7281)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.26"</b><b> (CONF:1198-10528)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32582)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7282)</b>.</li>
-<li class="list-group-item"><p>Compatibility support for C-CDA R1.1 and C-CDA 2.1: A vitals organizer conformant to both C-CDA 1.1 and C-CDA 2.1 would contain the SNOMED code (46680005) from R1.1 in the root code and a LOINC code in the translation. A vitals organizer conformant to only C-CDA 2.1 would only contain the LOINC code in the root code.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-32740)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46680005"</b> Vital Signs<b> (CONF:1198-32741)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> SNOMED CT (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-32742)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32743)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"74728-7"</b> Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel - HL7.CCDAr1.1 (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32744)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32746)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7284)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19120)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-7288)</b>.<br>Note: The effectiveTime may be a timestamp or an interval that spans the effectiveTimes of the contained vital signs observations.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31153)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-7285)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Vital Sign Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.27)</b><b> (CONF:1198-15946)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> CLUSTER
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-7279)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-7280)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7281)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.26"</b><b>
+              (CONF:1198-10528)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32582)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7282)</b>.</li>
+      <li class="list-group-item">
+        <p>Compatibility support for C-CDA R1.1 and C-CDA 2.1: A vitals organizer conformant to both C-CDA 1.1 and C-CDA
+          2.1 would contain the SNOMED code (46680005) from R1.1 in the root code and a LOINC code in the translation. A
+          vitals organizer conformant to only C-CDA 2.1 would only contain the LOINC code in the root code.<br></p>
+        <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-32740)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46680005"</b> Vital Signs<b>
+              (CONF:1198-32741)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            SNOMED CT (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-32742)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32743)</b> such that it
+          </li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"74728-7"</b> Vital signs, weight, height, head
+              circumference, oximetry, BMI, and BSA panel - HL7.CCDAr1.1 (CodeSystem: <b>LOINC
+                2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32744)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC
+              (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32746)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7284)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19120)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1198-7288)</b>.<br>Note: The effectiveTime may be a timestamp or an interval that spans the
+        effectiveTimes of the contained vital signs observations.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31153)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-7285)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Vital Sign Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.27)</b><b> (CONF:1198-15946)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Vital%20Signs%20Organizer%20(V3)_2.16.840.1.113883.10.20.22.4.26/Vital%20Signs%20Organizer%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Vital Signs Organizer (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Vital%20Signs%20Organizer%20(V3)_2.16.840.1.113883.10.20.22.4.26/Vital%20Signs%20Organizer%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Vital Signs Organizer (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Vital%20Signs"><i class="fas fa-external-link-alt"></i> Vital Signs</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Vital%20Signs"><i class="fas fa-external-link-alt"></i> Vital
+          Signs</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.27.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.27.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,58 +52,183 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Vital Sign Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.27, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.27.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Vital Sign Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.27,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.27.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents measurement of common vital signs. Vital signs are represented with additional vocabulary constraints for type of vital sign and unit of measure.</p><p>The following is a list of recommended units for common types of vital sign measurements:</p><table><thead><tr><th>Name</th><th>Unit</th></tr></thead><tbody><tr><td>PulseOx</td><td>%</td></tr><tr><td>Height/Head Circumf</td><td>cm</td></tr><tr><td>Weight</td><td>kg</td></tr><tr><td>Temp</td><td>Cel</td></tr><tr><td>BP</td><td>mm[Hg]</td></tr><tr><td>Pulse/Resp Rate</td><td>/min</td></tr><tr><td>BMI</td><td>kg/m2</td></tr><tr><td>BSA</td><td>m2</td></tr><tr><td>inhaled oxygen concentration</td><td>%</td></tr></tbody></table></div>
+    <div id="description">
+      <p>This template represents measurement of common vital signs. Vital signs are represented with additional
+        vocabulary constraints for type of vital sign and unit of measure.</p>
+      <p>The following is a list of recommended units for common types of vital sign measurements:</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Unit</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>PulseOx</td>
+            <td>%</td>
+          </tr>
+          <tr>
+            <td>Height/Head Circumf</td>
+            <td>cm</td>
+          </tr>
+          <tr>
+            <td>Weight</td>
+            <td>kg</td>
+          </tr>
+          <tr>
+            <td>Temp</td>
+            <td>Cel</td>
+          </tr>
+          <tr>
+            <td>BP</td>
+            <td>mm[Hg]</td>
+          </tr>
+          <tr>
+            <td>Pulse/Resp Rate</td>
+            <td>/min</td>
+          </tr>
+          <tr>
+            <td>BMI</td>
+            <td>kg/m2</td>
+          </tr>
+          <tr>
+            <td>BSA</td>
+            <td>m2</td>
+          </tr>
+          <tr>
+            <td>inhaled oxygen concentration</td>
+            <td>%</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.26.html">Vital Signs Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.26.html">Vital Signs Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7297)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-7298)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7299)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.27"</b><b> (CONF:1098-10527)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32574)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7300)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-7301)</b>.<ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Vital Sign Result Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.62/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.62</a></b><b> DYNAMIC</b><b> (CONF:1098-32934)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7303)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19119)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-7304)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b> (CONF:1098-7305)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@unit</b>, which <b>SHALL</b> be selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b> DYNAMIC</b><b> (CONF:1098-31579)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>interpretationCode</b><b> (CONF:1098-7307)</b>.<ul><li>The interpretationCode, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Observation Interpretation (HL7)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.78/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.78</a></b><b> DYNAMIC</b><b> (CONF:1098-32886)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1098-7308)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>targetSiteCode</b><b> (CONF:1098-7309)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-7310)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-7297)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7298)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7299)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.27"</b><b>
+              (CONF:1098-10527)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32574)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7300)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-7301)</b>.<ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from
+            ValueSet Vital Sign Result Type<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.62/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.62</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32934)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7303)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19119)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-7304)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b>
+          (CONF:1098-7305)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@unit</b>, which <b>SHALL</b> be selected from
+            ValueSet UnitsOfMeasureCaseSensitive<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-31579)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>interpretationCode</b><b>
+          (CONF:1098-7307)</b>.<ul>
+          <li>The interpretationCode, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which
+            <b>SHALL</b> be selected from ValueSet Observation Interpretation (HL7)<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.78/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.78</a></b><b> DYNAMIC</b><b>
+              (CONF:1098-32886)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1098-7308)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>targetSiteCode</b><b> (CONF:1098-7309)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-7310)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Vital%20Sign%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.27/Vital%20Sign%20Observation%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Vital Sign Observation (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Vital%20Sign%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.27/Vital%20Sign%20Observation%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Vital Sign Observation (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Vital%20Signs"><i class="fas fa-external-link-alt"></i> Vital Signs</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Vital%20Signs"><i class="fas fa-external-link-alt"></i> Vital
+          Signs</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.28.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.28.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,112 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Allergy Status Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.28, release 2019-06-20, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.28.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Allergy Status Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.28,
+        release 2019-06-20, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.28.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the clinical status attributed to the allergy or intolerance. There can be only one allergy status observation per allergy - intolerance observation.</p></div>
+    <div id="description">
+      <p>This template represents the clinical status attributed to the allergy or intolerance. There can be only one
+        allergy status observation per allergy - intolerance observation.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance
+              Observation (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-7318)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-7319)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7317)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.28"</b><b> (CONF:1198-10490)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-20"</b><b> (CONF:1198-32962)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-7320)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"33999-4"</b> Status<b> (CONF:1198-19131)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32155)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7321)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19087)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CE", where the code <b>SHALL</b> be selected from ValueSet Allergy Clinical Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.29/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.29</a></b><b> DYNAMIC</b><b> (CONF:1198-7322)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-7318)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-7319)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7317)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.28"</b><b>
+              (CONF:1198-10490)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-20"</b><b> (CONF:1198-32962)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-7320)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"33999-4"</b> Status<b>
+              (CONF:1198-19131)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32155)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7321)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19087)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CE", where the
+        code <b>SHALL</b> be selected from ValueSet Allergy Clinical Status<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.29/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.29</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-7322)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.3.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.3.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,183 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Problem Concern Act (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.3, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Problem Concern Act (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.3, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.3.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template reflects an ongoing concern on behalf of the provider that placed the concern on a patient's problem list. So long as the underlying condition is of concern to the provider (i.e., as long as the condition, whether active or resolved, is of ongoing concern and interest to the provider), the statusCode is 'active'. Only when the underlying condition is no longer of concern is the statusCode set to 'completed'. The effectiveTime reflects the time that the underlying condition was felt to be a concern; it may or may not correspond to the effectiveTime of the condition (e.g., even five years later, the clinician may remain concerned about a prior heart attack).</p><p>The statusCode of the Problem Concern Act is the definitive indication of the status of the concern, whereas the effectiveTime of the nested Problem Observation is the definitive indication of whether or not the underlying condition is resolved.</p><p>The effectiveTime/low of the Problem Concern Act asserts when the concern became active. The effectiveTime/high asserts when the concern was completed (e.g., when the clinician deemed there is no longer any need to track the underlying condition).</p><p>A Problem Concern Act can contain many Problem Observations (templateId 2.16.840.1.113883.10.20.22.4.4). Each Problem Observation is a discrete observation of a condition, and therefore will have a statusCode of 'completed'. The many Problem Observations nested under a Problem Concern Act reflect the change in the clinical understanding of a condition over time. For instance, a Concern may initially contain a Problem Observation of 'chest pain':</p><ul><li>Problem Concern 1--- Problem Observation: Chest PainLater, a new Problem Observation of 'esophagitis' will be added, reflecting a better understanding of the nature of the chest pain. The later problem observation will have a more recent author time stamp.</li><li>Problem Concern 1--- Problem Observation (author/time Jan 3, 2012): Chest Pain--- Problem Observation (author/time Jan 6, 2012): EsophagitisMany systems display the nested Problem Observation with the most recent author time stamp, and provide a mechanism for viewing prior observations.</li></ul></div>
+    <div id="description">
+      <p>This template reflects an ongoing concern on behalf of the provider that placed the concern on a patient's
+        problem list. So long as the underlying condition is of concern to the provider (i.e., as long as the condition,
+        whether active or resolved, is of ongoing concern and interest to the provider), the statusCode is 'active'.
+        Only when the underlying condition is no longer of concern is the statusCode set to 'completed'. The
+        effectiveTime reflects the time that the underlying condition was felt to be a concern; it may or may not
+        correspond to the effectiveTime of the condition (e.g., even five years later, the clinician may remain
+        concerned about a prior heart attack).</p>
+      <p>The statusCode of the Problem Concern Act is the definitive indication of the status of the concern, whereas
+        the effectiveTime of the nested Problem Observation is the definitive indication of whether or not the
+        underlying condition is resolved.</p>
+      <p>The effectiveTime/low of the Problem Concern Act asserts when the concern became active. The effectiveTime/high
+        asserts when the concern was completed (e.g., when the clinician deemed there is no longer any need to track the
+        underlying condition).</p>
+      <p>A Problem Concern Act can contain many Problem Observations (templateId 2.16.840.1.113883.10.20.22.4.4). Each
+        Problem Observation is a discrete observation of a condition, and therefore will have a statusCode of
+        'completed'. The many Problem Observations nested under a Problem Concern Act reflect the change in the clinical
+        understanding of a condition over time. For instance, a Concern may initially contain a Problem Observation of
+        'chest pain':</p>
+      <ul>
+        <li>Problem Concern 1--- Problem Observation: Chest PainLater, a new Problem Observation of 'esophagitis' will
+          be added, reflecting a better understanding of the nature of the chest pain. The later problem observation
+          will have a more recent author time stamp.</li>
+        <li>Problem Concern 1--- Problem Observation (author/time Jan 3, 2012): Chest Pain--- Problem Observation
+          (author/time Jan 6, 2012): EsophagitisMany systems display the nested Problem Observation with the most recent
+          author time stamp, and provide a mechanism for viewing prior observations.</li>
+      </ul>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-9024)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-9025)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16772)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.3"</b><b> (CONF:1198-16773)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32509)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-9026)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-9027)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"CONC"</b> Concern<b> (CONF:1198-19184)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.6"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-32168)</b>.</li></ul></li>
-<li class="list-group-item"><p>The statusCode of the Problem Concern Act is the definitive indication of the status of the concern, whereas the effectiveTime of the nested Problem Observation is the definitive indication of whether or not the underlying condition is resolved.</p> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-9029)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ProblemAct statusCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.19/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.19</a></b><b> STATIC</b><b> (CONF:1198-31525)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-9030)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-9032)</b>.<br>Note: The effectiveTime/low of the Problem Concern Act asserts when the concern became active.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1198-9033)</b>.<br>Note: The effectiveTime/high asserts when the concern was completed (e.g., when the clinician deemed there is no longer any need to track the underlying condition).</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31146)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-9034)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-9035)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15980)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the importance of the concern to a provider.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31638)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31639)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1198-31640)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-9024)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-9025)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16772)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.3"</b><b>
+              (CONF:1198-16773)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32509)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-9026)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-9027)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"CONC"</b> Concern<b>
+              (CONF:1198-19184)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.6"</b>
+            (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+              (CONF:1198-32168)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The statusCode of the Problem Concern Act is the definitive indication of the status of the concern, whereas
+          the effectiveTime of the nested Problem Observation is the definitive indication of whether or not the
+          underlying condition is resolved.</p> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b>
+          (CONF:1198-9029)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ProblemAct statusCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.19/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.19</a></b><b>
+              STATIC</b><b> (CONF:1198-31525)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-9030)</b>.
+        <ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-9032)</b>.<br>Note:
+            The effectiveTime/low of the Problem Concern Act asserts when the concern became active.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1198-9033)</b>.<br>Note: The
+            effectiveTime/high asserts when the concern was completed (e.g., when the clinician deemed there is no
+            longer any need to track the underlying condition).</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31146)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-9034)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-9035)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15980)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the importance of the concern to a provider.<br></p> <b>MAY</b>
+        contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31638)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31639)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1198-31640)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Concern%20Act%20(V3)_2.16.840.1.113883.10.20.22.4.3/Problem%20Concern%20Act%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Problem Concern Act (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Concern%20Act%20(V3)_2.16.840.1.113883.10.20.22.4.3/Problem%20Concern%20Act%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Problem Concern Act (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a>
+      </li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.30.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.30.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,153 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Allergy Concern Act (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.30, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.30.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Allergy Concern Act (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.30, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.30.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template reflects an ongoing concern on behalf of the provider that placed the allergy on a patient's allergy list. As long as the underlying condition is of concern to the provider (i.e., as long as the allergy, whether active or resolved, is of ongoing concern and interest to the provider), the statusCode is 'active'. Only when the underlying allergy is no longer of concern is the statusCode set to 'completed'. The effectiveTime reflects the time that the underlying allergy was felt to be a concern.</p><p>The statusCode of the Allergy Concern Act is the definitive indication of the status of the concern, whereas the effectiveTime of the nested Allergy - Intolerance Observation is the definitive indication of whether or not the underlying allergy is resolved.</p><p>The effectiveTime/low of the Allergy Concern Act asserts when the concern became active. This equates to the time the concern was authored in the patient's chart. The effectiveTime/high asserts when the concern was completed (e.g., when the clinician deemed there is no longer any need to track the underlying condition).</p></div>
+    <div id="description">
+      <p>This template reflects an ongoing concern on behalf of the provider that placed the allergy on a patient's
+        allergy list. As long as the underlying condition is of concern to the provider (i.e., as long as the allergy,
+        whether active or resolved, is of ongoing concern and interest to the provider), the statusCode is 'active'.
+        Only when the underlying allergy is no longer of concern is the statusCode set to 'completed'. The effectiveTime
+        reflects the time that the underlying allergy was felt to be a concern.</p>
+      <p>The statusCode of the Allergy Concern Act is the definitive indication of the status of the concern, whereas
+        the effectiveTime of the nested Allergy - Intolerance Observation is the definitive indication of whether or not
+        the underlying allergy is resolved.</p>
+      <p>The effectiveTime/low of the Allergy Concern Act asserts when the concern became active. This equates to the
+        time the concern was authored in the patient's chart. The effectiveTime/high asserts when the concern was
+        completed (e.g., when the clinician deemed there is no longer any need to track the underlying condition).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances Section (entries required) (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.6.html">Allergies and Intolerances Section
+              (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.6.1.html">Allergies and Intolerances
+              Section (entries required) (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-7469)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-7470)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7471)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.30"</b><b> (CONF:1198-10489)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32543)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7472)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-7477)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"CONC"</b> Concern<b> (CONF:1198-19158)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.6"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-32154)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7485)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ProblemAct statusCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.19/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.19</a></b><b> STATIC</b><b> (CONF:1198-19086)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-7498)</b>.<ul><li><p>If statusCode/@code="active" Active, then effectiveTime <strong>SHALL</strong> contain [1..1] low (CONF:1198-7504).</p></li></ul><ul><li><p>If statusCode/@code="completed" Completed, then effectiveTime <strong>SHALL</strong> contain [1..1] high (CONF:1198-10085).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31145)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-7509)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-7915)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergy - Intolerance Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.7)</b><b> (CONF:1198-14925)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1198-7469)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-7470)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7471)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.30"</b><b>
+              (CONF:1198-10489)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32543)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-7472)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-7477)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"CONC"</b> Concern<b>
+              (CONF:1198-19158)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.6"</b>
+            (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+              (CONF:1198-32154)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7485)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ProblemAct statusCode<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.19/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.19</a></b><b>
+              STATIC</b><b> (CONF:1198-19086)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-7498)</b>.
+        <ul>
+          <li>
+            <p>If statusCode/@code="active" Active, then effectiveTime <strong>SHALL</strong> contain [1..1] low
+              (CONF:1198-7504).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>If statusCode/@code="completed" Completed, then effectiveTime <strong>SHALL</strong> contain [1..1] high
+              (CONF:1198-10085).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31145)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-7509)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-7915)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Allergy - Intolerance Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.7)</b><b> (CONF:1198-14925)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Allergy%20Concern%20Act%20(V3)_2.16.840.1.113883.10.20.22.4.30/Allergy%20Concern%20Act%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Allergy Concern Act (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Allergy%20Concern%20Act%20(V3)_2.16.840.1.113883.10.20.22.4.30/Allergy%20Concern%20Act%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Allergy Concern Act (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.301.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.301.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,138 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Brand Name Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.301, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.301.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Brand Name Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.301,
+        release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.301.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Brand Name</strong>.  The UDI-DI of the medical device may be used to retrieve the <strong>Brand Name</strong> in accessGUDID, which should be considered the source of truth.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Brand Name</strong>. The UDI-DI of the medical device
+        may be used to retrieve the <strong>Brand Name</strong> in accessGUDID, which should be considered the source of
+        truth.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3403)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.301"</b><b> (CONF:4437-3405)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3406)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3404)</b>.<br>Note: Code for "Device Brand Name"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C71898"</b> Brand Name (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3407)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3408)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3409)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Brand Name"</b><b> (CONF:4437-3410)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b> (CONF:4437-3411)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3403)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.301"</b><b> (CONF:4437-3405)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3406)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3404)</b>.<br>Note:
+        Code for "Device Brand Name"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C71898"</b> Brand Name (CodeSystem:
+            <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b>
+              STATIC</b>)<b> (CONF:4437-3407)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3408)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3409)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Brand Name"</b><b>
+              (CONF:4437-3410)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b>
+          (CONF:4437-3411)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Brand%20Name%20Example_2.16.840.1.113883.10.20.22.4.301/Brand%20Name%20Example.xml"><i class="fab fa-github"></i>&nbsp;Brand Name Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Brand%20Name%20Example_2.16.840.1.113883.10.20.22.4.301/Brand%20Name%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Brand Name Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.302.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.302.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,138 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Catalog Number Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.302, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.302.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Catalog Number Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.302,
+        release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.302.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Catalog Number</strong>.  The UDI-DI of the medical device may be used to retrieve the Catalog Number in accessGUDID, which should be considered the source of truth.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Catalog Number</strong>. The UDI-DI of the medical
+        device may be used to retrieve the Catalog Number in accessGUDID, which should be considered the source of
+        truth.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3432)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.302"</b><b> (CONF:4437-3434)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3435)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3433)</b>.<br>Note: Code for "Device Catalog Number"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C99286"</b> Catalog Number (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3436)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3437)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3438)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Catalog Number"</b><b> (CONF:4437-3439)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b> (CONF:4437-3440)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3432)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.302"</b><b> (CONF:4437-3434)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3435)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3433)</b>.<br>Note:
+        Code for "Device Catalog Number"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C99286"</b> Catalog Number (CodeSystem:
+            <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b>
+              STATIC</b>)<b> (CONF:4437-3436)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3437)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3438)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Catalog Number"</b><b>
+              (CONF:4437-3439)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b>
+          (CONF:4437-3440)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Catalog_Number_Observation_2.16.840.1.113883.10.20.22.4.302/Catalog%20Number%20Sample.xml"><i class="fab fa-github"></i>&nbsp;Catalog_Number_Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Catalog_Number_Observation_2.16.840.1.113883.10.20.22.4.302/Catalog%20Number%20Sample.xml"><i
+            class="fab fa-github"></i>&nbsp;Catalog_Number_Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.303.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.303.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,138 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Company Name Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.303, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.303.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Company Name Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.303,
+        release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.303.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Company Name</strong>.  The UDI-DI of the medical device may be used to retrieve the <strong>Company Name</strong> in accessGUDID, which should be considered the source of truth.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Company Name</strong>. The UDI-DI of the medical device
+        may be used to retrieve the <strong>Company Name</strong> in accessGUDID, which should be considered the source
+        of truth.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3441)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.303"</b><b> (CONF:4437-3443)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3444)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3442)</b>.<br>Note: Code for "Company Name"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C54131"</b> Company Name  (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3445)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3446)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3447)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Company Name"</b><b> (CONF:4437-3448)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b> (CONF:4437-3449)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3441)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.303"</b><b> (CONF:4437-3443)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3444)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3442)</b>.<br>Note:
+        Code for "Company Name"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C54131"</b> Company Name (CodeSystem:
+            <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b>
+              STATIC</b>)<b> (CONF:4437-3445)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3446)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3447)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Company Name"</b><b>
+              (CONF:4437-3448)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b>
+          (CONF:4437-3449)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Company%20Name%20Observation_2.16.840.1.113883.10.20.22.4.303/Company%20Name.xml"><i class="fab fa-github"></i>&nbsp;Company Name Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Company%20Name%20Observation_2.16.840.1.113883.10.20.22.4.303/Company%20Name.xml"><i
+            class="fab fa-github"></i>&nbsp;Company Name Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.304.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.304.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,72 +24,164 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Device Identifier Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.304, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.304.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Device Identifier Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.304, release 2022-06-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.304.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Device Identifier</strong> (also known as the "Primary DI Number") for a medical device marketed in the US. The device identifier is parsed from the UDI value.</p><p>The Device Identifier number can be used as a key to look-up device identification information in the publicly available version of the US FDA Global UDI Database (GUDID) - the AccessGUDID: <a href="https://accessgudid.nlm.nih.gov/resources/home">https://accessgudid.nlm.nih.gov/resources/home</a></p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Device Identifier</strong> (also known as the "Primary
+        DI Number") for a medical device marketed in the US. The device identifier is parsed from the UDI value.</p>
+      <p>The Device Identifier number can be used as a key to look-up device identification information in the publicly
+        available version of the US FDA Global UDI Database (GUDID) - the AccessGUDID: <a
+          href="https://accessgudid.nlm.nih.gov/resources/home">https://accessgudid.nlm.nih.gov/resources/home</a></p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3421)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.304"</b><b> (CONF:4437-3424)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3425)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4524-3421)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.304"</b><b> (CONF:4524-3424)</b>.</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4524-3425)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4524-3422)</b>.<br>Note: Primary DI Number Code from NCIt<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101722"</b> Primary DI Number (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4524-3426)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4524-3427)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4524-3428)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Primary DI Number"</b><b> (CONF:4524-3429)</b>.</li></ul></li>
-<li class="list-group-item"><p>The value of the Device Identifier assigned using one of the FDA-accredited, UDI issuing  agency:  GS1, HIBCC, or ICBBA.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="II"<b> (CONF:4524-3423)</b>.<br>Note: This value is assigned by the Manufacturer by using an FDA-accredited UDI-issuing agency<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:4524-3430)</b>.</li></ul><ul><li>This value <b>SHOULD</b> contain zero or one [0..1] <b>@extension</b><b> (CONF:4524-3431)</b>.</li></ul><ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@displayable</b>=<b>"true"</b><b> (CONF:4524-3540)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3421)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.304"</b><b> (CONF:4437-3424)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3425)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4524-3421)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.304"</b><b> (CONF:4524-3424)</b>.</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b>
+              (CONF:4524-3425)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4524-3422)</b>.<br>Note:
+        Primary DI Number Code from NCIt<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101722"</b> Primary DI Number
+            (CodeSystem: <b>NCI Thesaurus (NCIt) <a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b>
+              (CONF:4524-3426)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4524-3427)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4524-3428)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Primary DI Number"</b><b>
+              (CONF:4524-3429)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The value of the Device Identifier assigned using one of the FDA-accredited, UDI issuing agency: GS1, HIBCC,
+          or ICBBA.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="II"<b>
+          (CONF:4524-3423)</b>.<br>Note: This value is assigned by the Manufacturer by using an FDA-accredited
+        UDI-issuing agency<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:4524-3430)</b>.</li>
+        </ul>
+        <ul>
+          <li>This value <b>SHOULD</b> contain zero or one [0..1] <b>@extension</b><b> (CONF:4524-3431)</b>.</li>
+        </ul>
+        <ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@displayable</b>=<b>"true"</b><b>
+              (CONF:4524-3540)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Device%20Identifier%20Observation_2.16.840.1.113883.10.20.22.4.304/Device%20Identifier.xml"><i class="fab fa-github"></i>&nbsp;Device Identifier Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Device%20Identifier%20Observation_2.16.840.1.113883.10.20.22.4.304/Device%20Identifier.xml"><i
+            class="fab fa-github"></i>&nbsp;Device Identifier Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.305.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.305.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,148 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Implantable Device Status Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.305, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.305.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Implantable Device Status Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.305, release 2019-06-21, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.305.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37  to augment the parsed data from the a Unique Device Identifier (UDI). This template is used to exchange the status of the patient's implantable medical device.  This status is only relevant to medical devices implanted in the patient's body.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to augment the parsed data from the a Unique Device Identifier (UDI). This
+        template is used to exchange the status of the patient's implantable medical device. This status is only
+        relevant to medical devices implanted in the patient's body.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3502)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.305"</b><b> (CONF:4437-3505)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3506)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3503)</b>.<br>Note: Code for "Implantable Device Status"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C160939"</b> Implantable Device Status (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3507)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3508)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3509)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Implantable Device Status"</b><b> (CONF:4437-3510)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Implantable Device Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.48/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.48</a></b><b> STATIC</b> 2019-06-21<b> (CONF:4437-3504)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:4437-3511)</b>.</li></ul><ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b><b> (CONF:4437-3512)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3502)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.305"</b><b> (CONF:4437-3505)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3506)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3503)</b>.<br>Note:
+        Code for "Implantable Device Status"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C160939"</b> Implantable Device Status
+            (CodeSystem: <b>NCI Thesaurus (NCIt) <a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b>
+              (CONF:4437-3507)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3508)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3509)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Implantable Device Status"</b><b>
+              (CONF:4437-3510)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Implantable Device Status<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.48/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.48</a></b><b> STATIC</b> 2019-06-21<b>
+          (CONF:4437-3504)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:4437-3511)</b>.</li>
+        </ul>
+        <ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b><b> (CONF:4437-3512)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Implantable%20Device%20Status%20Observation_2.16.840.1.113883.10.20.22.4.305/Implantable%20Device%20Status.xml"><i class="fab fa-github"></i>&nbsp;Implantable Device Status Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Implantable%20Device%20Status%20Observation_2.16.840.1.113883.10.20.22.4.305/Implantable%20Device%20Status.xml"><i
+            class="fab fa-github"></i>&nbsp;Implantable Device Status Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.308.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.308.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,141 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Distinct Identification Code Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.308, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.308.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Distinct Identification Code Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.308, release 2019-06-21, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.308.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Distinct Identification Code</strong> for an HCT/P product regulated as a device as cited in 21 CFR 1271.290(c). The distinct identification code is parsed from the UDI value, if present.</p><p>The distinct identification code may be equivalent to the serial number, lot or batch number, or the donation identification number. The appropriate value should be provided as the distinct identification code.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Distinct Identification Code</strong> for an HCT/P
+        product regulated as a device as cited in 21 CFR 1271.290(c). The distinct identification code is parsed from
+        the UDI value, if present.</p>
+      <p>The distinct identification code may be equivalent to the serial number, lot or batch number, or the donation
+        identification number. The appropriate value should be provided as the distinct identification code.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3348)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.308"</b><b> (CONF:4437-3350)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3351)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3349)</b>.<br>Note: Distinct Identification Code from NCIt<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C113843"</b> Distinct Identification Code  (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3355)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3352)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3353)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Distinct Identification Code"</b><b> (CONF:4437-3354)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b> (CONF:4437-3340)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3348)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.308"</b><b> (CONF:4437-3350)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3351)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3349)</b>.<br>Note:
+        Distinct Identification Code from NCIt<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C113843"</b> Distinct Identification
+            Code (CodeSystem: <b>NCI Thesaurus (NCIt) <a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b>
+              (CONF:4437-3355)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3352)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3353)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Distinct Identification
+              Code"</b><b> (CONF:4437-3354)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b>
+          (CONF:4437-3340)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Distinct%20Identification%20Code%20Observation_2.16.840.1.113883.10.20.22.4.308/Distinct%20Identification%20Code.xml"><i class="fab fa-github"></i>&nbsp;Distinct Identification Code Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Distinct%20Identification%20Code%20Observation_2.16.840.1.113883.10.20.22.4.308/Distinct%20Identification%20Code.xml"><i
+            class="fab fa-github"></i>&nbsp;Distinct Identification Code Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.309.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.309.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,141 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Expiration Date Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.309, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.309.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Expiration Date Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.309,
+        release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.309.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Expiration Date</strong> of the device.  The expiration date is parsed from the UDI value, if present.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Expiration Date</strong> of the device. The expiration
+        date is parsed from the UDI value, if present.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3393)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.309"</b><b> (CONF:4437-3396)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3397)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3394)</b>.<br>Note: Code for "Expiration Date"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101670"</b> Expiration Date (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3398)</b>.<br>Note: Expiration Date code</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3399)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3400)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Expiration Date"</b><b> (CONF:4437-3401)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="TS"<b> (CONF:4437-3395)</b>.<br>Note:  Expiration Date as a time stamp<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4437-3402)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3393)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.309"</b><b> (CONF:4437-3396)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3397)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3394)</b>.<br>Note:
+        Code for "Expiration Date"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101670"</b> Expiration Date
+            (CodeSystem: <b>NCI Thesaurus (NCIt) <a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b>
+              (CONF:4437-3398)</b>.<br>Note: Expiration Date code</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3399)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3400)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Expiration Date"</b><b>
+              (CONF:4437-3401)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="TS"<b>
+          (CONF:4437-3395)</b>.<br>Note: Expiration Date as a time stamp<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4437-3402)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Expiration%20Date%20Observation_2.16.840.1.113883.10.20.22.4.309/Expiration%20Date.xml"><i class="fab fa-github"></i>&nbsp;Expiration Date Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Expiration%20Date%20Observation_2.16.840.1.113883.10.20.22.4.309/Expiration%20Date.xml"><i
+            class="fab fa-github"></i>&nbsp;Expiration Date Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.31.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.31.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,116 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Age Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.31, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.31.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Age Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.31, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.31.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This Age Observation represents the subject's age at onset of an event or observation. The age of a relative in a Family History Observation at the time of that observation could also be inferred by comparing RelatedSubject/subject/birthTime with Observation/effectiveTime. However, a common scenario is that a patient will know the age of a relative when the relative had a certain condition or when the relative died, but will not know the actual year (e.g., "grandpa died of a heart attack at the age of 50"). Often times, neither precise dates nor ages are known (e.g., "cousin died of congenital heart disease as an infant").</p></div>
+    <div id="description">
+      <p>This Age Observation represents the subject's age at onset of an event or observation. The age of a relative in
+        a Family History Observation at the time of that observation could also be inferred by comparing
+        RelatedSubject/subject/birthTime with Observation/effectiveTime. However, a common scenario is that a patient
+        will know the age of a relative when the relative had a certain condition or when the relative died, but will
+        not know the actual year (e.g., "grandpa died of a heart attack at the age of 50"). Often times, neither precise
+        dates nor ages are known (e.g., "cousin died of congenital heart disease as an infant").</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.46.html">Family History Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.46.html">Family History Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-7613)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-7614)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7899)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.31"</b><b> (CONF:81-10487)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-7615)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"445518008"</b> Age At Onset<b> (CONF:81-16776)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:81-26499)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-15965)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:81-15966)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b> (CONF:81-7617)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@unit</b>, which <b>SHALL</b> be selected from ValueSet AgePQ_UCUM<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.21/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.21</a></b><b> DYNAMIC</b><b> (CONF:81-7618)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-7613)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-7614)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7899)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.31"</b><b>
+              (CONF:81-10487)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-7615)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"445518008"</b> Age At Onset<b>
+              (CONF:81-16776)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:81-26499)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-15965)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:81-15966)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b>
+          (CONF:81-7617)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@unit</b>, which <b>SHALL</b> be selected from
+            ValueSet AgePQ_UCUM<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.21/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.21</a></b><b>
+              DYNAMIC</b><b> (CONF:81-7618)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Age%20Observation_2.16.840.1.113883.10.20.22.4.31/Age%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Age Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Age%20Observation_2.16.840.1.113883.10.20.22.4.31/Age%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Age Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.311.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.311.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,87 +24,255 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">UDI Organizer <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.311, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.311.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">UDI Organizer <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.311, release
+        2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.311.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is nested in an entryRelationship/Procedure Activity Procedure to record all the UDI-related templates to exchange the parsed UDI data elements and associated data.</p><ul><li><strong>Device Identifier</strong>2.16.840.1.113883.10.20.22.4.304: 2019-06-21 NCIt: C101722 SHALL be included in UDI Organizer</li><li><strong>Lot or Batch Number</strong>2.16.840.1.113883.10.20.22.4.315: 2019-06-21 NCIt:C101672 SHOULD be included in UDI Organizer if present in UDI</li><li><strong>Serial Number</strong>2.16.840.1.113883.10.20.22.4.319: 2019-06-21 NCIt: C101671 SHOULD be included in UDI Organizer if present in UDI</li><li><strong>Manufacturing Date</strong><br>2.16.840.1.113883.10.20.22.4.316: 2019-06-21  NCIt:C101669 SHOULD be included in UDI Organizer if present in UDI</li><li><strong>Expiration Date</strong>2.16.840.1.113883.10.20.22.4.309: 2019-06-21 NCIt: C101670 SHOULD be included in UDI Organizer if present in UDI</li><li><strong>Distinct Identification Code</strong>2.16.840.1.113883.10.20.22.4.308: 2019-06-21 NCIt: C113843 SHOULD be included in UDI Organizer if present in UDI</li><li><strong>Brand Name</strong>2.16.840.1.113883.10.20.22.4.301: 2019-06-21 NCIt: C71898 MAY be included in the UDI Organizer if available</li><li><strong>Model Number</strong>2.16.840.1.113883.10.20.22.4.317: 2019-06-21 NCIt: C99285 MAY be included in the UDI Organizer if available</li><li><strong>Catalog Number</strong>2.16.840.1.113883.10.20.22.4.302: 2019-06-21 NCIt: C99286 MAY be included in the UDI Organizer if available</li><li><strong>Company Name</strong>2.16.840.1.113883.10.20.22.4.303: 2019-06-21   NCIt: C54131 MAY be included in the UDI Organizer if available</li><li><strong>MRI Safety</strong>2.16.840.1.113883.10.20.22.4.318: 2019-06-21 NCIt: C106044 MAY be included in the UDI Organizer if available</li><li><strong>Latex Safety</strong>2.16.840.1.113883.10.20.22.4.314: 2019-06-21 NCIt: C160938 MAY be included in the UDI Organizer if available</li><li><strong>Implantable Device Status</strong>2.16.840.1.113883.10.20.22.4.305 2019-06-21 NCIt: C160939 MAY be included in the UDI Organizer if available</li></ul></div>
+    <div id="description">
+      <p>This template is nested in an entryRelationship/Procedure Activity Procedure to record all the UDI-related
+        templates to exchange the parsed UDI data elements and associated data.</p>
+      <ul>
+        <li><strong>Device Identifier</strong>2.16.840.1.113883.10.20.22.4.304: 2019-06-21 NCIt: C101722 SHALL be
+          included in UDI Organizer</li>
+        <li><strong>Lot or Batch Number</strong>2.16.840.1.113883.10.20.22.4.315: 2019-06-21 NCIt:C101672 SHOULD be
+          included in UDI Organizer if present in UDI</li>
+        <li><strong>Serial Number</strong>2.16.840.1.113883.10.20.22.4.319: 2019-06-21 NCIt: C101671 SHOULD be included
+          in UDI Organizer if present in UDI</li>
+        <li><strong>Manufacturing Date</strong><br>2.16.840.1.113883.10.20.22.4.316: 2019-06-21 NCIt:C101669 SHOULD be
+          included in UDI Organizer if present in UDI</li>
+        <li><strong>Expiration Date</strong>2.16.840.1.113883.10.20.22.4.309: 2019-06-21 NCIt: C101670 SHOULD be
+          included in UDI Organizer if present in UDI</li>
+        <li><strong>Distinct Identification Code</strong>2.16.840.1.113883.10.20.22.4.308: 2019-06-21 NCIt: C113843
+          SHOULD be included in UDI Organizer if present in UDI</li>
+        <li><strong>Brand Name</strong>2.16.840.1.113883.10.20.22.4.301: 2019-06-21 NCIt: C71898 MAY be included in the
+          UDI Organizer if available</li>
+        <li><strong>Model Number</strong>2.16.840.1.113883.10.20.22.4.317: 2019-06-21 NCIt: C99285 MAY be included in
+          the UDI Organizer if available</li>
+        <li><strong>Catalog Number</strong>2.16.840.1.113883.10.20.22.4.302: 2019-06-21 NCIt: C99286 MAY be included in
+          the UDI Organizer if available</li>
+        <li><strong>Company Name</strong>2.16.840.1.113883.10.20.22.4.303: 2019-06-21 NCIt: C54131 MAY be included in
+          the UDI Organizer if available</li>
+        <li><strong>MRI Safety</strong>2.16.840.1.113883.10.20.22.4.318: 2019-06-21 NCIt: C106044 MAY be included in the
+          UDI Organizer if available</li>
+        <li><strong>Latex Safety</strong>2.16.840.1.113883.10.20.22.4.314: 2019-06-21 NCIt: C160938 MAY be included in
+          the UDI Organizer if available</li>
+        <li><strong>Implantable Device Status</strong>2.16.840.1.113883.10.20.22.4.305 2019-06-21 NCIt: C160939 MAY be
+          included in the UDI Organizer if available</li>
+      </ul>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.304.html">Device Identifier Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.315.html">Lot or Batch Number Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.319.html">Serial Number Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.316.html">Manufacturing Date Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.317.html">Model Number Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.301.html">Brand Name Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.308.html">Distinct Identification Code Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.309.html">Expiration Date Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.302.html">Catalog Number Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.314.html">Latex Safety Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.305.html">Implantable Device Status Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.318.html">MRI Safety Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.303.html">Company Name Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.304.html">Device Identifier Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.315.html">Lot or Batch Number Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.319.html">Serial Number Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.316.html">Manufacturing Date Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.317.html">Model Number Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.301.html">Brand Name Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.308.html">Distinct Identification Code Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.309.html">Expiration Date Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.302.html">Catalog Number Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.314.html">Latex Safety Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.305.html">Implantable Device Status Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.318.html">MRI Safety Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.303.html">Company Name Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b><b> (CONF:4437-3482)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b><b> (CONF:4437-3483)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3480)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.311"</b><b> (CONF:4437-3484)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3485)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:4437-3541)</b>.<ul><li>This id <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:4437-3542)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:4437-3481)</b>.<ul><li>The code, if present, <b>MAY</b> contain zero or one [0..1] <b>@code</b>=<b>"74711-3"</b> Unique Device Identifier (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4437-3486)</b>.</li></ul><ul><li>The code, if present, <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b><b> (CONF:4437-3487)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4437-3490)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:4437-3543)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:4437-3488)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Device Identifier Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.304)</b><b> (CONF:4437-3489)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3513)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Lot or Batch Number Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.315)</b><b> (CONF:4437-3514)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3515)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Serial Number Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.319)</b><b> (CONF:4437-3516)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3517)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Manufacturing Date Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.316)</b><b> (CONF:4437-3518)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3525)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Expiration Date Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.309)</b><b> (CONF:4437-3526)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3523)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Distinct Identification Code Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.308)</b><b> (CONF:4437-3524)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3521)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Brand Name Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.301)</b><b> (CONF:4437-3522)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3519)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Model Number Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.317)</b><b> (CONF:4437-3520)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3535)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Company Name Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.303)</b><b> (CONF:4437-3536)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3527)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Catalog Number Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.302)</b><b> (CONF:4437-3528)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3529)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Latex Safety Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.314)</b><b> (CONF:4437-3530)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3533)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  MRI Safety Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.318)</b><b> (CONF:4437-3534)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3531)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Implantable Device Status Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.305)</b><b> (CONF:4437-3532)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b><b>
+          (CONF:4437-3482)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b><b>
+          (CONF:4437-3483)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3480)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.311"</b><b>
+              (CONF:4437-3484)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3485)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:4437-3541)</b>.<ul>
+          <li>This id <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:4437-3542)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:4437-3481)</b>.<ul>
+          <li>The code, if present, <b>MAY</b> contain zero or one [0..1] <b>@code</b>=<b>"74711-3"</b> Unique Device
+            Identifier (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4437-3486)</b>.</li>
+        </ul>
+        <ul>
+          <li>The code, if present, <b>SHALL</b> contain exactly one [1..1]
+            <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b><b> (CONF:4437-3487)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4437-3490)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b>
+              (CONF:4437-3543)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>component</b><b> (CONF:4437-3488)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Device Identifier Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.304)</b><b> (CONF:4437-3489)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3513)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Lot or Batch Number Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.315)</b><b> (CONF:4437-3514)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3515)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Serial Number Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.319)</b><b> (CONF:4437-3516)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3517)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Manufacturing Date Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.316)</b><b> (CONF:4437-3518)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3525)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Expiration Date Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.309)</b><b> (CONF:4437-3526)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3523)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Distinct Identification Code Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.308)</b><b> (CONF:4437-3524)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3521)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Brand Name Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.301)</b><b> (CONF:4437-3522)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3519)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Model Number Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.317)</b><b> (CONF:4437-3520)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3535)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Company Name Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.303)</b><b> (CONF:4437-3536)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3527)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Catalog Number Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.302)</b><b> (CONF:4437-3528)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3529)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Latex Safety Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.314)</b><b> (CONF:4437-3530)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3533)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] MRI Safety Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.318)</b><b> (CONF:4437-3534)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4437-3531)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Implantable Device Status Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.305)</b><b> (CONF:4437-3532)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/UDI%20Organizer_2.16.840.1.113883.10.20.22.4.311/Unique%20Device%20Identifier%20(UDI)%20Organizer.xml"><i class="fab fa-github"></i>&nbsp;UDI Organizer</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/UDI%20Organizer_2.16.840.1.113883.10.20.22.4.311/Unique%20Device%20Identifier%20(UDI)%20Organizer.xml"><i
+            class="fab fa-github"></i>&nbsp;UDI Organizer</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.314.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.314.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,148 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Latex Safety Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.314, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.314.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Latex Safety Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.314,
+        release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.314.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Latex Safety Status</strong> of the patient's medical device. The UDI-DI of the medical device may be used to retrieve the Latex Safety status in accessGUDID, which should be considered the source of truth.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Latex Safety Status</strong> of the patient's medical
+        device. The UDI-DI of the medical device may be used to retrieve the Latex Safety status in accessGUDID, which
+        should be considered the source of truth.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3491)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.314"</b><b> (CONF:4437-3494)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3495)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3492)</b>.<br>Note: Code for "Latex Status"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C160938"</b> Latex Safety Status (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3496)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3497)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3498)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Latex Safety Status"</b><b> (CONF:4437-3499)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Device Latex Safety<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.47/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.47</a></b><b> STATIC</b> 2019-06-21<b> (CONF:4437-3493)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:4437-3500)</b>.</li></ul><ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b><b> (CONF:4437-3501)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3491)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.314"</b><b> (CONF:4437-3494)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3495)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3492)</b>.<br>Note:
+        Code for "Latex Status"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C160938"</b> Latex Safety Status
+            (CodeSystem: <b>NCI Thesaurus (NCIt) <a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b>
+              (CONF:4437-3496)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3497)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3498)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Latex Safety Status"</b><b>
+              (CONF:4437-3499)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Device Latex Safety<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.47/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.47</a></b><b> STATIC</b> 2019-06-21<b>
+          (CONF:4437-3493)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:4437-3500)</b>.</li>
+        </ul>
+        <ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b><b> (CONF:4437-3501)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Latex%20Safety%20Status%20Example_2.16.840.1.113883.10.20.22.4.314/Latex%20Safety%20Status.xml"><i class="fab fa-github"></i>&nbsp;Latex Safety Status Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Latex%20Safety%20Status%20Example_2.16.840.1.113883.10.20.22.4.314/Latex%20Safety%20Status.xml"><i
+            class="fab fa-github"></i>&nbsp;Latex Safety Status Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.315.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.315.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,138 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Lot or Batch Number Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.315, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.315.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Lot or Batch Number Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.315, release 2019-06-21, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.315.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Lot or Batch Number</strong> of the device. The Lot or Batch Number is parsed from the UDI value, if present.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Lot or Batch Number</strong> of the device. The Lot or
+        Batch Number is parsed from the UDI value, if present.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3450)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.315"</b><b> (CONF:4437-3452)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3453)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3451)</b>.<br>Note: Code for "Lot or Batch Number"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101672"</b> Lot or Batch Number  (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3454)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3455)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3456)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Lot or Batch Number"</b><b> (CONF:4437-3457)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b> (CONF:4437-3458)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3450)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.315"</b><b> (CONF:4437-3452)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3453)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3451)</b>.<br>Note:
+        Code for "Lot or Batch Number"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101672"</b> Lot or Batch Number
+            (CodeSystem: <b>NCI Thesaurus (NCIt) <a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b>
+              (CONF:4437-3454)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3455)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3456)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Lot or Batch Number"</b><b>
+              (CONF:4437-3457)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b>
+          (CONF:4437-3458)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Lot%20or%20Batch%20Number%20Observation_2.16.840.1.113883.10.20.22.4.315/Lot%20or%20Batch%20Number.xml"><i class="fab fa-github"></i>&nbsp;Lot or Batch Number Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Lot%20or%20Batch%20Number%20Observation_2.16.840.1.113883.10.20.22.4.315/Lot%20or%20Batch%20Number.xml"><i
+            class="fab fa-github"></i>&nbsp;Lot or Batch Number Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.316.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.316.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,141 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Manufacturing Date Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.316, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.316.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Manufacturing Date Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.316, release 2019-06-21, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.316.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Manufacturing Date</strong> of the device.  The manufacturing date is parsed from the UDI value, if present.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Manufacturing Date</strong> of the device. The
+        manufacturing date is parsed from the UDI value, if present.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3459)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.316"</b><b> (CONF:4437-3462)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3463)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3460)</b>.<br>Note: Code for "Manufacturing Date"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101669"</b> Manufacturing Date  (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3464)</b>.<br>Note: Manufacturing Date code</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3465)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3466)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Manufacturing Date"</b><b> (CONF:4437-3467)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="TS"<b> (CONF:4437-3461)</b>.<br>Note:  Manufacturing Date as a time stamp<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4437-3468)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3459)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.316"</b><b> (CONF:4437-3462)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3463)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3460)</b>.<br>Note:
+        Code for "Manufacturing Date"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101669"</b> Manufacturing Date
+            (CodeSystem: <b>NCI Thesaurus (NCIt) <a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b>
+              (CONF:4437-3464)</b>.<br>Note: Manufacturing Date code</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3465)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3466)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Manufacturing Date"</b><b>
+              (CONF:4437-3467)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="TS"<b>
+          (CONF:4437-3461)</b>.<br>Note: Manufacturing Date as a time stamp<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4437-3468)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Manufacturing%20Date%20Observation_2.16.840.1.113883.10.20.22.4.316/Manufacturing%20Date.xml"><i class="fab fa-github"></i>&nbsp;Manufacturing Date Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Manufacturing%20Date%20Observation_2.16.840.1.113883.10.20.22.4.316/Manufacturing%20Date.xml"><i
+            class="fab fa-github"></i>&nbsp;Manufacturing Date Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.317.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.317.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,138 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Model Number Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.317, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.317.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Model Number Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.317,
+        release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.317.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Model Number</strong> associated with the device.  The UDI-DI of the medical device may be used to retrieve the <strong>Model Number</strong> in accessGUDID, which should be considered the source of truth.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Model Number</strong> associated with the device. The
+        UDI-DI of the medical device may be used to retrieve the <strong>Model Number</strong> in accessGUDID, which
+        should be considered the source of truth.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3412)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.317"</b><b> (CONF:4437-3414)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3415)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3413)</b>.<br>Note: Code for "Device Model Number"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C99285"</b> Model Number (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3416)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3417)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3418)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Model Number"</b><b> (CONF:4437-3419)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b> (CONF:4437-3420)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3412)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.317"</b><b> (CONF:4437-3414)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3415)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3413)</b>.<br>Note:
+        Code for "Device Model Number"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C99285"</b> Model Number (CodeSystem:
+            <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b>
+              STATIC</b>)<b> (CONF:4437-3416)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3417)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3418)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Model Number"</b><b>
+              (CONF:4437-3419)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b>
+          (CONF:4437-3420)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Model%20Number%20Observation_2.16.840.1.113883.10.20.22.4.317/Model%20Number.xml"><i class="fab fa-github"></i>&nbsp;Model Number Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Model%20Number%20Observation_2.16.840.1.113883.10.20.22.4.317/Model%20Number.xml"><i
+            class="fab fa-github"></i>&nbsp;Model Number Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.318.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.318.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,147 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">MRI Safety Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.318, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.318.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">MRI Safety Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.318,
+        release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.318.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the MRI Safety Status of the patient's medical device. The UDI-DI of the medical device may be used to retrieve the <strong>MRI Safety Status</strong> in accessGUDID, which should be considered the source of truth.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the MRI Safety Status of the patient's medical device. The UDI-DI of
+        the medical device may be used to retrieve the <strong>MRI Safety Status</strong> in accessGUDID, which should
+        be considered the source of truth.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3469)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.318"</b><b> (CONF:4437-3471)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3472)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3470)</b>.<br>Note: Code for "MRI Safety Status"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C106044"</b> MRI Safety (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3473)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3474)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3475)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"MRI Safety"</b><b> (CONF:4437-3476)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Device Magnetic resonance (MR) Safety<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.46/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.46</a></b><b> STATIC</b> 2019-06-21<b> (CONF:4437-3477)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:4437-3478)</b>.</li></ul><ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b><b> (CONF:4437-3479)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3469)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.318"</b><b> (CONF:4437-3471)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3472)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3470)</b>.<br>Note:
+        Code for "MRI Safety Status"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C106044"</b> MRI Safety (CodeSystem:
+            <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b>
+              STATIC</b>)<b> (CONF:4437-3473)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3474)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3475)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"MRI Safety"</b><b>
+              (CONF:4437-3476)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Device Magnetic resonance (MR) Safety<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.46/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.46</a></b><b> STATIC</b> 2019-06-21<b>
+          (CONF:4437-3477)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:4437-3478)</b>.</li>
+        </ul>
+        <ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b><b> (CONF:4437-3479)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/MRI%20Safety%20Status%20Observation_2.16.840.1.113883.10.20.22.4.318/MRI%20Safety%20Status.xml"><i class="fab fa-github"></i>&nbsp;MRI Safety Status Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/MRI%20Safety%20Status%20Observation_2.16.840.1.113883.10.20.22.4.318/MRI%20Safety%20Status.xml"><i
+            class="fab fa-github"></i>&nbsp;MRI Safety Status Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.319.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.319.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,71 +24,137 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Serial Number Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.319, release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.319.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Serial Number Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.319,
+        release 2019-06-21, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.319.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is intended to be used in addition to the <strong>Product Instance</strong> template 2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Serial Number</strong> of the device.  The serial number is parsed from the UDI value, if present.</p></div>
+    <div id="description">
+      <p>This template is intended to be used in addition to the <strong>Product Instance</strong> template
+        2.16.840.1.113883.10.20.22.4.37 to exchange the <strong>Serial Number</strong> of the device. The serial number
+        is parsed from the UDI value, if present.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.311.html">UDI Organizer</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3373)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.319"</b><b> (CONF:4437-3377)</b>.<br>Note: template oid</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b> (CONF:4437-3368)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3374)</b>.<br>Note: Code for "Serial Number"<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101671"</b> Serial Number  (CodeSystem: <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b> STATIC</b>)<b> (CONF:4437-3378)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3369)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b> (CONF:4437-3370)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Serial Number"</b><b> (CONF:4437-3379)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b> (CONF:4437-3372)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4437-3373)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.319"</b><b> (CONF:4437-3377)</b>.<br>Note: template oid</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-21"</b><b>
+              (CONF:4437-3368)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4437-3374)</b>.<br>Note:
+        Code for "Serial Number"<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"C101671"</b> Serial Number (CodeSystem:
+            <b>NCI Thesaurus (NCIt) <a href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a></b><b>
+              STATIC</b>)<b> (CONF:4437-3378)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                href="https://terminology.hl7.org/2.0.0/CodeSystem-v3-nciThesaurus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.26.1.1</a>"</b><b> (CONF:4437-3369)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystemName</b>=<b>"NCI Thesaurus"</b><b>
+              (CONF:4437-3370)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@displayName</b>=<b>"Serial Number"</b><b>
+              (CONF:4437-3379)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b>
+          (CONF:4437-3372)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Serial%20Number%20Observation_2.16.840.1.113883.10.20.22.4.319/Serial%20Number.xml"><i class="fab fa-github"></i>&nbsp;Serial Number Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Serial%20Number%20Observation_2.16.840.1.113883.10.20.22.4.319/Serial%20Number.xml"><i
+            class="fab fa-github"></i>&nbsp;Serial Number Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.32.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.32.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,105 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Service Delivery Location <small class="text-muted">[participantRole, 2.16.840.1.113883.10.20.22.4.32, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.32.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Service Delivery Location <small class="text-muted">[participantRole,
+        2.16.840.1.113883.10.20.22.4.32, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.32.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement represents the location of a service event where an act, observation or procedure took place.</p></div>
+    <div id="description">
+      <p>This clinical statement represents the location of a service event where an act, observation or procedure took
+        place.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.12.html">Procedure Activity Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.40.html">Planned Encounter (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SDLOC"</b> (CodeSystem: <b>HL7RoleCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.111</a></b><b> STATIC</b>)<b> (CONF:81-7758)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7635)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.32"</b><b> (CONF:81-10524)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet HealthcareServiceLocation<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20275/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20275</a></b><b> DYNAMIC</b><b> (CONF:81-16850)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:81-7760)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:81-7761)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>playingEntity</b><b> (CONF:81-7762)</b>.<ul><li>The playingEntity, if present, <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PLC"</b> (CodeSystem: <b>HL7EntityClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b><b> STATIC</b>)<b> (CONF:81-7763)</b>.</li></ul><ul><li>The playingEntity, if present, <b>MAY</b> contain zero or one [0..1] <b>name</b><b> (CONF:81-16037)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SDLOC"</b> (CodeSystem:
+        <b>HL7RoleCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleCode.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.111</a></b><b> STATIC</b>)<b>
+          (CONF:81-7758)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7635)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.32"</b><b>
+              (CONF:81-10524)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected
+        from ValueSet HealthcareServiceLocation<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20275/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20275</a></b><b> DYNAMIC</b><b>
+          (CONF:81-16850)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:81-7760)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:81-7761)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>playingEntity</b><b> (CONF:81-7762)</b>.<ul>
+          <li>The playingEntity, if present, <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PLC"</b>
+            (CodeSystem: <b>HL7EntityClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b><b>
+              STATIC</b>)<b> (CONF:81-7763)</b>.</li>
+        </ul>
+        <ul>
+          <li>The playingEntity, if present, <b>MAY</b> contain zero or one [0..1] <b>name</b><b> (CONF:81-16037)</b>.
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Service%20Delivery%20Location_2.16.840.1.113883.10.20.22.4.32/Service%20Delivery%20Location%20Example.xml"><i class="fab fa-github"></i>&nbsp;Service Delivery Location Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Service%20Delivery%20Location_2.16.840.1.113883.10.20.22.4.32/Service%20Delivery%20Location%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Service Delivery Location Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.33.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.33.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,117 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Hospital Discharge Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.33, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.33.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Hospital Discharge Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.33,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.33.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents problems or diagnoses present at the time of discharge which occurred during the hospitalization or need to be monitored after hospitalization. It requires at least one Problem Observation entry.</p></div>
+    <div id="description">
+      <p>This template represents problems or diagnoses present at the time of discharge which occurred during the
+        hospitalization or need to be monitored after hospitalization. It requires at least one Problem Observation
+        entry.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.24.html">Discharge Diagnosis Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.24.html">Discharge Diagnosis Section (V3)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-7663)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-7664)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16764)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.33"</b><b> (CONF:1198-16765)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32534)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19147)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11535-2"</b> Hospital discharge diagnosis<b> (CONF:1198-19148)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32163)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-7666)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-7667)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15536)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1198-7663)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-7664)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16764)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.33"</b><b>
+              (CONF:1198-16765)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32534)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19147)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11535-2"</b> Hospital discharge
+            diagnosis<b> (CONF:1198-19148)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32163)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-7666)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-7667)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15536)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Discharge%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.33/Hospital%20Discharge%20Diagnosis%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Hospital Discharge Diagnosis (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Discharge%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.33/Hospital%20Discharge%20Diagnosis%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Hospital Discharge Diagnosis (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.34.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.34.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,115 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Hospital Admission Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.34, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.34.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Hospital Admission Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.34,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.34.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents problems or diagnoses identified by the clinician at the time of the patient's admission.This Hospital Admission Diagnosis act may contain more than one Problem Observation to represent multiple diagnoses for a Hospital Admission.</p></div>
+    <div id="description">
+      <p>This template represents problems or diagnoses identified by the clinician at the time of the patient's
+        admission.This Hospital Admission Diagnosis act may contain more than one Problem Observation to represent
+        multiple diagnoses for a Hospital Admission.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.43.html">Admission Diagnosis Section (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.43.html">Admission Diagnosis Section
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-7671)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-7672)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16747)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.34"</b><b> (CONF:1198-16748)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32535)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19145)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46241-6"</b> Admission diagnosis<b> (CONF:1198-19146)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32162)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-7674)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-7675)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15535)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1198-7671)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-7672)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16747)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.34"</b><b>
+              (CONF:1198-16748)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32535)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19145)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"46241-6"</b> Admission diagnosis<b>
+              (CONF:1198-19146)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32162)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-7674)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-7675)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15535)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Admission%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.34/Hospital%20Admission%20Diagnosis%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Hospital Admission Diagnosis (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Hospital%20Admission%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.34/Hospital%20Admission%20Diagnosis%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Hospital Admission Diagnosis (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.35.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.35.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,133 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Discharge Medication (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.35, release 2016-03-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.35.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Discharge Medication (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.35, release
+        2016-03-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.35.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents medications that the patient is intended to take (or stop) after discharge.</p></div>
+    <div id="description">
+      <p>This template represents medications that the patient is intended to take (or stop) after discharge.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.11.html">Discharge Medications Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.11.1.html">Discharge Medications Section (entries required) (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.11.html">Discharge Medications Section (entries
+              optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.11.1.html">Discharge Medications Section
+              (entries required) (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-7689)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-7690)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16760)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.35"</b><b> (CONF:1198-16761)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-03-01"</b><b> (CONF:1198-32513)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-7691)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10183-2"</b> Hospital discharge medication<b> (CONF:1198-19161)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32159)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32952)</b>.</li><ul><li>This translation <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75311-1"</b> Discharge Medication<b> (CONF:1198-32953)</b>.</li></ul><ul><li>This translation <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32954)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32779)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-32780)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-7692)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-7693)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1198-15525)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1198-7689)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-7690)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16760)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.35"</b><b>
+              (CONF:1198-16761)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2016-03-01"</b><b> (CONF:1198-32513)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-7691)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10183-2"</b> Hospital discharge
+            medication<b> (CONF:1198-19161)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32159)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32952)</b>.</li>
+          <ul>
+            <li>This translation <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75311-1"</b> Discharge
+              Medication<b> (CONF:1198-32953)</b>.</li>
+          </ul>
+          <ul>
+            <li>This translation <b>SHALL</b> contain exactly one [1..1]
+              <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b>
+                (CONF:1198-32954)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-32779)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-32780)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-7692)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-7693)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1198-15525)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Discharge%20Medication%20(V3)_2.16.840.1.113883.10.20.22.4.35/Discharge%20Medication%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Discharge Medication (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Discharge%20Medication%20(V3)_2.16.840.1.113883.10.20.22.4.35/Discharge%20Medication%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Discharge Medication (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.36.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.36.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,112 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Admission Medication (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.36, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.36.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Admission Medication (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.36, release
+        2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.36.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the medications taken by the patient prior to and at the time of admission.</p></div>
+    <div id="description">
+      <p>This template represents the medications taken by the patient prior to and at the time of admission.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.44.html">Admission Medications Section (entries optional) (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.44.html">Admission Medications Section (entries
+              optional) (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7698)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-7699)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16758)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.36"</b><b> (CONF:1098-16759)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32524)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15518)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42346-7"</b> Medications on Admission<b> (CONF:1098-15519)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32152)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1098-7701)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7702)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15520)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-7698)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7699)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16758)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.36"</b><b>
+              (CONF:1098-16759)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32524)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15518)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"42346-7"</b> Medications on
+            Admission<b> (CONF:1098-15519)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32152)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1098-7701)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7702)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15520)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Admission%20Medication%20(V2)_2.16.840.1.113883.10.20.22.4.36/Admission%20Medication%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Admission Medication (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Admission%20Medication%20(V2)_2.16.840.1.113883.10.20.22.4.36/Admission%20Medication%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Admission Medication (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.37.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.37.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,113 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Product Instance <small class="text-muted">[participantRole, 2.16.840.1.113883.10.20.22.4.37, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.37.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Product Instance <small class="text-muted">[participantRole, 2.16.840.1.113883.10.20.22.4.37, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.22.4.37.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement represents a particular device that was placed in a patient or used as part of a procedure or other act. This provides a record of the identifier and other details about the given product that was used. For example, it is important to have a record that indicates not just that a hip prostheses was placed in a patient but that it was a particular hip prostheses number with a unique identifier.</p><p>The FDA Amendments Act specifies the creation of a Unique Device Identification (UDI) System that requires the label of devices to bear a unique identifier that will standardize device identification and identify the device through distribution and use.</p><p>The FDA permits an issuing agency to designate that their Device Identifier (DI) + Production Identifier (PI) format qualifies as a UDI through a process of accreditation. Currently, there are three FDA-accredited issuing agencies that are allowed to call their format a UDI. These organizations are GS1, HIBCC, and ICCBBA. For additional information on technical formats that qualify as UDI from each of the issuing agencies see the UDI Appendix.</p><p>When communicating only the issuing agency device identifier (i.e., subcomponent of the UDI), the use of the issuing agency OID is appropriate. However, when communicating the unique device identifier (DI + PI), the FDA OID (2.16.840.1.113883.3.3719) must be used.When sending a UDI, populate the participantRole/id/@root with the FDA OID (2.16.840.1.113883.3.3719) and participantRole/id/@extension with the UDI.</p><p>When sending a DI, populate the participantRole/id/@root with the appropriate assigning agency OID and participantRole/id/@extension with the DI.The scopingEntity/id should correspond to FDA or the appropriate issuing agency.</p></div>
+    <div id="description">
+      <p>This clinical statement represents a particular device that was placed in a patient or used as part of a
+        procedure or other act. This provides a record of the identifier and other details about the given product that
+        was used. For example, it is important to have a record that indicates not just that a hip prostheses was placed
+        in a patient but that it was a particular hip prostheses number with a unique identifier.</p>
+      <p>The FDA Amendments Act specifies the creation of a Unique Device Identification (UDI) System that requires the
+        label of devices to bear a unique identifier that will standardize device identification and identify the device
+        through distribution and use.</p>
+      <p>The FDA permits an issuing agency to designate that their Device Identifier (DI) + Production Identifier (PI)
+        format qualifies as a UDI through a process of accreditation. Currently, there are three FDA-accredited issuing
+        agencies that are allowed to call their format a UDI. These organizations are GS1, HIBCC, and ICCBBA. For
+        additional information on technical formats that qualify as UDI from each of the issuing agencies see the UDI
+        Appendix.</p>
+      <p>When communicating only the issuing agency device identifier (i.e., subcomponent of the UDI), the use of the
+        issuing agency OID is appropriate. However, when communicating the unique device identifier (DI + PI), the FDA
+        OID (2.16.840.1.113883.3.3719) must be used.When sending a UDI, populate the participantRole/id/@root with the
+        FDA OID (2.16.840.1.113883.3.3719) and participantRole/id/@extension with the UDI.</p>
+      <p>When sending a DI, populate the participantRole/id/@root with the appropriate assigning agency OID and
+        participantRole/id/@extension with the DI.The scopingEntity/id should correspond to FDA or the appropriate
+        issuing agency.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> Manufactured Product (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b> (CONF:81-7900)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7901)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.37"</b><b> (CONF:81-10522)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-7902)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>playingDevice</b><b> (CONF:81-7903)</b>.<ul><li>This playingDevice <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:81-16837)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>scopingEntity</b><b> (CONF:81-7905)</b>.<ul><li>This scopingEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-7908)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> Manufactured
+        Product (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b>
+          (CONF:81-7900)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-7901)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.37"</b><b>
+              (CONF:81-10522)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-7902)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>playingDevice</b><b> (CONF:81-7903)</b>.
+        <ul>
+          <li>This playingDevice <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:81-16837)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>scopingEntity</b><b> (CONF:81-7905)</b>.
+        <ul>
+          <li>This scopingEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-7908)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Product%20Instance_2.16.840.1.113883.10.20.22.4.37/Product%20Instance%20Example.xml"><i class="fab fa-github"></i>&nbsp;Product Instance Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Product%20Instance_2.16.840.1.113883.10.20.22.4.37/Product%20Instance%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Product Instance Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i> Medical Equipment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Medical%20Equipment"><i class="fas fa-external-link-alt"></i>
+          Medical Equipment</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.38.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.38.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,85 +24,212 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Social History Observation (V4) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.38, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.38.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Social History Observation (V4) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.38, release 2022-06-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.38.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a patient's occupations, lifestyle, and environmental health risk factors. Demographic data (e.g., marital status, race, ethnicity, religious affiliation) are captured in the header. Though tobacco use and exposure may be represented with a Social History Observation, it is recommended to use the Current Smoking Status template or the Tobacco Use template instead, to represent smoking or tobacco habits. 
-      <br/> 
-      <br/> 
-      There are supplemental templates and guidance for observations of <a href="https://www.hl7.org/implement/standards/product_brief.cfm?product_id=522">occupational data</a>, <a href="https://www.hl7.org/implement/standards/product_brief.cfm?product_id=478">nutrition</a> and <a href="https://www.hl7.org/implement/standards/product_brief.cfm?product_id=494">pregnancy</a> that could be captured in the Social History Observation, and implementers may want to consider using those more specific templates in the Social History section.</p></div>
+    <div id="description">
+      <p>This template represents a patient's occupations, lifestyle, and environmental health risk factors. Demographic
+        data (e.g., marital status, race, ethnicity, religious affiliation) are captured in the header. Though tobacco
+        use and exposure may be represented with a Social History Observation, it is recommended to use the Current
+        Smoking Status template or the Tobacco Use template instead, to represent smoking or tobacco habits.
+        <br />
+        <br />
+        There are supplemental templates and guidance for observations of <a
+          href="https://www.hl7.org/implement/standards/product_brief.cfm?product_id=522">occupational data</a>, <a
+          href="https://www.hl7.org/implement/standards/product_brief.cfm?product_id=478">nutrition</a> and <a
+          href="https://www.hl7.org/implement/standards/product_brief.cfm?product_id=494">pregnancy</a> that could be
+        captured in the Social History Observation, and implementers may want to consider using those more specific
+        templates in the Social History section.
+      </p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-8548)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-8549)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-8550)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.38"</b><b> (CONF:4515-10526)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32495)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-8551)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Social History Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.60/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.60</a></b><b> DYNAMIC</b><b> (CONF:4515-8558)</b>.<ul><li><p>If @codeSystem is not LOINC, then this code <strong>SHALL</strong> contain at least one [1..*] translation, which <strong>SHOULD</strong> be selected from CodeSystem LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) (CONF:4515-32956).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-8553)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:4515-19117)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-31868)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>value</b><b> (CONF:4515-8559)</b>.<ul><li><p>If Observation/value is a physical quantity (xsi:type="PQ"), the unit of measure <strong>SHALL</strong> be selected from ValueSet UnitsOfMeasureCaseSensitive (<a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a>) <em>DYNAMIC</em> (CONF:4515-8555).</p></li></ul><ul><li><p>If the Social History Observation is a Social Determinant of Health Observation, the observation/value code <strong>SHOULD</strong> be selected from ValueSet Social Determinant of Health Conditions <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.788/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1196.788</a> <strong>DYNAMIC</strong> (CONF:4515-32957).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-31869)</b>.</li>
-<li class="list-group-item"><p>When an Assessment Scale Observation is contained in a Social History Observation instance that is a Social Determinant of Health Social History Observation, that Assessment Scale Observation MAY contain Assessment Scale Supporting Observations that contain LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32958)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32960)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-32959)</b>.</li></ul></li>
-<li class="list-group-item"><p>When an Entry Reference is contained in a Social History Template instance that is a Social Determinant of Health Social History, that Entry Reference MAY reference an Assessment Scale Observation elsewhere in the document that represent LOINC question and answer pairs from SDOH screening instruments.</p><b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32969)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32971)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32970)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:4515-8548)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4515-8549)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-8550)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.38"</b><b>
+              (CONF:4515-10526)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32495)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-8551)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet Social History Type<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.60/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.60</a></b><b> DYNAMIC</b><b>
+          (CONF:4515-8558)</b>.<ul>
+          <li>
+            <p>If @codeSystem is not LOINC, then this code <strong>SHALL</strong> contain at least one [1..*]
+              translation, which <strong>SHOULD</strong> be selected from CodeSystem LOINC (<a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) (CONF:4515-32956).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-8553)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:4515-19117)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:4515-31868)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>value</b><b> (CONF:4515-8559)</b>.<ul>
+          <li>
+            <p>If Observation/value is a physical quantity (xsi:type="PQ"), the unit of measure <strong>SHALL</strong>
+              be selected from ValueSet UnitsOfMeasureCaseSensitive (<a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a>)
+              <em>DYNAMIC</em> (CONF:4515-8555).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>If the Social History Observation is a Social Determinant of Health Observation, the observation/value
+              code <strong>SHOULD</strong> be selected from ValueSet Social Determinant of Health Conditions <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.788/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1196.788</a>
+              <strong>DYNAMIC</strong> (CONF:4515-32957).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-31869)</b>.</li>
+      <li class="list-group-item">
+        <p>When an Assessment Scale Observation is contained in a Social History Observation instance that is a Social
+          Determinant of Health Social History Observation, that Assessment Scale Observation MAY contain Assessment
+          Scale Supporting Observations that contain LOINC question and answer pairs from SDOH screening
+          instruments.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32958)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-32960)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-32959)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When an Entry Reference is contained in a Social History Template instance that is a Social Determinant of
+          Health Social History, that Entry Reference MAY reference an Assessment Scale Observation elsewhere in the
+          document that represent LOINC question and answer pairs from SDOH screening instruments.</p><b>MAY</b> contain
+        zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32969)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-32971)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32970)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Social%20History%20Observation%20(V4)_2.16.840.1.113883.10.20.22.4.38/Social%20History%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Social History Observation Example</a></li>
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Social%20History%20Observation%20(V4)_2.16.840.1.113883.10.20.22.4.38/Social%20Determinant%20of%20Health%20Social%20History%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Social Determinant of Health Social History Observation Example</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Social%20History%20Observation%20(V4)_2.16.840.1.113883.10.20.22.4.38/Social%20History%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Social History Observation Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Social%20History%20Observation%20(V4)_2.16.840.1.113883.10.20.22.4.38/Social%20Determinant%20of%20Health%20Social%20History%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Social Determinant of Health Social History Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social History</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social
+          History</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.39.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.39.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,58 +52,173 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.39, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.39.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.39, release 2014-06-09,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.39.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents planned acts that are not classified as an observation or a procedure according to the HL7 RIM. Examples of these acts are a dressing change, the teaching or feeding of a patient or the providing of comfort measures.The priority of the activity to the patient and provider is communicated through Priority Preference. The effectiveTime indicates the time when the activity is intended to take place.</p></div>
+    <div id="description">
+      <p>This template represents planned acts that are not classified as an observation or a procedure according to the
+        HL7 RIM. Examples of these acts are a dressing change, the teaching or feeding of a patient or the providing of
+        comfort measures.The priority of the activity to the patient and provider is communicated through Priority
+        Preference. The effectiveTime indicates the time when the activity is intended to take place.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.9.html">Assessment and Plan Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8538)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Planned moodCode (Act/Encounter/Procedure)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.23/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.23</a></b><b> STATIC</b> 2014-09-01<b> (CONF:1098-8539)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30430)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.39"</b><b> (CONF:1098-30431)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32552)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8546)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31687)</b>.<ul><li><p>This code in a Planned Act <strong>SHOULD</strong> be selected from LOINC (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) <em>OR</em> SNOMED CT (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1098-32030).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30432)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32019)</b>.</li></ul></li>
-<li class="list-group-item"><p>The effectiveTime in a planned act represents the time that the act should occur.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-30433)</b>.</li>
-<li class="list-group-item"><p>The clinician who is expected to carry out the act could be identified using act/performer. <br></p> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-30435)</b>.</li>
-<li class="list-group-item"><p>The author in a planned act represents the clinician who is requesting or planning the act.<br></p> <b>SHOULD</b> contain zero or one [0..1]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32020)</b>.</li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that a patient or a provider places on the activity.<br /><br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31067)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31068)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31069)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the indication for the act.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32021)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32022)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32023)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship captures any instructions associated with the planned act.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32024)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32025)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32026)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-8538)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Planned moodCode (Act/Encounter/Procedure)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.23/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.23</a></b><b> STATIC</b> 2014-09-01<b>
+          (CONF:1098-8539)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30430)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.39"</b><b>
+              (CONF:1098-30431)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32552)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8546)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-31687)</b>.<ul>
+          <li>
+            <p>This code in a Planned Act <strong>SHOULD</strong> be selected from LOINC (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) <em>OR</em> SNOMED CT (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1098-32030).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30432)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32019)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime in a planned act represents the time that the act should occur.<br></p> <b>SHOULD</b>
+        contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-30433)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The clinician who is expected to carry out the act could be identified using act/performer. <br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-30435)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The author in a planned act represents the clinician who is requesting or planning the act.<br></p>
+        <b>SHOULD</b> contain zero or one [0..1] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32020)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that a patient or a provider places on the
+          activity.<br /><br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-31067)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31068)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31069)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the indication for the act.<br></p> <b>MAY</b> contain zero or
+        more [0..*] <b>entryRelationship</b><b> (CONF:1098-32021)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32022)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32023)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship captures any instructions associated with the planned act.<br></p> <b>MAY</b>
+        contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32024)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32025)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32026)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.39/Planned%20Act%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Planned Act (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.39/Planned%20Act%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Planned Act (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.4.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.4.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,89 +24,336 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Problem Observation (V4) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.4, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.4.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Problem Observation (V4) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.4,
+        release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.4.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template reflects a discrete observation about a patient's problem. Because it is a discrete observation, it will have a statusCode of "completed". The effectiveTime, also referred to as the 'clinically relevant time' is the time at which the observation holds for the patient. For a provider seeing a patient in the clinic today, observing a history of heart attack that occurred five years ago, the effectiveTime is five years ago.</p><p>The effectiveTime of the Problem Observation is the definitive indication of whether or not the underlying condition is resolved. If the problem is known to be resolved, then an effectiveTime/high would be present. If the date of resolution is not known, then effectiveTime/high will be present with a nullFlavor of "UNK".</p></div>
+    <div id="description">
+      <p>This template reflects a discrete observation about a patient's problem. Because it is a discrete observation,
+        it will have a statusCode of "completed". The effectiveTime, also referred to as the 'clinically relevant time'
+        is the time at which the observation holds for the patient. For a provider seeing a patient in the clinic today,
+        observing a history of heart attack that occurred five years ago, the effectiveTime is five years ago.</p>
+      <p>The effectiveTime of the Problem Observation is the definitive indication of whether or not the underlying
+        condition is resolved. If the problem is known to be resolved, then an effectiveTime/high would be present. If
+        the date of resolution is not known, then effectiveTime/high will be present with a nullFlavor of "UNK".</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.31.html">Age Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.113.html">Prognosis Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.6.html">Problem Status</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.502.html">Date of Diagnosis Act</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.31.html">Age Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.113.html">Prognosis Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.6.html">Problem Status</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.502.html">Date of Diagnosis Act</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Problem Observation (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.4.4:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-9041)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-9042)</b>.</li>
-<li class="list-group-item"><p>The negationInd is used to indicate the absence of the condition in observation/value. A negationInd of "true" coupled with an observation/value of SNOMED code 64572001 "Disease (disorder)" indicates that the patient has no known conditions.<br></p> <b>MAY</b> contain zero or one [0..1] <b>@negationInd</b><b> (CONF:4515-10139)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-14926)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.4"</b><b> (CONF:4515-14927)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32508)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-9043)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Problem Type (SNOMEDCT)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.2/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.2</a></b><b> DYNAMIC</b><b> (CONF:4515-9045)</b>.<ul><li><p>If code is selected from ValueSet Problem Type (SNOMEDCT) <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.2/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.2 </a><strong>DYNAMIC</strong>, then it <strong>SHALL</strong> have at least one [1..*] translation, which <strong>SHOULD</strong> be selected from ValueSet Problem Type (LOINC) <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.28/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.28 </a><strong>DYNAMIC</strong> (CONF:1198-32950) (CONF:4515-32950).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-9049)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:4515-19112)</b>.</li></ul></li>
-<li class="list-group-item"><p>The effectiveTime/low (a.k.a. "onset date") asserts when the condition became clinically active.</p><p>The effectiveTime/high (a.k.a. "resolution date") asserts when the condition became clinically resolved.</p><p>If the problem is known to be resolved, but the date of resolution is not known, then the high element <b>SHALL</b> be present, and the nullFlavor attribute <b>SHALL</b> be set to 'UNK'. Therefore, the existence of a high element within a problem does indicate that the problem has been resolved.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-9050)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-15603)</b>.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-15604)</b>.</li></ul><ul><li><p>When an observation/value code concept name has a temporal aspect, ensure that observation/effectiveTime/value aligns with the temporal aspect of the code. Most often, a single time is appropriate, rather than low and high values. An example SNOMED CT code is 714093000 (Sexually active in last six months (finding)) (CONF:4515-32964).</p></li></ul>
-<li class="list-group-item"><b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Problem<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b> DYNAMIC</b><b> (CONF:4515-9058)</b>.<ul><li>A negationInd of "true" coupled with an observation/value/@code of SNOMED code 64572001 "Disease (disorder)" indicates that the patient has no known conditions.<br/> This value <b>MAY</b> contain zero or one [0..1] <b>@code</b><b> (CONF:4515-31871)</b>.</li><ul><li><p>When the Problem is Social Determinant of Health Observation, the observation/value <strong>SHOULD</strong> be a SNOMED code selected from ValueSet  Social Determinant of Health Conditions <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.788/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1196.788</a>  <strong>DYNAMIC</strong> (CONF:4515-32951).</p></li></ul></ul><ul><li>The observation/value and all the qualifiers together (often referred to as a post-coordinated expression) make up one concept. Qualifiers constrain the meaning of the primary code, and cannot negate it or change its meaning. Qualifiers can only be used according to well-defined rules of post-coordination and only if the underlying code system defines the use of such qualifiers or if there is a third code system that specifies how other code systems may be combined.<br>For example, SNOMED CT allows constructing concepts as a combination of multiple codes. SNOMED CT defines a concept "pneumonia (disorder)" (233604007) an attribute "finding site" (363698007) and another concept "left lower lobe of lung (body structure)" (41224006). In this example the observation value would contain "pneumonia (disorder)" (233604007), the qualifier name would contain "finding site" (363698007), and the qualifier value would contain "left lower lobe of lung (body structure)" (41224006). For more information on SNOMED CT expressions, see: https://confluence.ihtsdotools.org/display/DOCSTART/7.+SNOMED+CT+Expressions.<br/>This value <b>MAY</b> contain zero or more [0..*] <b>qualifier</b><b> (CONF:4515-31870)</b>.</li></ul><ul><li>This value <b>MAY</b> contain zero or more [0..*] <b>translation</b><b> (CONF:4515-16749)</b> such that it</li><ul><li><b>MAY</b> contain zero or one [0..1] <b>@code</b> (CodeSystem: <b>ICD-10-CM 2.16.840.1.113883.6.90</b><b> STATIC</b>)<b> (CONF:4515-16750)</b>.</li><ul><li><p>When the Problem is Social Determinant of Health Observation, the observation/value/translation SHOULD be an ICD10 code selected from ValueSet Social Determinant of Health Conditions <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.788/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1196.788</a> DYNAMIC (CONF:4515-32952).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-31147)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:4515-9059)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:4515-9060)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:4515-9069)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Age Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.31)</b><b> (CONF:4515-15590)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:4515-29951)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31531)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Prognosis Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.113)</b><b> (CONF:4515-29952)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31063)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31532)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:4515-31064)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:4515-9063)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-9068)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Status<b> (identifier: 2.16.840.1.113883.10.20.22.4.6)</b><b> (CONF:4515-15591)</b>.</li></ul></li>
-<li class="list-group-item"><p>When an Entry Reference template is contained in a Problem Template instance that is a Social Determinant of Health problem, that Entry Reference <strong>MAY</strong> reference an Assessment Scale Observation elsewhere in the document. That Assessment Scale <strong>MAY</strong> contain assessment scale observations that represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32965)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32968)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32966)</b>.</li></ul></li>
-<li class="list-group-item"><p>When an Assessment Scale Observation is contained in a Problem Template instance that is a Social Determinant of Health problem, that Assessment scale <strong>MAY</strong> contain assessment scale observations that represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32953)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32955)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-32954)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-33012)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-33014)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Date of Diagnosis Act<b> (identifier: 2.16.840.1.113883.10.20.22.4.502)</b><b> (CONF:4515-33013)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Problem Observation (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.4.4:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:4515-9041)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4515-9042)</b>.</li>
+      <li class="list-group-item">
+        <p>The negationInd is used to indicate the absence of the condition in observation/value. A negationInd of
+          "true" coupled with an observation/value of SNOMED code 64572001 "Disease (disorder)" indicates that the
+          patient has no known conditions.<br></p> <b>MAY</b> contain zero or one [0..1] <b>@negationInd</b><b>
+          (CONF:4515-10139)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-14926)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.4"</b><b>
+              (CONF:4515-14927)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-32508)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-9043)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet Problem Type (SNOMEDCT)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.2/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.2</a></b><b>
+          DYNAMIC</b><b> (CONF:4515-9045)</b>.<ul>
+          <li>
+            <p>If code is selected from ValueSet Problem Type (SNOMEDCT) <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.2/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.2
+              </a><strong>DYNAMIC</strong>, then it <strong>SHALL</strong> have at least one [1..*] translation, which
+              <strong>SHOULD</strong> be selected from ValueSet Problem Type (LOINC) <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.28/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.28
+              </a><strong>DYNAMIC</strong> (CONF:1198-32950) (CONF:4515-32950).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-9049)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:4515-19112)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime/low (a.k.a. "onset date") asserts when the condition became clinically active.</p>
+        <p>The effectiveTime/high (a.k.a. "resolution date") asserts when the condition became clinically resolved.</p>
+        <p>If the problem is known to be resolved, but the date of resolution is not known, then the high element
+          <b>SHALL</b> be present, and the nullFlavor attribute <b>SHALL</b> be set to 'UNK'. Therefore, the existence
+          of a high element within a problem does indicate that the problem has been resolved.<br></p> <b>SHALL</b>
+        contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-9050)</b>.<ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-15603)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-15604)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>When an observation/value code concept name has a temporal aspect, ensure that
+              observation/effectiveTime/value aligns with the temporal aspect of the code. Most often, a single time is
+              appropriate, rather than low and high values. An example SNOMED CT code is 714093000 (Sexually active in
+              last six months (finding)) (CONF:4515-32964).</p>
+          </li>
+        </ul>
+      <li class="list-group-item"><b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet Problem<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b>
+          DYNAMIC</b><b> (CONF:4515-9058)</b>.<ul>
+          <li>A negationInd of "true" coupled with an observation/value/@code of SNOMED code 64572001 "Disease
+            (disorder)" indicates that the patient has no known conditions.<br /> This value <b>MAY</b> contain zero or
+            one [0..1] <b>@code</b><b> (CONF:4515-31871)</b>.</li>
+          <ul>
+            <li>
+              <p>When the Problem is Social Determinant of Health Observation, the observation/value
+                <strong>SHOULD</strong> be a SNOMED code selected from ValueSet Social Determinant of Health Conditions
+                <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.788/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1196.788</a>
+                <strong>DYNAMIC</strong> (CONF:4515-32951).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li>The observation/value and all the qualifiers together (often referred to as a post-coordinated expression)
+            make up one concept. Qualifiers constrain the meaning of the primary code, and cannot negate it or change
+            its meaning. Qualifiers can only be used according to well-defined rules of post-coordination and only if
+            the underlying code system defines the use of such qualifiers or if there is a third code system that
+            specifies how other code systems may be combined.<br>For example, SNOMED CT allows constructing concepts as
+            a combination of multiple codes. SNOMED CT defines a concept "pneumonia (disorder)" (233604007) an attribute
+            "finding site" (363698007) and another concept "left lower lobe of lung (body structure)" (41224006). In
+            this example the observation value would contain "pneumonia (disorder)" (233604007), the qualifier name
+            would contain "finding site" (363698007), and the qualifier value would contain "left lower lobe of lung
+            (body structure)" (41224006). For more information on SNOMED CT expressions, see:
+            https://confluence.ihtsdotools.org/display/DOCSTART/7.+SNOMED+CT+Expressions.<br />This value <b>MAY</b>
+            contain zero or more [0..*] <b>qualifier</b><b> (CONF:4515-31870)</b>.</li>
+        </ul>
+        <ul>
+          <li>This value <b>MAY</b> contain zero or more [0..*] <b>translation</b><b> (CONF:4515-16749)</b> such that it
+          </li>
+          <ul>
+            <li><b>MAY</b> contain zero or one [0..1] <b>@code</b> (CodeSystem: <b>ICD-10-CM
+                2.16.840.1.113883.6.90</b><b> STATIC</b>)<b> (CONF:4515-16750)</b>.</li>
+            <ul>
+              <li>
+                <p>When the Problem is Social Determinant of Health Observation, the observation/value/translation
+                  SHOULD be an ICD10 code selected from ValueSet Social Determinant of Health Conditions <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.788/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1196.788</a> DYNAMIC
+                  (CONF:4515-32952).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-31147)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:4515-9059)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:4515-9060)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:4515-9069)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Age Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.31)</b><b> (CONF:4515-15590)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:4515-29951)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31531)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Prognosis Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.113)</b><b> (CONF:4515-29952)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-31063)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31532)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:4515-31064)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:4515-9063)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-9068)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Status<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.6)</b><b> (CONF:4515-15591)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When an Entry Reference template is contained in a Problem Template instance that is a Social Determinant of
+          Health problem, that Entry Reference <strong>MAY</strong> reference an Assessment Scale Observation elsewhere
+          in the document. That Assessment Scale <strong>MAY</strong> contain assessment scale observations that
+          represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or
+        more [0..*] <b>entryRelationship</b><b> (CONF:4515-32965)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-32968)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32966)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When an Assessment Scale Observation is contained in a Problem Template instance that is a Social Determinant
+          of Health problem, that Assessment scale <strong>MAY</strong> contain assessment scale observations that
+          represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or
+        more [0..*] <b>entryRelationship</b><b> (CONF:4515-32953)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-32955)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-32954)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-33012)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-33014)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Date of Diagnosis Act<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.502)</b><b> (CONF:4515-33013)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Observation%20(V4)_2.16.840.1.113883.10.20.22.4.4/Problem%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Problem Observation Example</a></li>
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Observation%20(V4)_2.16.840.1.113883.10.20.22.4.4/Social%20Determinant%20of%20Health%20Problem%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Social Deteriminant of Health Problem Observation Example</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Observation%20(V4)_2.16.840.1.113883.10.20.22.4.4/Problem%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Problem Observation Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Problem%20Observation%20(V4)_2.16.840.1.113883.10.20.22.4.4/Social%20Determinant%20of%20Health%20Problem%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Social Deteriminant of Health Problem Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a>
+      </li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.40.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.40.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,58 +52,168 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Encounter (V2) <small class="text-muted">[encounter, 2.16.840.1.113883.10.20.22.4.40, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.40.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Encounter (V2) <small class="text-muted">[encounter, 2.16.840.1.113883.10.20.22.4.40, release
+        2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.40.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a planned or ordered encounter. The type of encounter (e.g., comprehensive outpatient visit) is represented. Clinicians participating in the encounter and the location of the planned encounter may be captured. The priority that the patient and providers place on the encounter may be represented.</p></div>
+    <div id="description">
+      <p>This template represents a planned or ordered encounter. The type of encounter (e.g., comprehensive outpatient
+        visit) is represented. Clinicians participating in the encounter and the location of the planned encounter may
+        be captured. The priority that the patient and providers place on the encounter may be represented.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8564)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Planned moodCode (Act/Encounter/Procedure)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.23/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.23</a></b><b> STATIC</b> 2014-09-01<b> (CONF:1098-8565)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30437)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.40"</b><b> (CONF:1098-30438)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32553)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8567)</b>.</li>
-<li class="list-group-item"><p>Records the type of encounter ordered or recommended.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Encounter Planned<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.52/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.52</a></b><b> DYNAMIC</b><b> (CONF:1098-31032)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30439)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31880)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-30440)</b>.</li>
-<li class="list-group-item"><p>Performers represent clinicians who are responsible for assessing and treating the patient.<br></p> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-30442)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1098-31874)</b>.</li></ul></li>
-<li class="list-group-item"><p>The author in a planned encounter represents the clinician who is requesting or planning the encounter.<br></p> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32045)</b>.</li>
-<li class="list-group-item"><p>This location participation captures where the planned or ordered encounter may take place.<br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-30443)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:1098-31875)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Service Delivery Location<b> (identifier: 2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:1098-31876)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that a patient or a provider places on the encounter.<br></p> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-31033)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31034)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31035)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship captures the reason for the planned or ordered encounter<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31877)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31878)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-31879)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-8564)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Planned moodCode (Act/Encounter/Procedure)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.23/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.23</a></b><b> STATIC</b> 2014-09-01<b>
+          (CONF:1098-8565)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30437)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.40"</b><b>
+              (CONF:1098-30438)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32553)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8567)</b>.</li>
+      <li class="list-group-item">
+        <p>Records the type of encounter ordered or recommended.<br></p> <b>SHOULD</b> contain zero or one [0..1]
+        <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Encounter Planned<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.52/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.52</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-31032)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30439)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31880)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-30440)</b>.</li>
+      <li class="list-group-item">
+        <p>Performers represent clinicians who are responsible for assessing and treating the patient.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-30442)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1098-31874)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The author in a planned encounter represents the clinician who is requesting or planning the encounter.<br>
+        </p> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32045)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>This location participation captures where the planned or ordered encounter may take place.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-30443)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:1098-31875)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Service Delivery Location<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:1098-31876)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that a patient or a provider places on the
+          encounter.<br></p> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-31033)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31034)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31035)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship captures the reason for the planned or ordered encounter<br></p> <b>MAY</b>
+        contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31877)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31878)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-31879)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Encounter%20(V2)_2.16.840.1.113883.10.20.22.4.40/Planned%20Encounter%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Planned Encounter (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Encounter%20(V2)_2.16.840.1.113883.10.20.22.4.40/Planned%20Encounter%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Planned Encounter (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.41.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.41.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,88 +24,282 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Procedure (V3) <small class="text-muted">[procedure, 2.16.840.1.113883.10.20.22.4.41, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.41.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Procedure (V3) <small class="text-muted">[procedure, 2.16.840.1.113883.10.20.22.4.41, release
+        2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.41.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents planned alterations of the patient's physical condition. Examples of such procedures are tracheostomy, knee replacement, and craniectomy. The priority of the procedure to the patient and provider is communicated through Priority Preference. The effectiveTime indicates the time when the procedure is intended to take place and authorTime indicates when the documentation of the plan occurred. The Planned Procedure Template may also indicate the potential insurance coverage for the procedure.</p><p>Planned Procedure V3 Usage Note: Common practice in the industry has shown that Planned Procedure is the usually implemented CDA template for any type of intervention or procedure regardless of if the "immediate and primary outcome (post-condition) is the alteration of the physical condition of the patient", or not. As a result, it is recommended to use Planned Procedure when sending procedures also thought of as "interventions" such as "Home Environment Evaluation" or "Assessment of nutritional status".</p></div>
+    <div id="description">
+      <p>This template represents planned alterations of the patient's physical condition. Examples of such procedures
+        are tracheostomy, knee replacement, and craniectomy. The priority of the procedure to the patient and provider
+        is communicated through Priority Preference. The effectiveTime indicates the time when the procedure is intended
+        to take place and authorTime indicates when the documentation of the plan occurred. The Planned Procedure
+        Template may also indicate the potential insurance coverage for the procedure.</p>
+      <p>Planned Procedure V3 Usage Note: Common practice in the industry has shown that Planned Procedure is the
+        usually implemented CDA template for any type of intervention or procedure regardless of if the "immediate and
+        primary outcome (post-condition) is the alteration of the physical condition of the patient", or not. As a
+        result, it is recommended to use Planned Procedure when sending procedures also thought of as "interventions"
+        such as "Home Environment Evaluation" or "Assessment of nutritional status".</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.129.html">Planned Coverage</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.129.html">Planned Coverage</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PROC"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-8568)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Planned moodCode (Act/Encounter/Procedure)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.23/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.23</a></b><b> STATIC</b> 2011-09-30<b> (CONF:4515-8569)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-30444)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.41"</b><b> (CONF:4515-30445)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:4515-32554)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-8571)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-31976)</b>.<ul><li><p>The procedure/code in a planned procedure <strong>SHOULD</strong> be selected from LOINC (codeSystem <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) <em>OR</em> SNOMED CT (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be selected from CPT-4 (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-CPT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) <strong>OR</strong> ICD10 PCS (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-icd10PCS.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.4</a>) <strong>OR</strong> HCPCS (Code System: <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1247.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1247.9</a>) (CONF:4515-31977).</p></li></ul><ul><li><p>If the Planned Intervention Procedure is a Social Determinant of Health Planned Intervention Procedure, the procedure code <strong>SHOULD</strong> be selected from ValueSet Social Determinant of Health Service Request <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.790/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i>2.16.840.1.113762.1.4.1196.790</a><strong>DYNAMIC</strong> (CONF:4515-32993).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-30446)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:4515-31978)</b>.</li></ul></li>
-<li class="list-group-item"><p>The effectiveTime in a planned procedure represents the time that the procedure should occur.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:4515-30447)</b>.</li>
-<li class="list-group-item"><p>In a planned procedure the provider may suggest that a procedure should be performed using a particular method.<br />MethodCode <i>SHALL NOT</i> conflict with the method inherent in Procedure / code.<br></p> <b>MAY</b> contain zero or more [0..*] <b>methodCode</b><b> (CONF:4515-31980)</b>.</li>
-<li class="list-group-item"><p>The targetSiteCode is used to identify the part of the body of concern for the planned procedure.<br></p> <b>MAY</b> contain zero or more [0..*] <b>targetSiteCode</b>, which <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b> DYNAMIC</b><b> (CONF:4515-31981)</b>.</li>
-<li class="list-group-item"><p>The clinician who is expected to perform the procedure could be identified using procedure/performer. <br></p> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:4515-30449)</b>.</li>
-<li class="list-group-item"><p>The author in a planned procedure represents the clinician who is requesting or planning the procedure.<br></p> <b>SHOULD</b> contain zero or one [0..1]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-31979)</b>.</li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that a patient or a provider places on the procedure.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31079)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31080)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:4515-31081)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the indication for the procedure.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31982)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31983)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:4515-31984)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship captures any instructions associated with the planned procedure.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31985)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-31986)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:4515-31987)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:4515-31989)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the insurance coverage the patient may have for the procedure.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31990)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component<b> (CONF:4515-31991)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Coverage<b> (identifier: 2.16.840.1.113883.10.20.22.4.129)</b><b> (CONF:4515-31992)</b>.</li></ul></li>
-<li class="list-group-item"><p>When an Assessment Scale Observation is contained in a Procedure Template instance that is a Social Determinant of Health procedure, that Assessment scale <b>MAY</b> contain Assessment Scale observations that represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32994)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-32998)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-32995)</b>.</li></ul></li>
-<li class="list-group-item"><p>When an Entry Reference Template is contained in a Procedure Template instance that is a Social Determinant of Health procedure, that Entry Reference <b>MAY</b> refer to Assessment Scale Observation in the same document that represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32996)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason<b> (CONF:4515-32999)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32997)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PROC"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:4515-8568)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Planned moodCode (Act/Encounter/Procedure)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.23/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.23</a></b><b> STATIC</b> 2011-09-30<b>
+          (CONF:4515-8569)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-30444)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.41"</b><b>
+              (CONF:4515-30445)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:4515-32554)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-8571)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-31976)</b>.<ul>
+          <li>
+            <p>The procedure/code in a planned procedure <strong>SHOULD</strong> be selected from LOINC (codeSystem <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) <em>OR</em> SNOMED CT (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>), and <strong>MAY</strong> be
+              selected from CPT-4 (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-CPT.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.12</a>) <strong>OR</strong>
+              ICD10 PCS (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-icd10PCS.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.4</a>) <strong>OR</strong> HCPCS (Code
+              System: <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1247.9/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1247.9</a>)
+              (CONF:4515-31977).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>If the Planned Intervention Procedure is a Social Determinant of Health Planned Intervention Procedure,
+              the procedure code <strong>SHOULD</strong> be selected from ValueSet Social Determinant of Health Service
+              Request <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1196.790/expansion/Latest"
+                target="_blank"><i
+                  class="fas fa-external-link-alt"></i>2.16.840.1.113762.1.4.1196.790</a><strong>DYNAMIC</strong>
+              (CONF:4515-32993).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-30446)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:4515-31978)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime in a planned procedure represents the time that the procedure should occur.<br></p>
+        <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:4515-30447)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>In a planned procedure the provider may suggest that a procedure should be performed using a particular
+          method.<br />MethodCode <i>SHALL NOT</i> conflict with the method inherent in Procedure / code.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>methodCode</b><b> (CONF:4515-31980)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The targetSiteCode is used to identify the part of the body of concern for the planned procedure.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>targetSiteCode</b>, which <b>SHALL</b> be selected from ValueSet Body
+        Site Value Set<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b>
+          DYNAMIC</b><b> (CONF:4515-31981)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The clinician who is expected to perform the procedure could be identified using procedure/performer. <br>
+        </p> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:4515-30449)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The author in a planned procedure represents the clinician who is requesting or planning the procedure.<br>
+        </p> <b>SHOULD</b> contain zero or one [0..1] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-31979)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that a patient or a provider places on the
+          procedure.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31079)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31080)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:4515-31081)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the indication for the procedure.<br></p> <b>MAY</b> contain zero
+        or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31982)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31983)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:4515-31984)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship captures any instructions associated with the planned procedure.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31985)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-31986)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:4515-31987)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:4515-31989)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the insurance coverage the patient may have for the procedure.<br>
+        </p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-31990)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has component<b>
+              (CONF:4515-31991)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Coverage<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.129)</b><b> (CONF:4515-31992)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When an Assessment Scale Observation is contained in a Procedure Template instance that is a Social
+          Determinant of Health procedure, that Assessment scale <b>MAY</b> contain Assessment Scale observations that
+          represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b> contain zero or
+        more [0..*] <b>entryRelationship</b><b> (CONF:4515-32994)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-32998)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:4515-32995)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When an Entry Reference Template is contained in a Procedure Template instance that is a Social Determinant
+          of Health procedure, that Entry Reference <b>MAY</b> refer to Assessment Scale Observation in the same
+          document that represent LOINC question and answer pairs from SDOH screening instruments.<br></p> <b>MAY</b>
+        contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-32996)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason<b>
+              (CONF:4515-32999)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-32997)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Procedure%20(V3)_2.16.840.1.113883.10.20.22.4.41/Planned%20Procedure%20Example.xml"><i class="fab fa-github"></i>&nbsp;Planned Procedure Example</a></li>
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Procedure%20(V3)_2.16.840.1.113883.10.20.22.4.41/Social%20Determinant%20of%20Health%20Planned%20Procedure%20Example.xml"><i class="fab fa-github"></i>&nbsp;Social Determinant of Health Planned Procedure Example</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Procedure%20(V3)_2.16.840.1.113883.10.20.22.4.41/Planned%20Procedure%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Planned Procedure Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Procedure%20(V3)_2.16.840.1.113883.10.20.22.4.41/Social%20Determinant%20of%20Health%20Planned%20Procedure%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Social Determinant of Health Planned Procedure Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.42.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.42.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,67 +52,262 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Medication Activity (V2) <small class="text-muted">[substanceAdministration, 2.16.840.1.113883.10.20.22.4.42, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.42.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Medication Activity (V2) <small class="text-muted">[substanceAdministration,
+        2.16.840.1.113883.10.20.22.4.42, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.42.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents planned medication activities. The priority of the medication activity to the patient and provider is communicated through Priority Preference. The effectiveTime indicates the time when the medication activity is intended to take place. The authorTime indicates when the documentation of the plan occurred.</p></div>
+    <div id="description">
+      <p>This template represents planned medication activities. The priority of the medication activity to the patient
+        and provider is communicated through Priority Preference. The effectiveTime indicates the time when the
+        medication activity is intended to take place. The authorTime indicates when the documentation of the plan
+        occurred.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.25.html">Precondition for Substance Administration (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.25.html">Precondition for Substance Administration (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8572)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Planned moodCode (SubstanceAdministration/Supply)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.24/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.24</a></b><b> STATIC</b> 2011-09-30<b> (CONF:1098-8573)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30465)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.42"</b><b> (CONF:1098-30466)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32557)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8575)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-32087)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32088)</b>.</li></ul></li>
-<li class="list-group-item"><p>The effectiveTime in a planned medication activity represents the time that the medication activity should occur.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-30468)</b> such that it<br>Note: This effectiveTime represents either the medication duration (i.e., the time the medication should be started and stopped) or the timestamp when the single-administration should occur.<ul><li><b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:1098-32944)</b>.<br>Note: indicates a single-administration timestamp</li></ul><ul><li><b>SHOULD</b> contain zero or one [0..1] <b>low</b><b> (CONF:1098-32948)</b>.<br>Note: indicates when medication started</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-32949)</b>.<br>Note: indicates when medication stopped</li></ul><ul><li><p>This effectiveTime <strong>SHALL</strong> contain either a low or a @value but not both (CONF:1098-32947).</p></li></ul></li>
-<li class="list-group-item"><p>The effectiveTime in a planned medication activity represents the time that the medication activity should occur.<br></p> <b>SHOULD</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-32943)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@operator</b>=<b>"A"</b><b> (CONF:1098-32945)</b>.</li></ul><ul><li><p><strong>SHALL</strong> contain exactly one [1..1] @xsi:type="PIVL_TS" or "EIVL_TS" (CONF:1098-32946).</p></li></ul></li>
-<li class="list-group-item"><p>In a Planned Medication Activity, repeatNumber defines the number of allowed administrations. For example, a repeatNumber of "3" means that the substance can be administered up to 3 times. <br></p> <b>MAY</b> contain zero or one [0..1] <b>repeatNumber</b><b> (CONF:1098-32066)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>routeCode</b>, which <b>SHALL</b> be selected from ValueSet SPL Drug Route of Administration Terminology<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.7/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.7</a></b><b> DYNAMIC</b><b> (CONF:1098-32067)</b>.<ul><li>The routeCode, if present, <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which <b>SHALL</b> be selected from ValueSet Medication Route<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.12/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.12</a></b><b> DYNAMIC</b><b> (CONF:1098-32952)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>approachSiteCode</b>, which <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b> DYNAMIC</b><b> (CONF:1098-32078)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>doseQuantity</b><b> (CONF:1098-32068)</b>.<ul><li>The doseQuantity, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b> DYNAMIC</b><b> (CONF:1098-32133)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>rateQuantity</b><b> (CONF:1098-32079)</b>.<ul><li>The rateQuantity, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b> DYNAMIC</b><b> (CONF:1098-32134)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>maxDoseQuantity</b><b> (CONF:1098-32080)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>administrationUnitCode</b>, which <b>SHALL</b> be selected from ValueSet AdministrationUnitDoseForm<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.30/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.30</a></b><b> DYNAMIC</b><b> (CONF:1098-32081)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:1098-32082)</b>.<ul><li>This consumable <b>SHALL</b> contain exactly one [1..1]  Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-32083)</b>.</li></ul></li>
-<li class="list-group-item"><p>The clinician who is expected to perform the medication activity could be identified using substanceAdministration/performer. <br></p> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-30470)</b>.</li>
-<li class="list-group-item"><p>The author in a planned medication activity represents the clinician who is requesting or planning the medication activity.<br></p> <b>SHOULD</b> contain zero or one [0..1]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32046)</b>.</li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that a patient or a provider places on the planned medication activity.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31104)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31105)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31106)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the indication for the planned medication activity.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32069)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32070)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32071)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship captures any instructions associated with the planned medication activity.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32072)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32073)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32074)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>precondition</b><b> (CONF:1098-32084)</b>.<ul><li>The precondition, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRCN"</b> Precondition (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32085)</b>.</li></ul><ul><li>The precondition, if present, <b>SHALL</b> contain exactly one [1..1]  Precondition for Substance Administration (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.25)</b><b> (CONF:1098-32086)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-8572)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Planned moodCode (SubstanceAdministration/Supply)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.24/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.24</a></b><b> STATIC</b> 2011-09-30<b>
+          (CONF:1098-8573)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30465)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.42"</b><b>
+              (CONF:1098-30466)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32557)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8575)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-32087)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32088)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime in a planned medication activity represents the time that the medication activity should
+          occur.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-30468)</b> such that
+        it<br>Note: This effectiveTime represents either the medication duration (i.e., the time the medication should
+        be started and stopped) or the timestamp when the single-administration should occur.<ul>
+          <li><b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:1098-32944)</b>.<br>Note: indicates a
+            single-administration timestamp</li>
+        </ul>
+        <ul>
+          <li><b>SHOULD</b> contain zero or one [0..1] <b>low</b><b> (CONF:1098-32948)</b>.<br>Note: indicates when
+            medication started</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-32949)</b>.<br>Note: indicates when
+            medication stopped</li>
+        </ul>
+        <ul>
+          <li>
+            <p>This effectiveTime <strong>SHALL</strong> contain either a low or a @value but not both
+              (CONF:1098-32947).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime in a planned medication activity represents the time that the medication activity should
+          occur.<br></p> <b>SHOULD</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-32943)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@operator</b>=<b>"A"</b><b> (CONF:1098-32945)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p><strong>SHALL</strong> contain exactly one [1..1] @xsi:type="PIVL_TS" or "EIVL_TS" (CONF:1098-32946).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>In a Planned Medication Activity, repeatNumber defines the number of allowed administrations. For example, a
+          repeatNumber of "3" means that the substance can be administered up to 3 times. <br></p> <b>MAY</b> contain
+        zero or one [0..1] <b>repeatNumber</b><b> (CONF:1098-32066)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>routeCode</b>, which <b>SHALL</b> be
+        selected from ValueSet SPL Drug Route of Administration Terminology<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.7/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.7</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-32067)</b>.<ul>
+          <li>The routeCode, if present, <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which
+            <b>SHALL</b> be selected from ValueSet Medication Route<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.12/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.12</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32952)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>approachSiteCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Body Site Value Set<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-32078)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>doseQuantity</b><b> (CONF:1098-32068)</b>.
+        <ul>
+          <li>The doseQuantity, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be
+            selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32133)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>rateQuantity</b><b> (CONF:1098-32079)</b>.
+        <ul>
+          <li>The rateQuantity, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be
+            selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32134)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>maxDoseQuantity</b><b>
+          (CONF:1098-32080)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>administrationUnitCode</b>, which
+        <b>SHALL</b> be selected from ValueSet AdministrationUnitDoseForm<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.30/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.30</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-32081)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:1098-32082)</b>.
+        <ul>
+          <li>This consumable <b>SHALL</b> contain exactly one [1..1] Medication Information (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-32083)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The clinician who is expected to perform the medication activity could be identified using
+          substanceAdministration/performer. <br></p> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b>
+          (CONF:1098-30470)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The author in a planned medication activity represents the clinician who is requesting or planning the
+          medication activity.<br></p> <b>SHOULD</b> contain zero or one [0..1] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32046)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that a patient or a provider places on the planned
+          medication activity.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-31104)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31105)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31106)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the indication for the planned medication activity.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32069)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32070)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32071)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship captures any instructions associated with the planned medication
+          activity.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32072)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32073)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32074)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>precondition</b><b> (CONF:1098-32084)</b>.
+        <ul>
+          <li>The precondition, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRCN"</b>
+            Precondition (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32085)</b>.</li>
+        </ul>
+        <ul>
+          <li>The precondition, if present, <b>SHALL</b> contain exactly one [1..1] Precondition for Substance
+            Administration (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.25)</b><b> (CONF:1098-32086)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Medication%20Activity%20(V2)_2.16.840.1.113883.10.20.22.4.42/Planned%20Medication%20Activity%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Planned Medication Activity (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Medication%20Activity%20(V2)_2.16.840.1.113883.10.20.22.4.42/Planned%20Medication%20Activity%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Planned Medication Activity (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.43.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.43.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,64 +52,235 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Supply (V2) <small class="text-muted">[supply, 2.16.840.1.113883.10.20.22.4.43, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.43.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Supply (V2) <small class="text-muted">[supply, 2.16.840.1.113883.10.20.22.4.43, release
+        2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.43.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents both medicinal and non-medicinal supplies ordered, requested, or intended for the patient (e.g., medication prescription, order for wheelchair). The importance of the supply order or request to the patient and provider may be indicated in the Priority Preference.The effective time indicates the time when the supply is intended to take place and author time indicates when the documentation of the plan occurred. The Planned Supply template may also indicate the potential insurance coverage for the procedure.Depending on the type of supply, the product or participant will be either a Medication Information product (medication), an Immunization Medication Information product (immunization), or a Product Instance participant (device/equipment).</p></div>
+    <div id="description">
+      <p>This template represents both medicinal and non-medicinal supplies ordered, requested, or intended for the
+        patient (e.g., medication prescription, order for wheelchair). The importance of the supply order or request to
+        the patient and provider may be indicated in the Priority Preference.The effective time indicates the time when
+        the supply is intended to take place and author time indicates when the documentation of the plan occurred. The
+        Planned Supply template may also indicate the potential insurance coverage for the procedure.Depending on the
+        type of supply, the product or participant will be either a Medication Information product (medication), an
+        Immunization Medication Information product (immunization), or a Product Instance participant
+        (device/equipment).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.129.html">Planned Coverage</a><br><a href="2.16.840.1.113883.10.20.22.4.37.html">Product Instance</a><br><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.23.html">Medication Information (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.129.html">Planned Coverage</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.37.html">Product Instance</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SPLY"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8577)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Planned moodCode (SubstanceAdministration/Supply)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.24/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.24</a></b><b> STATIC</b> 2011-09-30<b> (CONF:1098-8578)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30463)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.43"</b><b> (CONF:1098-30464)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32556)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8580)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30458)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32047)</b>.</li></ul></li>
-<li class="list-group-item"><p>The effectiveTime in a planned supply represents the time that the supply should occur.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-30459)</b>.</li>
-<li class="list-group-item"><p>In a Planned Supply, repeatNumber indicates the number of times the supply event can occur. For example, if a medication is filled at a pharmacy and the prescription may be refilled 3 more times, the supply RepeatNumber equals 4.<br></p> <b>MAY</b> contain zero or one [0..1] <b>repeatNumber</b><b> (CONF:1098-32063)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>quantity</b><b> (CONF:1098-32064)</b>.</li>
-<li class="list-group-item"><p>This product represents medication that is ordered, requested or intended for the patient.<br></p> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-32049)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-32050)</b>.</li></ul><ul><li><p>If the product is Medication Information (V2) (2.16.840.1.113883.10.20.22.4.23.2) then the product <strong>SHALL NOT</strong> be Immunization Medication Information (2.16.840.1.113883.10.20.22.4.54.2) and the participant <strong>SHALL NOT</strong> be Product Instance (CONF:1098-32092).</p></li></ul></li>
-<li class="list-group-item"><p>This product represents immunization medication that is ordered, requested or intended for the patient.<br></p> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-32051)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Immunization Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1098-32052)</b>.</li></ul><ul><li><p>If the product is Medication Information (V2) (2.16.840.1.113883.10.20.22.4.23.2) then the product <strong>SHALL NOT</strong> be Immunization Medication Information (2.16.840.1.113883.10.20.22.4.54.2) and the participant <strong>SHALL NOT</strong> be Product Instance (CONF:1098-32093).</p></li></ul></li>
-<li class="list-group-item"><p>A product is recommended or even required under certain implementations. This IG makes product as recommended (SHOULD).<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-32325)</b>.</li>
-<li class="list-group-item"><p>The clinician who is expected to perform the supply could be identified using supply/performer. <br></p> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-32048)</b>.</li>
-<li class="list-group-item"><p>The author in a supply represents the clinician who is requesting or planning the supply.<br></p> <b>SHOULD</b> contain zero or one [0..1]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31129)</b>.</li>
-<li class="list-group-item"><p>This participant represents a device that is ordered, requested or intended for the patient.<br></p> <b>MAY</b> contain zero or one [0..1] <b>participant</b><b> (CONF:1098-32094)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Product Instance<b> (identifier: 2.16.840.1.113883.10.20.22.4.37)</b><b> (CONF:1098-32095)</b>.</li></ul><ul><li><p>If the participant is Product Instance then the product <strong>SHALL NOT</strong> be Medication Information (V2) (2.16.840.1.113883.10.20.22.4.23.2) and the product <strong>SHALL NOT</strong> be Immunization Medication Information (V2) (2.16.840.1.113883.10.20.22.4.54.2) (CONF:1098-32096).</p></li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that a patient or a provider places on the supply.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31110)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31111)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31112)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the indication for the supply.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32054)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32055)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32056)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship captures any instructions associated with the planned supply.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32057)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32058)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32059)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the insurance coverage the patient may have for the supply.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32060)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32061)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Coverage<b> (identifier: 2.16.840.1.113883.10.20.22.4.129)</b><b> (CONF:1098-32062)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SPLY"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-8577)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Planned moodCode (SubstanceAdministration/Supply)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.24/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.24</a></b><b> STATIC</b> 2011-09-30<b>
+          (CONF:1098-8578)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30463)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.43"</b><b>
+              (CONF:1098-30464)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32556)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8580)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30458)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32047)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime in a planned supply represents the time that the supply should occur.<br></p> <b>SHOULD</b>
+        contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-30459)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>In a Planned Supply, repeatNumber indicates the number of times the supply event can occur. For example, if a
+          medication is filled at a pharmacy and the prescription may be refilled 3 more times, the supply RepeatNumber
+          equals 4.<br></p> <b>MAY</b> contain zero or one [0..1] <b>repeatNumber</b><b> (CONF:1098-32063)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>quantity</b><b> (CONF:1098-32064)</b>.</li>
+      <li class="list-group-item">
+        <p>This product represents medication that is ordered, requested or intended for the patient.<br></p> <b>MAY</b>
+        contain zero or one [0..1] <b>product</b><b> (CONF:1098-32049)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Information (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.23)</b><b> (CONF:1098-32050)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>If the product is Medication Information (V2) (2.16.840.1.113883.10.20.22.4.23.2) then the product
+              <strong>SHALL NOT</strong> be Immunization Medication Information (2.16.840.1.113883.10.20.22.4.54.2) and
+              the participant <strong>SHALL NOT</strong> be Product Instance (CONF:1098-32092).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This product represents immunization medication that is ordered, requested or intended for the patient.<br>
+        </p> <b>MAY</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-32051)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Immunization Medication Information (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1098-32052)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>If the product is Medication Information (V2) (2.16.840.1.113883.10.20.22.4.23.2) then the product
+              <strong>SHALL NOT</strong> be Immunization Medication Information (2.16.840.1.113883.10.20.22.4.54.2) and
+              the participant <strong>SHALL NOT</strong> be Product Instance (CONF:1098-32093).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>A product is recommended or even required under certain implementations. This IG makes product as recommended
+          (SHOULD).<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>product</b><b> (CONF:1098-32325)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The clinician who is expected to perform the supply could be identified using supply/performer. <br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-32048)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The author in a supply represents the clinician who is requesting or planning the supply.<br></p>
+        <b>SHOULD</b> contain zero or one [0..1] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31129)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>This participant represents a device that is ordered, requested or intended for the patient.<br></p>
+        <b>MAY</b> contain zero or one [0..1] <b>participant</b><b> (CONF:1098-32094)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Product Instance<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.37)</b><b> (CONF:1098-32095)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>If the participant is Product Instance then the product <strong>SHALL NOT</strong> be Medication
+              Information (V2) (2.16.840.1.113883.10.20.22.4.23.2) and the product <strong>SHALL NOT</strong> be
+              Immunization Medication Information (V2) (2.16.840.1.113883.10.20.22.4.54.2) (CONF:1098-32096).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that a patient or a provider places on the
+          supply.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31110)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31111)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31112)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the indication for the supply.<br></p> <b>MAY</b> contain zero or
+        more [0..*] <b>entryRelationship</b><b> (CONF:1098-32054)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32055)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32056)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship captures any instructions associated with the planned supply.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32057)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32058)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32059)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the insurance coverage the patient may have for the supply.<br>
+        </p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32060)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32061)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Coverage<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.129)</b><b> (CONF:1098-32062)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Supply%20(V2)_2.16.840.1.113883.10.20.22.4.43/Planned%20Supply%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Planned Supply (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Supply%20(V2)_2.16.840.1.113883.10.20.22.4.43/Planned%20Supply%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Planned Supply (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.44.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.44.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,62 +52,196 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Planned Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.44, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.44.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Planned Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.44,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.44.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents planned observations that result in new information about the patient which cannot be classified as a procedure according to the HL7 RIM, i.e., procedures alter the patient's body. Examples of these observations are laboratory tests, diagnostic imaging tests, EEGs, and EKGs.</p><p>The importance of the planned observation to the patient and provider is communicated through Priority Preference. The effectiveTime indicates the time when the observation is intended to take place and authorTime indicates when the documentation of the plan occurred.The Planned Observation template may also indicate the potential insurance coverage for the observation.</p></div>
+    <div id="description">
+      <p>This template represents planned observations that result in new information about the patient which cannot be
+        classified as a procedure according to the HL7 RIM, i.e., procedures alter the patient's body. Examples of these
+        observations are laboratory tests, diagnostic imaging tests, EEGs, and EKGs.</p>
+      <p>The importance of the planned observation to the patient and provider is communicated through Priority
+        Preference. The effectiveTime indicates the time when the observation is intended to take place and authorTime
+        indicates when the documentation of the plan occurred.The Planned Observation template may also indicate the
+        potential insurance coverage for the observation.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.129.html">Planned Coverage</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.10.html">Plan of Treatment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.130.html">Nutrition Recommendation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.121.html">Goal Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.143.html">Priority Preference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.129.html">Planned Coverage</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8581)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet Planned moodCode (Observation)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.25/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.25</a></b><b> STATIC</b> 2011-09-30<b> (CONF:1098-8582)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30451)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.44"</b><b> (CONF:1098-30452)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32555)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8584)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> (CONF:1098-31030)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30453)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32032)</b>.</li></ul></li>
-<li class="list-group-item"><p>The effectiveTime in a planned observation represents the time that the observation should occur.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-30454)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>value</b><b> (CONF:1098-31031)</b>.</li>
-<li class="list-group-item"><p>In a planned observation the provider may suggest that an observation should be performed using a particular method.<br></p> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1098-32043)</b>.</li>
-<li class="list-group-item"><p>The targetSiteCode is used to identify the part of the body of concern for the planned observation.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>targetSiteCode</b>, which <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b> DYNAMIC</b><b> (CONF:1098-32044)</b>.</li>
-<li class="list-group-item"><p>The clinician who is expected to perform the observation could be identified using procedure/performer. <br></p> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-30456)</b>.</li>
-<li class="list-group-item"><p>The author in a planned observation represents the clinician who is requesting or planning the observation.<br></p> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32033)</b>.</li>
-<li class="list-group-item"><p>The following entryRelationship represents the priority that a patient or a provider places on the observation.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31073)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-31074)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Priority Preference<b> (identifier: 2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31075)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the indication for the observation.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32034)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32035)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32036)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship captures any instructions associated with the planned observation.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32037)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32038)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32039)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship represents the insurance coverage the patient may have for the observation.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32040)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32041)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Planned Coverage<b> (identifier: 2.16.840.1.113883.10.20.22.4.129)</b><b> (CONF:1098-32042)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-8581)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet Planned moodCode (Observation)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.25/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.25</a></b><b> STATIC</b> 2011-09-30<b>
+          (CONF:1098-8582)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30451)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.44"</b><b>
+              (CONF:1098-30452)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32555)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8584)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> (CONF:1098-31030)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-30453)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"active"</b> Active (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-32032)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime in a planned observation represents the time that the observation should occur.<br></p>
+        <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-30454)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>value</b><b> (CONF:1098-31031)</b>.</li>
+      <li class="list-group-item">
+        <p>In a planned observation the provider may suggest that an observation should be performed using a particular
+          method.<br></p> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1098-32043)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The targetSiteCode is used to identify the part of the body of concern for the planned observation.<br></p>
+        <b>SHOULD</b> contain zero or more [0..*] <b>targetSiteCode</b>, which <b>SHALL</b> be selected from ValueSet
+        Body Site Value Set<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-32044)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The clinician who is expected to perform the observation could be identified using procedure/performer. <br>
+        </p> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1098-30456)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The author in a planned observation represents the clinician who is requesting or planning the
+          observation.<br></p> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-32033)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the priority that a patient or a provider places on the
+          observation.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-31073)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-31074)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Priority Preference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.143)</b><b> (CONF:1098-31075)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the indication for the observation.<br></p> <b>MAY</b> contain
+        zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32034)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32035)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1098-32036)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship captures any instructions associated with the planned observation.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32037)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32038)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-32039)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship represents the insurance coverage the patient may have for the
+          observation.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-32040)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32041)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Planned Coverage<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.129)</b><b> (CONF:1098-32042)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.44/Planned%20Observation%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Planned Observation (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Planned%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.44/Planned%20Observation%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Planned Observation (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i> Plan of Treatment</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Plan%20of%20Treatment"><i class="fas fa-external-link-alt"></i>
+          Plan of Treatment</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.45.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.45.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,169 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Family History Organizer (V3) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.45, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.45.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Family History Organizer (V3) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.45,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.45.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Family History Organizer associates a set of observations with a family member. For example, the Family History Organizer can group a set of observations about the patient's father.</p></div>
+    <div id="description">
+      <p>The Family History Organizer associates a set of observations with a family member. For example, the Family
+        History Organizer can group a set of observations about the patient's father.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.46.html">Family History Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.15.html">Family History Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.46.html">Family History Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> Cluster (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-8600)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-8601)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8604)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.45"</b><b> (CONF:1198-10497)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32606)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-32485)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8602)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19099)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>subject</b><b> (CONF:1198-8609)</b>.<ul><li>This subject <b>SHALL</b> contain exactly one [1..1] <b>relatedSubject</b><b> (CONF:1198-15244)</b>.</li><ul><li>This relatedSubject <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PRS"</b> Person (CodeSystem: <b>HL7EntityClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b><b> STATIC</b>)<b> (CONF:1198-15245)</b>.</li></ul><ul><li>This relatedSubject <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Family Member Value<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.19579/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.19579</a></b><b> DYNAMIC</b><b> (CONF:1198-15246)</b>.</li></ul><ul><li>This relatedSubject <b>SHOULD</b> contain zero or one [0..1] <b>subject</b><b> (CONF:1198-15248)</b>.</li><ul><li>The subject, if present, <b>SHALL</b> contain exactly one [1..1] <b>administrativeGenderCode</b>, which <b>SHALL</b> be selected from ValueSet Administrative Gender (HL7 V3)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.1</a></b><b> DYNAMIC</b><b> (CONF:1198-15974)</b>.</li></ul><ul><li>The subject, if present, <b>SHOULD</b> contain zero or one [0..1] <b>birthTime</b><b> (CONF:1198-15976)</b>.</li></ul><ul><li><p>The subject <strong>SHOULD</strong> contain zero or more [0..*] sdtc:id. The prefix sdtc: <strong>SHALL</strong> be bound to the namespace urn:hl7-org:sdtc. The use of the namespace provides a necessary extension to CDA R2 for the use of the id element (CONF:1198-15249).</p></li></ul><ul><li><p>The subject <strong>MAY</strong> contain zero or one [0..1] <em>sdtc:deceasedInd</em>. The prefix sdtc: <strong>SHALL</strong> be bound to the namespace urn:hl7-org:sdtc. The use of the namespace provides a necessary extension to CDA R2 for the use of the deceasedInd element (CONF:1198-15981).</p></li></ul><ul><li><p>The subject <strong>MAY</strong> contain zero or one [0..1] <em>sdtc:deceasedTime</em>. The prefix sdtc: <strong>SHALL</strong> be bound to the namespace urn:hl7-org:sdtc. The use of the namespace provides a necessary extension to CDA R2 for the use of the deceasedTime element (CONF:1198-15982).</p></li></ul><ul><li><p>The age of a relative at the time of a family history observation <strong>SHOULD</strong> be inferred by comparing RelatedSubject/subject/birthTime with Observation/effectiveTime (CONF:1198-15983).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-32428)</b>.<ul><li>Such components <b>SHALL</b> contain exactly one [1..1]  Family History Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.46)</b><b> (CONF:1198-32429)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> Cluster
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-8600)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-8601)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8604)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.45"</b><b>
+              (CONF:1198-10497)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32606)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-32485)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8602)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19099)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>subject</b><b> (CONF:1198-8609)</b>.<ul>
+          <li>This subject <b>SHALL</b> contain exactly one [1..1] <b>relatedSubject</b><b> (CONF:1198-15244)</b>.</li>
+          <ul>
+            <li>This relatedSubject <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PRS"</b> Person
+              (CodeSystem: <b>HL7EntityClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b><b>
+                STATIC</b>)<b> (CONF:1198-15245)</b>.</li>
+          </ul>
+          <ul>
+            <li>This relatedSubject <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+              from ValueSet Family Member Value<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.19579/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.19579</a></b><b>
+                DYNAMIC</b><b> (CONF:1198-15246)</b>.</li>
+          </ul>
+          <ul>
+            <li>This relatedSubject <b>SHOULD</b> contain zero or one [0..1] <b>subject</b><b> (CONF:1198-15248)</b>.
+            </li>
+            <ul>
+              <li>The subject, if present, <b>SHALL</b> contain exactly one [1..1] <b>administrativeGenderCode</b>,
+                which <b>SHALL</b> be selected from ValueSet Administrative Gender (HL7 V3)<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.1/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.1</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-15974)</b>.</li>
+            </ul>
+            <ul>
+              <li>The subject, if present, <b>SHOULD</b> contain zero or one [0..1] <b>birthTime</b><b>
+                  (CONF:1198-15976)</b>.</li>
+            </ul>
+            <ul>
+              <li>
+                <p>The subject <strong>SHOULD</strong> contain zero or more [0..*] sdtc:id. The prefix sdtc:
+                  <strong>SHALL</strong> be bound to the namespace urn:hl7-org:sdtc. The use of the namespace provides a
+                  necessary extension to CDA R2 for the use of the id element (CONF:1198-15249).</p>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <p>The subject <strong>MAY</strong> contain zero or one [0..1] <em>sdtc:deceasedInd</em>. The prefix
+                  sdtc: <strong>SHALL</strong> be bound to the namespace urn:hl7-org:sdtc. The use of the namespace
+                  provides a necessary extension to CDA R2 for the use of the deceasedInd element (CONF:1198-15981).</p>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <p>The subject <strong>MAY</strong> contain zero or one [0..1] <em>sdtc:deceasedTime</em>. The prefix
+                  sdtc: <strong>SHALL</strong> be bound to the namespace urn:hl7-org:sdtc. The use of the namespace
+                  provides a necessary extension to CDA R2 for the use of the deceasedTime element (CONF:1198-15982).
+                </p>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <p>The age of a relative at the time of a family history observation <strong>SHOULD</strong> be inferred
+                  by comparing RelatedSubject/subject/birthTime with Observation/effectiveTime (CONF:1198-15983).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-32428)</b>.
+        <ul>
+          <li>Such components <b>SHALL</b> contain exactly one [1..1] Family History Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.46)</b><b> (CONF:1198-32429)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Family%20History%20Organizer%20(V3)_2.16.840.1.113883.10.20.22.4.45/Family%20History%20Organizer%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Family History Organizer (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Family%20History%20Organizer%20(V3)_2.16.840.1.113883.10.20.22.4.45/Family%20History%20Organizer%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Family History Organizer (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Family%20History"><i class="fas fa-external-link-alt"></i> Family History</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Family%20History"><i class="fas fa-external-link-alt"></i> Family
+          History</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.46.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.46.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,152 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Family History Observation (V3) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.46, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.46.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Family History Observation (V3) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.46, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.46.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>Family History Observations related to a particular family member are contained within a Family History Organizer. The effectiveTime in the Family History Observation is the biologically or clinically relevant time of the observation. The biologically or clinically relevant time is the time at which the observation holds (is effective) for the family member (the subject of the observation).</p></div>
+    <div id="description">
+      <p>Family History Observations related to a particular family member are contained within a Family History
+        Organizer. The effectiveTime in the Family History Observation is the biologically or clinically relevant time
+        of the observation. The biologically or clinically relevant time is the time at which the observation holds (is
+        effective) for the family member (the subject of the observation).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.45.html">Family History Organizer (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.31.html">Age Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.47.html">Family History Death Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.45.html">Family History Organizer (V3)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.31.html">Age Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.47.html">Family History Death Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-8586)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-8587)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8599)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.46"</b><b> (CONF:1198-10496)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32605)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8592)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Problem Type (SNOMEDCT)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.2/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.2</a></b><b> DYNAMIC</b><b> (CONF:1198-32427)</b>.<ul><li>This code <b>SHALL</b> contain at least one [1..*] <b>translation</b>, which <b>SHOULD</b> be selected from ValueSet Problem Type (LOINC)<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.28/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.28</a></b><b> DYNAMIC</b><b> (CONF:1198-32847)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8590)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19098)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1198-8593)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Problem<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b> DYNAMIC</b><b> (CONF:1198-8591)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1198-8675)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Subject (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8676)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1198-8677)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Age Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.31)</b><b> (CONF:1198-15526)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1198-8678)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CAUS"</b> Causal or Contributory (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8679)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Family History Death Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.47)</b><b> (CONF:1198-15527)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-8586)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-8587)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8599)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.46"</b><b>
+              (CONF:1198-10496)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32605)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8592)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet Problem Type (SNOMEDCT)<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.2/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.2</a></b><b>
+          DYNAMIC</b><b> (CONF:1198-32427)</b>.<ul>
+          <li>This code <b>SHALL</b> contain at least one [1..*] <b>translation</b>, which <b>SHOULD</b> be selected
+            from ValueSet Problem Type (LOINC)<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.28/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.28</a></b><b>
+              DYNAMIC</b><b> (CONF:1198-32847)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8590)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19098)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1198-8593)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Problem<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b>
+          DYNAMIC</b><b> (CONF:1198-8591)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1198-8675)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Subject (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1198-8676)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1198-8677)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Age Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.31)</b><b> (CONF:1198-15526)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1198-8678)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CAUS"</b> Causal or Contributory (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1198-8679)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Family History Death Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.47)</b><b> (CONF:1198-15527)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Family%20History%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.46/Family%20History%20Observation%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Family History Observation (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Family%20History%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.46/Family%20History%20Observation%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Family History Observation (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Family%20History"><i class="fas fa-external-link-alt"></i> Family History</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Family%20History"><i class="fas fa-external-link-alt"></i> Family
+          History</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.47.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.47.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,112 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Family History Death Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.47, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.47.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Family History Death Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.47, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.47.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement records whether the family member is deceased.</p></div>
+    <div id="description">
+      <p>This clinical statement records whether the family member is deceased.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.46.html">Family History Observation (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.46.html">Family History Observation (V3)</a><br>
+          </td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-8621)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-8622)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8623)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.47"</b><b> (CONF:81-10495)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19141)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b> (CONF:81-19142)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:81-26504)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-8625)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:81-19097)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b> (CONF:81-8626)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"419099009"</b> Dead (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:81-26470)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-8621)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-8622)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8623)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.47"</b><b>
+              (CONF:81-10495)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19141)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b>
+              (CONF:81-19142)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:81-26504)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-8625)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:81-19097)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b>
+          (CONF:81-8626)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"419099009"</b> Dead (CodeSystem:
+            <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:81-26470)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Family%20History%20Death%20Observation_2.16.840.1.113883.10.20.22.4.47/Family%20History%20Death%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Family History Death Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Family%20History%20Death%20Observation_2.16.840.1.113883.10.20.22.4.47/Family%20History%20Death%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Family History Death Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Family%20History"><i class="fas fa-external-link-alt"></i> Family History</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Family%20History"><i class="fas fa-external-link-alt"></i> Family
+          History</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.48.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.48.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,60 +52,284 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Advance Directive Observation (V3) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.48, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.48.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Advance Directive Observation (V3) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.48, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.48.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement represents Advance Directive Observation findings (e.g., 'resuscitation status is Full Code') rather than orders. It should not be considered a legal document or a substitute for the actual Advance Directive document. The related legal documents are referenced using the reference/externalReference element.The Advance Directive Observation describes the patient's directives, including but not limited to:'	Medications'	Transfer of Care to Hospital'	Treatment'	Procedures'	Intubation and Ventilation'	Diagnostic Tests'	Tests</p><p>The observation/value element contains the detailed patient directive which may be coded or text. For example, a category directive may be antibiotics, and the details would be intravenous antibiotics only.</p></div>
+    <div id="description">
+      <p>This clinical statement represents Advance Directive Observation findings (e.g., 'resuscitation status is Full
+        Code') rather than orders. It should not be considered a legal document or a substitute for the actual Advance
+        Directive document. The related legal documents are referenced using the reference/externalReference element.The
+        Advance Directive Observation describes the patient's directives, including but not limited to:' Medications'
+        Transfer of Care to Hospital' Treatment' Procedures' Intubation and Ventilation' Diagnostic Tests' Tests</p>
+      <p>The observation/value element contains the detailed patient directive which may be coded or text. For example,
+        a category directive may be antibiotics, and the details would be intravenous antibiotics only.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.108.html">Advance Directive Organizer (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.21.1.html">Advance Directives Section (entries required) (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address (AD.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.108.html">Advance Directive Organizer
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.21.html">Advance Directives Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.21.1.html">Advance Directives Section (entries required) (V3)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name
+              (PN.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address
+              (AD.US.FIELDED)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-8648)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-8649)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8655)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.48"</b><b> (CONF:1198-10485)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32496)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8654)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Advance Directive Type Code<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2</a></b><b> DYNAMIC</b><b> (CONF:1198-8651)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32842)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75320-2"</b> Advance directive<b> (CONF:1198-32843)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32844)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8652)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19082)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-8656)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-28719)</b>.</li></ul><ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1198-15521)</b>.</li><ul><li><p>If the Advance Directive does not have a specified ending time, the <high> element <strong>SHALL</strong> have the nullFlavor attribute set to <em>NA</em> (CONF:1198-32449).</high></p></li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1198-30804)</b> such that it<ul><li><p>If type CD, then value will be SNOMED-CT 2.16.840.1.113883.6.96 (CONF:1198-32493).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-32406)</b>.</li>
-<li class="list-group-item"><p>The participant "VRF" represents the clinician(s) who verified the patient advance directive observation. <br></p> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8662)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"VRF"</b> Verifier (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8663)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8664)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.1.58"</b><b> (CONF:1198-10486)</b>.</li></ul></ul><ul><li><b>SHOULD</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-8665)</b>.</li><ul><li><p>The data type of Observation/participant/time in a verification <strong>SHALL</strong> be <em>TS</em> (time stamp) (CONF:1198-8666).</p></li></ul></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1198-8825)</b>.</li><ul><li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1198-28446)</b>.</li></ul><ul><li>This participantRole <b>MAY</b> contain zero or more [0..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-28451)</b>.</li></ul><ul><li>This participantRole <b>MAY</b> contain zero or one [0..1] <b>playingEntity</b><b> (CONF:1198-28428)</b>.</li><ul><li>The playingEntity, if present, <b>MAY</b> contain zero or more [0..*]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-28454)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>This custodian (CST) participant identifies a legal representative for the patient's advance directive. Examples of such  individuals are called health care agents, substitute decision makers and/or health care proxies.  If there is more than one  legal representative, a qualifier may be used to designate the  legal representative as primary or secondary.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8667)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CST"</b> Custodian (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8668)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1198-8669)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"AGNT"</b> Agent (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b> (CONF:1198-8670)</b>.</li></ul><ul><li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b> DYNAMIC</b><b> (CONF:1198-28440)</b>.</li></ul><ul><li>This participantRole <b>SHOULD</b> contain zero or one [0..1]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-8671)</b>.</li></ul><ul><li>This participantRole <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1198-8672)</b>.</li></ul><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b> (CONF:1198-8824)</b>.</li><ul><li>This playingEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Agent Qualifier<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.51/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.51</a></b><b> DYNAMIC</b><b> (CONF:1198-28444)</b>.</li></ul><ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:1198-8673)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain at least one [1..*] <b>reference</b><b> (CONF:1198-8692)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8694)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>externalDocument</b><b> (CONF:1198-8693)</b>.</li><ul><li>This externalDocument <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8695)</b>.</li></ul><ul><li>This externalDocument <b>MAY</b> contain zero or one [0..1] <b>text</b><b> (CONF:1198-8696)</b>.</li><ul><li>The text, if present, <b>MAY</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1198-8697)</b>.</li><ul><li><p>The URL of a referenced advance directive document <strong>MAY</strong> be present, and <strong>SHALL</strong> be represented in Observation/reference/ExternalDocument/text/reference (CONF:1198-8698).</p></li></ul><ul><li><p>If a URL is referenced, then it <strong>SHOULD</strong> have a corresponding linkHTML element in narrative block (CONF:1198-8699).</p></li></ul></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-8648)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-8649)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8655)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.48"</b><b>
+              (CONF:1198-10485)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32496)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8654)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet Advance Directive Type Code<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.2/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.2</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-8651)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32842)</b> such that it
+          </li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75320-2"</b> Advance directive<b>
+                (CONF:1198-32843)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem:
+              <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32844)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8652)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19082)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-8656)</b>.
+        <ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-28719)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>high</b><b> (CONF:1198-15521)</b>.</li>
+          <ul>
+            <li>
+              <p>If the Advance Directive does not have a specified ending time, the <high> element
+                  <strong>SHALL</strong> have the nullFlavor attribute set to <em>NA</em> (CONF:1198-32449).</high>
+              </p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1198-30804)</b> such
+        that it<ul>
+          <li>
+            <p>If type CD, then value will be SNOMED-CT 2.16.840.1.113883.6.96 (CONF:1198-32493).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-32406)</b>.</li>
+      <li class="list-group-item">
+        <p>The participant "VRF" represents the clinician(s) who verified the patient advance directive observation.
+          <br></p> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8662)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"VRF"</b> Verifier (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1198-8663)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8664)</b> such that it</li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.1.58"</b><b>
+                (CONF:1198-10486)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>SHOULD</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-8665)</b>.</li>
+          <ul>
+            <li>
+              <p>The data type of Observation/participant/time in a verification <strong>SHALL</strong> be <em>TS</em>
+                (time stamp) (CONF:1198-8666).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1198-8825)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be
+              selected from ValueSet Healthcare Provider Taxonomy<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b>
+                DYNAMIC</b><b> (CONF:1198-28446)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>MAY</b> contain zero or more [0..*] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-28451)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>MAY</b> contain zero or one [0..1] <b>playingEntity</b><b>
+                (CONF:1198-28428)</b>.</li>
+            <ul>
+              <li>The playingEntity, if present, <b>MAY</b> contain zero or more [0..*] US Realm Person Name
+                (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1198-28454)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This custodian (CST) participant identifies a legal representative for the patient's advance directive.
+          Examples of such individuals are called health care agents, substitute decision makers and/or health care
+          proxies. If there is more than one legal representative, a qualifier may be used to designate the legal
+          representative as primary or secondary.<br></p> <b>SHOULD</b> contain zero or more [0..*]
+        <b>participant</b><b> (CONF:1198-8667)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CST"</b> Custodian (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1198-8668)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1198-8669)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"AGNT"</b> Agent
+              (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b>
+                STATIC</b>)<b> (CONF:1198-8670)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be
+              selected from ValueSet Personal And Legal Relationship Role Type<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b>
+                DYNAMIC</b><b> (CONF:1198-28440)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or one [0..1] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-8671)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1198-8672)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b>
+                (CONF:1198-8824)</b>.</li>
+            <ul>
+              <li>This playingEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be
+                selected from ValueSet Healthcare Agent Qualifier<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.51/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.51</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-28444)</b>.</li>
+            </ul>
+            <ul>
+              <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:1198-8673)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain at least one [1..*] <b>reference</b><b> (CONF:1198-8692)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8694)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>externalDocument</b><b> (CONF:1198-8693)</b>.</li>
+          <ul>
+            <li>This externalDocument <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8695)</b>.</li>
+          </ul>
+          <ul>
+            <li>This externalDocument <b>MAY</b> contain zero or one [0..1] <b>text</b><b> (CONF:1198-8696)</b>.</li>
+            <ul>
+              <li>The text, if present, <b>MAY</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1198-8697)</b>.
+              </li>
+              <ul>
+                <li>
+                  <p>The URL of a referenced advance directive document <strong>MAY</strong> be present, and
+                    <strong>SHALL</strong> be represented in Observation/reference/ExternalDocument/text/reference
+                    (CONF:1198-8698).</p>
+                </li>
+              </ul>
+              <ul>
+                <li>
+                  <p>If a URL is referenced, then it <strong>SHOULD</strong> have a corresponding linkHTML element in
+                    narrative block (CONF:1198-8699).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Advance%20Directive%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.48/Advance%20Directive%20Observation%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Advance Directive Observation (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Advance%20Directive%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.48/Advance%20Directive%20Observation%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Advance Directive Observation (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.49.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.49.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,188 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Encounter Activity (V3) <small class="text-muted">[encounter, 2.16.840.1.113883.10.20.22.4.49, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.49.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Encounter Activity (V3) <small class="text-muted">[encounter, 2.16.840.1.113883.10.20.22.4.49,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.49.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement describes an interaction between a patient and clinician. Interactions may include in-person encounters, telephone conversations, and email exchanges.</p></div>
+    <div id="description">
+      <p>This clinical statement describes an interaction between a patient and clinician. Interactions may include
+        in-person encounters, telephone conversations, and email exchanges.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.22.html">Encounters Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.22.1.html">Encounters Section (entries required) (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.80.html">Encounter Diagnosis (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.22.html">Encounters Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.22.1.html">Encounters Section (entries required) (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.32.html">Service Delivery Location</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.80.html">Encounter Diagnosis (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-8710)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-8711)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8712)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.49"</b><b> (CONF:1198-26353)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32546)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8713)</b>.</li>
-<li class="list-group-item"><p>The translation may exist to map the code of EncounterTypeCode (2.16.840.1.113883.3.88.12.80.32) value set to the code of Encounter Planned (2.16.840.1.113883.11.20.9.52) value set.</p> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet EncounterTypeCode<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.32/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.32</a></b><b> DYNAMIC</b><b> (CONF:1198-8714)</b>.<ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:1198-8719)</b>.</li><ul><li>The originalText, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1198-15970)</b>.</li><ul><li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:1198-15971)</b>.</li><ul><li><p>This reference/@value <strong>SHALL</strong> begin with a '#' and <strong>SHALL</strong> point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:1198-15972).</p></li></ul></ul></ul></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>translation</b><b> (CONF:1198-32323)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-8715)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>sdtc:dischargeDispositionCode</b><b> (CONF:1198-32176)</b>.<br>Note: The prefix sdtc: SHALL be bound to the namespace urn:hl7-org:sdtc. The use of the namespace provides a necessary extension to CDA R2 for the use of the dischargeDispositionCode element<ul><li><p>This sdtc:dischargeDispositionCode <strong>SHOULD</strong> contain exactly [0..1] <em>code</em>, which <strong>SHOULD</strong> be selected from ValueSet 2.16.840.1.113883.3.88.12.80.33 NUBC UB-04 FL17-Patient Status (code system 2.16.840.1.113883.6.301.5) <em>DYNAMIC</em> or, if access to NUBC is unavailable, from CodeSystem 2.16.840.1.113883.12.112 HL7 Discharge Disposition (CONF:1198-32177).</p></li></ul><ul><li><p>This sdtc:dischargeDispositionCode <strong>SHOULD</strong> contain exactly [0..1] <em>codeSystem</em>, which <strong>SHOULD</strong> be either CodeSystem: NUBC 2.16.840.1.113883.6.301.5 <em>OR</em> CodeSystem: HL7 Discharge Disposition 2.16.840.1.113883.12.112 (CONF:1198-32377).</p></li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-8725)</b>.<ul><li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-8726)</b>.</li><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b> DYNAMIC</b><b> (CONF:1198-8727)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8738)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8740)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Service Delivery Location<b> (identifier: 2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:1198-14903)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-8722)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8723)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1198-14899)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-15492)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Encounter Diagnosis (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.80)</b><b> (CONF:1198-15973)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ENC"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1198-8710)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-8711)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8712)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.49"</b><b>
+              (CONF:1198-26353)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32546)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8713)</b>.</li>
+      <li class="list-group-item">
+        <p>The translation may exist to map the code of EncounterTypeCode (2.16.840.1.113883.3.88.12.80.32) value set to
+          the code of Encounter Planned (2.16.840.1.113883.11.20.9.52) value set.</p> <b>SHALL</b> contain exactly one
+        [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet EncounterTypeCode<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.32/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.32</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-8714)</b>.<ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:1198-8719)</b>.</li>
+          <ul>
+            <li>The originalText, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b>
+                (CONF:1198-15970)</b>.</li>
+            <ul>
+              <li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b>
+                  (CONF:1198-15971)</b>.</li>
+              <ul>
+                <li>
+                  <p>This reference/@value <strong>SHALL</strong> begin with a '#' and <strong>SHALL</strong> point to
+                    its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1)
+                    (CONF:1198-15972).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>translation</b><b> (CONF:1198-32323)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-8715)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>sdtc:dischargeDispositionCode</b><b>
+          (CONF:1198-32176)</b>.<br>Note: The prefix sdtc: SHALL be bound to the namespace urn:hl7-org:sdtc. The use of
+        the namespace provides a necessary extension to CDA R2 for the use of the dischargeDispositionCode element<ul>
+          <li>
+            <p>This sdtc:dischargeDispositionCode <strong>SHOULD</strong> contain exactly [0..1] <em>code</em>, which
+              <strong>SHOULD</strong> be selected from ValueSet 2.16.840.1.113883.3.88.12.80.33 NUBC UB-04 FL17-Patient
+              Status (code system 2.16.840.1.113883.6.301.5) <em>DYNAMIC</em> or, if access to NUBC is unavailable, from
+              CodeSystem 2.16.840.1.113883.12.112 HL7 Discharge Disposition (CONF:1198-32177).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>This sdtc:dischargeDispositionCode <strong>SHOULD</strong> contain exactly [0..1] <em>codeSystem</em>,
+              which <strong>SHOULD</strong> be either CodeSystem: NUBC 2.16.840.1.113883.6.301.5 <em>OR</em> CodeSystem:
+              HL7 Discharge Disposition 2.16.840.1.113883.12.112 (CONF:1198-32377).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-8725)</b>.<ul>
+          <li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+              (CONF:1198-8726)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected
+              from ValueSet Healthcare Provider Taxonomy<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b><b>
+                DYNAMIC</b><b> (CONF:1198-8727)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8738)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1198-8740)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Service Delivery Location<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.32)</b><b> (CONF:1198-14903)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-8722)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8723)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1198-14899)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-15492)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Encounter Diagnosis (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.80)</b><b> (CONF:1198-15973)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Encounter%20Activity%20(V3)_2.16.840.1.113883.10.20.22.4.49/Encounter%20Activity%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Encounter Activity (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Encounter%20Activity%20(V3)_2.16.840.1.113883.10.20.22.4.49/Encounter%20Activity%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Encounter Activity (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Encounters"><i class="fas fa-external-link-alt"></i> Encounters</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Encounters"><i class="fas fa-external-link-alt"></i> Encounters</a>
+      </li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.5.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.5.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,117 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Health Status Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.5, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Health Status Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.5, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents information about the overall health status of the patient. To represent the impact of a specific problem or concern related to the patient's expected health outcome use the Prognosis Observation template 2.16.840.1.113883.10.20.22.4.113.</p></div>
+    <div id="description">
+      <p>This template represents information about the overall health status of the patient. To represent the impact of
+        a specific problem or concern related to the patient's expected health outcome use the Prognosis Observation
+        template 2.16.840.1.113883.10.20.22.4.113.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.58.html">Health Concerns Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.58.html">Health Concerns Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.html">Problem Section (entries optional) (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.5.1.html">Problem Section (entries required) (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-9057)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-9072)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16756)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.5"</b><b> (CONF:1098-16757)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32558)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32486)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19143)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11323-3"</b> Health status<b> (CONF:1098-19144)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32161)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-9074)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19103)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet HealthStatus<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.12/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.12</a></b><b> DYNAMIC</b><b> (CONF:1098-9075)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-9057)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-9072)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16756)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.5"</b><b>
+              (CONF:1098-16757)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32558)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32486)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19143)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11323-3"</b> Health status<b>
+              (CONF:1098-19144)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32161)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-9074)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19103)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet HealthStatus<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.20.12/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.20.12</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-9075)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Status%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.5/Health%20Status%20Observation%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Health Status Observation (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Health%20Status%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.5/Health%20Status%20Observation%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Health Status Observation (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.50.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.50.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,143 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Non-Medicinal Supply Activity (V2) <small class="text-muted">[supply, 2.16.840.1.113883.10.20.22.4.50, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.50.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Non-Medicinal Supply Activity (V2) <small class="text-muted">[supply,
+        2.16.840.1.113883.10.20.22.4.50, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.50.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents equipment supplied to the patient (e.g., pumps, inhalers, wheelchairs). Devices applied to, or placed in, the patient are represented with the Product Instance entry contained within a Procedure Activity Procedure (V2) (identifier:  2.16.840.1.113883.10.20.22.4.14)</p></div>
+    <div id="description">
+      <p>This template represents equipment supplied to the patient (e.g., pumps, inhalers, wheelchairs). Devices
+        applied to, or placed in, the patient are represented with the Product Instance entry contained within a
+        Procedure Activity Procedure (V2) (identifier: 2.16.840.1.113883.10.20.22.4.14)</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.135.html">Medical Equipment Organizer</a><br><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.37.html">Product Instance</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.23.html">Medical Equipment Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.135.html">Medical Equipment Organizer</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.37.html">Product Instance</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SPLY"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8745)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet MoodCodeEvnInt<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.18/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.18</a></b><b> STATIC</b> 2011-04-03<b> (CONF:1098-8746)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8747)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.50"</b><b> (CONF:1098-10509)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32514)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8748)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-8749)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ActStatus<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b> DYNAMIC</b><b> (CONF:1098-32363)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-15498)</b>.<ul><li><p>The effectiveTime, if present, <strong>SHOULD</strong> contain zero or one [0..1] <em>high</em> (CONF:1098-16867).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>quantity</b><b> (CONF:1098-8751)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>participant</b><b> (CONF:1098-8752)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRD"</b> Product (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1098-8754)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Product Instance<b> (identifier: 2.16.840.1.113883.10.20.22.4.37)</b><b> (CONF:1098-15900)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-30277)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b><b> (CONF:1098-30278)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"TRUE"</b><b> (CONF:1098-30279)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31393)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SPLY"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-8745)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet MoodCodeEvnInt<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.18/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.18</a></b><b> STATIC</b> 2011-04-03<b>
+          (CONF:1098-8746)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-8747)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.50"</b><b>
+              (CONF:1098-10509)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32514)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8748)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-8749)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ActStatus<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-32363)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-15498)</b>.<ul>
+          <li>
+            <p>The effectiveTime, if present, <strong>SHOULD</strong> contain zero or one [0..1] <em>high</em>
+              (CONF:1098-16867).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>quantity</b><b> (CONF:1098-8751)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>participant</b><b> (CONF:1098-8752)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRD"</b> Product (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1098-8754)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Product Instance<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.37)</b><b> (CONF:1098-15900)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-30277)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b><b> (CONF:1098-30278)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"TRUE"</b><b> (CONF:1098-30279)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1098-31393)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Non-Medicinal%20Supply%20Activity%20(V2)_2.16.840.1.113883.10.20.22.4.50/Non-Medicinal%20Supply%20Activity%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Non-Medicinal Supply Activity (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Non-Medicinal%20Supply%20Activity%20(V2)_2.16.840.1.113883.10.20.22.4.50/Non-Medicinal%20Supply%20Activity%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Non-Medicinal Supply Activity (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.500.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.500.1.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,80 +24,290 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Care Team Member Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.500.1, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.500.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Care Team Member Act (V2) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.500.1, release
+        2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.500.1.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is used to represent a member of the care team. Care team members can include healthcare and community services providers, caregivers, relatives, the patient themselves, etc. A care team member can be another care team or an organization.Care team member attributes include the following:'	Care team member status on the care team'	Care team member time (e.g. duration, point-in-time, etc.) on the care team'	Schedule of the care team member describing when the care team member usually participates on the care team'	Care team member function on the care team such as the care team member specialty, relationship to the patient, and also role on the care team'	Care team member name, address, telecom, organization, etc.'	Care team member information (narrative description about the care team member)</p><p>The performer/assignedEntity/id may be set equal to (a pointer to) an id on a performer elsewhere in the document (header or entries) or a new performer can be described here. If the id is pointing to a performer already described elsewhere in the document, assignedEntity/id is sufficient to identify this performer and none of the remaining details of assignedEntity are required to be set. Application Software must be responsible for resolving the identifier back to its original object and then rendering the information in the correct place in the containing section's narrative text.</p><p>This id must be a pointer to another Performer.</p></div>
+    <div id="description">
+      <p>This template is used to represent a member of the care team. Care team members can include healthcare and
+        community services providers, caregivers, relatives, the patient themselves, etc. A care team member can be
+        another care team or an organization.Care team member attributes include the following:' Care team member status
+        on the care team' Care team member time (e.g. duration, point-in-time, etc.) on the care team' Schedule of the
+        care team member describing when the care team member usually participates on the care team' Care team member
+        function on the care team such as the care team member specialty, relationship to the patient, and also role on
+        the care team' Care team member name, address, telecom, organization, etc.' Care team member information
+        (narrative description about the care team member)</p>
+      <p>The performer/assignedEntity/id may be set equal to (a pointer to) an id on a performer elsewhere in the
+        document (header or entries) or a new performer can be described here. If the id is pointing to a performer
+        already described elsewhere in the document, assignedEntity/id is sufficient to identify this performer and none
+        of the remaining details of assignedEntity are required to be set. Application Software must be responsible for
+        resolving the identifier back to its original object and then rendering the information in the correct place in
+        the containing section's narrative text.</p>
+      <p>This id must be a pointer to another Performer.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.500.html">Care Team Organizer (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.202.html">Note Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.500.3.html">Care Team Member Schedule Observation</a><br><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.500.html">Care Team Organizer (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.202.html">Note Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.500.3.html">Care Team Member Schedule Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Provision of Care<b> (CONF:4515-53)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event<b> (CONF:4515-54)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-45)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.500.1"</b><b> (CONF:4515-66)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-67)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-27)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"85847-2"</b> Patient Care team information (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-48)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC<b> (CONF:4515-49)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-62)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ActStatus<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b> STATIC</b> 2019-05-27<b> (CONF:4515-68)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-33)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-167)</b>.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-168)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>performer</b><b> (CONF:4515-160)</b> such that it<ul><li><b>MAY</b> contain zero or one [0..1] <b>sdtc:functionCode</b>, which <b>SHOULD</b> be selected from ValueSet Care Team Member Function<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.30</a></b><b> DYNAMIC</b><b> (CONF:4515-161)</b>.<br>Note: 	This sdtc:functionCode represents the function or role of the member on the care team. For example, the care team member roles on the care team can be a caregiver and a professional nurse or a primary care provider and the care coordinator.  </li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:4515-175)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-176)</b>.</li><ul><li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider Identifier<b> (CONF:4515-177)</b>.</li></ul><ul><li><p>If the assignedEntity/id is not referencing a Performer elsewhere in the document with an assignedPerson populated, this assignedEntity SHALL contain exactly one [1..1] assignedPerson (CONF:4515-180).</p></li></ul></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:4515-182)</b>.</li></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:4515-183)</b>.</li></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>assignedPerson</b><b> (CONF:4515-178)</b>.<br>Note: This assignedPerson must be present on at least one performer in this document for each unique assignedEntity/id.</li><ul><li>The assignedPerson, if present, <b>SHALL</b> contain exactly one [1..1]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:4515-179)</b>.</li></ul></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>representedOrganization</b><b> (CONF:4515-181)</b>.</li><ul><li><p>When a provider is working on behalf of an organization an addr &amp; telecom <strong>SHALL</strong> be present in representedOrganization (CONF:4515-184).</p></li></ul></ul></ul></li>
-<li class="list-group-item"><p>This participant represents the location where the care team member provides the service<br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-171)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:4515-174)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:4515-173)</b>.</li></ul></li>
-<li class="list-group-item"><p>This participant is used to express additional care team functions performed by this member of the team. Include additional participant to record additional roles (functionCode) this Care Team member plays.<br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-76)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> Indirect Target (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:4515-78)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>sdtc:functionCode</b>, which <b>SHALL</b> be selected from ValueSet Care Team Member Function<b> 2.16.840.1.113762.1.4.1099.30</b><b> DYNAMIC</b><b> (CONF:4515-169)</b>.</li></ul><ul><li><p>This participantRole SHALL contain exactly one [1..1] @nullFlavor="NI" No Information. (CONF:4515-172).</p></li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-86)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-87)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:4515-88)</b>.</li><ul><li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:4515-89)</b>.</li><ul><li><p>If the id does not match an encounter/id from an encounter elsewhere within the same document and the id does not contain @nullFlavor=NA, then this entry SHALL conform to the Encounter Activity (V3) (identifier: 2.16.840.1.113883.10.20.22.4.49) (CONF:4515-90).</p></li></ul></ul></ul></li>
-<li class="list-group-item"><p>This is the note activity to naratively describe information about the member on the care team.<br></p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-91)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-92)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Note Activity<b> (identifier: 2.16.840.1.113883.10.20.22.4.202)</b><b> (CONF:4515-93)</b>.</li></ul></li>
-<li class="list-group-item"><p>This is the schedule of when or how frequently the care team member participates (or provides care to the patient) on the care team.<br></p> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:4515-94)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:4515-96)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Care Team Member Schedule Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.500.3)</b><b> (CONF:4515-95)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PCPR"</b> Provision of
+        Care<b> (CONF:4515-53)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event<b>
+          (CONF:4515-54)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-45)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.500.1"</b><b>
+              (CONF:4515-66)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-67)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-27)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"85847-2"</b> Patient Care team
+            information (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-48)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            LOINC<b> (CONF:4515-49)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-62)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ActStatus<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b>
+              STATIC</b> 2019-05-27<b> (CONF:4515-68)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-33)</b>.
+        <ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-167)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-168)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>performer</b><b> (CONF:4515-160)</b> such
+        that it<ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>sdtc:functionCode</b>, which <b>SHOULD</b> be selected from
+            ValueSet Care Team Member Function<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.30</a></b><b>
+              DYNAMIC</b><b> (CONF:4515-161)</b>.<br>Note: This sdtc:functionCode represents the function or role of the
+            member on the care team. For example, the care team member roles on the care team can be a caregiver and a
+            professional nurse or a primary care provider and the care coordinator. </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:4515-175)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-176)</b>.</li>
+            <ul>
+              <li>Such ids <b>SHOULD</b> contain zero or one [0..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National
+                Provider Identifier<b> (CONF:4515-177)</b>.</li>
+            </ul>
+            <ul>
+              <li>
+                <p>If the assignedEntity/id is not referencing a Performer elsewhere in the document with an
+                  assignedPerson populated, this assignedEntity SHALL contain exactly one [1..1] assignedPerson
+                  (CONF:4515-180).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or more [0..*] <b>addr</b><b> (CONF:4515-182)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:4515-183)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>assignedPerson</b><b>
+                (CONF:4515-178)</b>.<br>Note: This assignedPerson must be present on at least one performer in this
+              document for each unique assignedEntity/id.</li>
+            <ul>
+              <li>The assignedPerson, if present, <b>SHALL</b> contain exactly one [1..1] US Realm Person Name
+                (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:4515-179)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>representedOrganization</b><b>
+                (CONF:4515-181)</b>.</li>
+            <ul>
+              <li>
+                <p>When a provider is working on behalf of an organization an addr &amp; telecom <strong>SHALL</strong>
+                  be present in representedOrganization (CONF:4515-184).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This participant represents the location where the care team member provides the service<br></p> <b>MAY</b>
+        contain zero or more [0..*] <b>participant</b><b> (CONF:4515-171)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:4515-174)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:4515-173)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This participant is used to express additional care team functions performed by this member of the team.
+          Include additional participant to record additional roles (functionCode) this Care Team member plays.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-76)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b> Indirect Target (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:4515-78)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>sdtc:functionCode</b>, which <b>SHALL</b> be selected from
+            ValueSet Care Team Member Function<b> 2.16.840.1.113762.1.4.1099.30</b><b> DYNAMIC</b><b>
+              (CONF:4515-169)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>This participantRole SHALL contain exactly one [1..1] @nullFlavor="NI" No Information. (CONF:4515-172).
+            </p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-86)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-87)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:4515-88)</b>.</li>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:4515-89)</b>.</li>
+            <ul>
+              <li>
+                <p>If the id does not match an encounter/id from an encounter elsewhere within the same document and the
+                  id does not contain @nullFlavor=NA, then this entry SHALL conform to the Encounter Activity (V3)
+                  (identifier: 2.16.840.1.113883.10.20.22.4.49) (CONF:4515-90).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This is the note activity to naratively describe information about the member on the care team.<br></p>
+        <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-91)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-92)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Note Activity<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.202)</b><b> (CONF:4515-93)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This is the schedule of when or how frequently the care team member participates (or provides care to the
+          patient) on the care team.<br></p> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:4515-94)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:4515-96)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Care Team Member Schedule Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.500.3)</b><b> (CONF:4515-95)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Team%20Member%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.500.1/Care%20Team%20Member%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Team Member Act</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Team%20Member%20Act%20(V2)_2.16.840.1.113883.10.20.22.4.500.1/Care%20Team%20Member%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Team Member Act</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a>
+      </li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.500.2.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.500.2.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,74 +24,150 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Care Team Type Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.500.2, release 2019-07-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.500.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Care Team Type Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.500.2, release 2019-07-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.500.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is used to express the care team type. A care team can have multiple care team types. Examples include but are not limited to:</p><ul><li>Condition focused, longitudinal care team</li><li>Event focused, Home &amp; Community Based Services care team</li><li>Condition focused, clinical research care team</li><li>Public health focused, Longitudinal care-coordination care team</li></ul></div>
+    <div id="description">
+      <p>This template is used to express the care team type. A care team can have multiple care team types. Examples
+        include but are not limited to:</p>
+      <ul>
+        <li>Condition focused, longitudinal care team</li>
+        <li>Event focused, Home &amp; Community Based Services care team</li>
+        <li>Condition focused, clinical research care team</li>
+        <li>Public health focused, Longitudinal care-coordination care team</li>
+      </ul>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.500.html">Care Team Organizer (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.500.html">Care Team Organizer (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4435-101)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4435-102)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4435-99)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>" 2.16.840.1.113883.10.20.22.4.500.2"</b><b> (CONF:4435-106)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-07-01"</b><b> (CONF:4435-108)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4435-97)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"86744-0"</b> Care Team<b> (CONF:4435-103)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4435-104)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4435-100)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:4435-107)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b> (CONF:4435-98)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Care Team Category<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.4.642.3.155/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.4.642.3.155</a></b><b> DYNAMIC</b><b> (CONF:4435-109)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:4435-101)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4435-102)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4435-99)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>" 2.16.840.1.113883.10.20.22.4.500.2"</b><b>
+              (CONF:4435-106)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-07-01"</b><b> (CONF:4435-108)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4435-97)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"86744-0"</b> Care Team<b>
+              (CONF:4435-103)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4435-104)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4435-100)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:4435-107)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b>
+          (CONF:4435-98)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Care
+            Team Category<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.4.642.3.155/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.4.642.3.155</a></b><b>
+              DYNAMIC</b><b> (CONF:4435-109)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Team%20Type%20Observation_2.16.840.1.113883.10.20.22.4.500.2/Care%20Team%20Type%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Team Type Observation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Team%20Type%20Observation_2.16.840.1.113883.10.20.22.4.500.2/Care%20Team%20Type%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Team Type Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a>
+      </li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.500.3.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.500.3.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,84 +24,203 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Care Team Member Schedule Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.500.3, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.500.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Care Team Member Schedule Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.500.3, release 2022-06-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.500.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the schedule of when the care team member participates on the care team. Examples include:' An oncologist who participated on the care team for one week.' A primary care provider who participated on a care team during one summer (e.g. in the case of patients who are snow-birds).' A crisis team who participated on the care team for the patient during an inpatient stay (e.g. in the case of children with special needs).</p></div>
+    <div id="description">
+      <p>This template represents the schedule of when the care team member participates on the care team. Examples
+        include:' An oncologist who participated on the care team for one week.' A primary care provider who
+        participated on a care team during one summer (e.g. in the case of patients who are snow-birds).' A crisis team
+        who participated on the care team for the patient during an inpatient stay (e.g. in the case of children with
+        special needs).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4435-24)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4435-25)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4435-12)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.500.3"</b><b> (CONF:4435-18)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-07-01"</b><b> (CONF:4435-19)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4435-13)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"57203-2"</b> Episode Timing [CMS Assessment]<b> (CONF:4435-20)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC<b> (CONF:4435-21)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:4435-15)</b>.<ul><li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:4435-16)</b>.</li><ul><li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4435-26)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4435-11)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:4435-17)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="TS"<b> (CONF:4435-14)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-33026)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-33027)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-33019)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.500.3"</b><b> (CONF:4515-33022)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-19)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-13)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"57203-2"</b> Episode Timing [CMS Assessment]<b> (CONF:4515-33023)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC<b> (CONF:4515-33024)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:4515-33020)</b>.<ul><li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:4515-16)</b>.</li><ul><li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4515-33025)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-33018)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:4515-33021)</b>.</li></ul></li>
-<li class="list-group-item"><p>Observation/value Interval Time Stamp holds the time range the Care Team Member participated on the Care Team of the patient.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="IVL_TS"<b> (CONF:4515-14)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-33030)</b>.</li></ul><ul><li>This value <b>SHOULD</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-33029)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:4435-24)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4435-25)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4435-12)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.500.3"</b><b>
+              (CONF:4435-18)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-07-01"</b><b> (CONF:4435-19)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4435-13)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"57203-2"</b> Episode Timing [CMS
+            Assessment]<b> (CONF:4435-20)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            LOINC<b> (CONF:4435-21)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:4435-15)</b>.<ul>
+          <li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:4435-16)</b>.</li>
+          <ul>
+            <li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4435-26)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4435-11)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:4435-17)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="TS"<b>
+          (CONF:4435-14)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:4515-33026)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4515-33027)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-33019)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.500.3"</b><b>
+              (CONF:4515-33022)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-19)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-13)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"57203-2"</b> Episode Timing [CMS
+            Assessment]<b> (CONF:4515-33023)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            LOINC<b> (CONF:4515-33024)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:4515-33020)</b>.<ul>
+          <li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:4515-16)</b>.</li>
+          <ul>
+            <li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4515-33025)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-33018)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:4515-33021)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Observation/value Interval Time Stamp holds the time range the Care Team Member participated on the Care Team
+          of the patient.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="IVL_TS"<b>
+          (CONF:4515-14)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-33030)</b>.</li>
+        </ul>
+        <ul>
+          <li>This value <b>SHOULD</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-33029)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Team%20Member%20Schedule%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.500.3/Care%20Team%20Member%20Schedule%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Team Member Schedule Observation</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Team%20Member%20Schedule%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.500.3/Care%20Team%20Member%20Schedule%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Team Member Schedule Observation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a>
+      </li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.500.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.500.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,83 +24,274 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Care Team Organizer (V2) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.500, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.500.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Care Team Organizer (V2) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.500,
+        release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.500.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This organizer template contains information about a single care team.The author of the organizer is the person who documented the care team information.The participants of the organizer are the care team lead(s) and the care team organization.</p><p>The components of the organizer contain the following information:</p><ul><li>The encounter that caused the care team to be formed</li><li>Narrative information about the care team</li><li>The care team members</li><li>Reasons for the care team</li><li>The care team type(s) - a care team can have multiple care team types</li></ul></div>
+    <div id="description">
+      <p>This organizer template contains information about a single care team.The author of the organizer is the person
+        who documented the care team information.The participants of the organizer are the care team lead(s) and the
+        care team organization.</p>
+      <p>The components of the organizer contain the following information:</p>
+      <ul>
+        <li>The encounter that caused the care team to be formed</li>
+        <li>Narrative information about the care team</li>
+        <li>The care team members</li>
+        <li>Reasons for the care team</li>
+        <li>The care team type(s) - a care team can have multiple care team types</li>
+      </ul>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.500.html">Care Teams Section (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.500.2.html">Care Team Type Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a href="2.16.840.1.113883.10.20.22.4.202.html">Note Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.500.1.html">Care Team Member Act (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.500.html">Care Teams Section (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.500.2.html">Care Team Type Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.122.html">Entry Reference</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.202.html">Note Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.500.1.html">Care Team Member Act (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> CLUSTER (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-124)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-125)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-112)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.500"</b><b> (CONF:4515-117)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-118)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-126)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-114)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"86744-0"</b> Care Team<b> (CONF:4515-120)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-121)</b>.</li></ul><ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:4515-154)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:4515-155)</b>.</li><ul><li>The value attribute references the narrative in section.text where the care team name is rendered. The intention of this reference is to clarify which care team this Organizer refers to. <br/>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4515-156)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-113)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ActStatus<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b> STATIC</b><b> (CONF:4515-119)</b>.<br>Note: When statusCode has a value set, its value MAY be rendered in the narrative.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-127)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-157)</b>.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-158)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-116)</b>.</li>
-<li class="list-group-item"><p>This Participant represents the Care Team lead.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-128)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PPRF"</b> Primary Performer (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:4515-129)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>sdtc:functionCode</b>, which <b>SHOULD</b> be selected from ValueSet Care Team Member Function<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.30</a></b><b> DYNAMIC</b><b> (CONF:4515-130)</b>.<br>Note: Describes the person's, caregiver's or health care provider's functional role on the care team.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:4515-131)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-132)</b>.</li><ul><li><p>This id <strong>SHALL</strong> match a performer/assignedEntity/id of at least one Care Team Member described in component/act (CONF:4515-133).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-134)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b> (CONF:4515-137)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:4515-135)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-138)</b>.</li></ul><ul><li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>addr</b><b> (CONF:4515-139)</b>.</li></ul><ul><li>This participantRole <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:4515-140)</b>.</li></ul><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b> (CONF:4515-136)</b>.</li><ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PLC"</b> Place (CodeSystem: <b>HL7EntityClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b>)<b> (CONF:4515-141)</b>.</li></ul><ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:4515-142)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:4515-110)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Care Team Type Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.500.2)</b><b> (CONF:4515-163)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following components represent the reasons for the existence of the care team.<br />These entry references are typically a health concern, risk concern or problem but can also be some other entry present in the document.<br /></p> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:4515-146)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Entry Reference<b> (identifier: 2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-147)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:4515-148)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:4515-164)</b>.</li><ul><li>This encounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-165)</b>.<br>Note: 1.	If the id does not match an encounter/id from an encounter elsewhere within the same document and the id does not contain @nullFlavor=NA, then this entry SHALL conform to the Encounter Activity (V3) (identifier: 2.16.840.1.113883.10.20.22.4.49) (CONF:4435-145).</li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4515-150)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Note Activity<b> (identifier: 2.16.840.1.113883.10.20.22.4.202)</b><b> (CONF:4515-151)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:4515-152)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Care Team Member Act (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.500.1)</b><b> (CONF:4515-166)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> CLUSTER
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:4515-124)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4515-125)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-112)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.500"</b><b>
+              (CONF:4515-117)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-118)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-126)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-114)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"86744-0"</b> Care Team<b>
+              (CONF:4515-120)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:4515-121)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>originalText</b><b> (CONF:4515-154)</b> such that it
+          </li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:4515-155)</b>.</li>
+            <ul>
+              <li>The value attribute references the narrative in section.text where the care team name is rendered. The
+                intention of this reference is to clarify which care team this Organizer refers to. <br />This reference
+                <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4515-156)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-113)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ActStatus<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b>
+              STATIC</b><b> (CONF:4515-119)</b>.<br>Note: When statusCode has a value set, its value MAY be rendered in
+            the narrative.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-127)</b>.
+        <ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-157)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-158)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:4515-116)</b>.</li>
+      <li class="list-group-item">
+        <p>This Participant represents the Care Team lead.<br></p> <b>SHOULD</b> contain zero or more [0..*]
+        <b>participant</b><b> (CONF:4515-128)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PPRF"</b> Primary Performer (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:4515-129)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>sdtc:functionCode</b>, which <b>SHOULD</b> be selected from
+            ValueSet Care Team Member Function<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.30</a></b><b>
+              DYNAMIC</b><b> (CONF:4515-130)</b>.<br>Note: Describes the person's, caregiver's or health care provider's
+            functional role on the care team.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:4515-131)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-132)</b>.</li>
+            <ul>
+              <li>
+                <p>This id <strong>SHALL</strong> match a performer/assignedEntity/id of at least one Care Team Member
+                  described in component/act (CONF:4515-133).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:4515-134)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"LOC"</b> Location (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b>)<b>
+              (CONF:4515-137)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:4515-135)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-138)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>addr</b><b> (CONF:4515-139)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:4515-140)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b>
+                (CONF:4515-136)</b>.</li>
+            <ul>
+              <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"PLC"</b> Place
+                (CodeSystem: <b>HL7EntityClass <a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b>)<b> (CONF:4515-141)</b>.</li>
+            </ul>
+            <ul>
+              <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:4515-142)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:4515-110)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Care Team Type Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.500.2)</b><b> (CONF:4515-163)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following components represent the reasons for the existence of the care team.<br />These entry
+          references are typically a health concern, risk concern or problem but can also be some other entry present in
+          the document.<br /></p> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:4515-146)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Entry Reference<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.122)</b><b> (CONF:4515-147)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>component</b><b> (CONF:4515-148)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>encounter</b><b> (CONF:4515-164)</b>.</li>
+          <ul>
+            <li>This encounter <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-165)</b>.<br>Note: 1. If
+              the id does not match an encounter/id from an encounter elsewhere within the same document and the id does
+              not contain @nullFlavor=NA, then this entry SHALL conform to the Encounter Activity (V3) (identifier:
+              2.16.840.1.113883.10.20.22.4.49) (CONF:4435-145).</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>component</b><b> (CONF:4515-150)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Note Activity<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.202)</b><b> (CONF:4515-151)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:4515-152)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Care Team Member Act (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.500.1)</b><b> (CONF:4515-166)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Team%20Organizer%20(V2)_2.16.840.1.113883.10.20.22.4.500/Care%20Team%20Organizer%20Example.xml"><i class="fab fa-github"></i>&nbsp;Care Team Organizer</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Care%20Team%20Organizer%20(V2)_2.16.840.1.113883.10.20.22.4.500/Care%20Team%20Organizer%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Care Team Organizer</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a></li></ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Care%20Team"><i class="fas fa-external-link-alt"></i> Care Team</a>
+      </li>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.501.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.501.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,80 +24,170 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Sexual Orientation Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.501, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.501.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Sexual Orientation Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.501, release 2022-06-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.501.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This observation represents the sexual orientation of the patient, defined as:</p><blockquote><p>A person's identification of their emotional, romantic, sexual, or affectional attraction to another person.</p></blockquote><p>This template was informed by the HL7 Gender Harmony project.</p><p>This observation is not appropriate for recording patient gender (administrativeGender), Gender Identity (Gender Identity Observation), or birth sex (Birth Sex Observation).</p></div>
+    <div id="description">
+      <p>This observation represents the sexual orientation of the patient, defined as:</p>
+      <blockquote>
+        <p>A person's identification of their emotional, romantic, sexual, or affectional attraction to another person.
+        </p>
+      </blockquote>
+      <p>This template was informed by the HL7 Gender Harmony project.</p>
+      <p>This observation is not appropriate for recording patient gender (administrativeGender), Gender Identity
+        (Gender Identity Observation), or birth sex (Birth Sex Observation).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Social History Observation (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.4.38:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-193)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-194)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-185)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.501"</b><b> (CONF:4515-188)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-189)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-186)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"76690-7"</b> Sexual Orientation<b> (CONF:4515-190)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:4515-191)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-32881)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:4515-32883)</b>.</li></ul></li>
-<li class="list-group-item"><p>The effectiveTime represents the relevant time of the observation. A patient's "sexual orientation" may change and using effectiveTime/low and effectiveTime/high defines the time during which the patient had identified their emotional, romantic, sexual, or affectional attraction to another person.</p> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-32882)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-32884)</b>.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-32885)</b>.</li></ul></li>
-<li class="list-group-item"><p>To represent additional orientations, set nullFlavor="OTH". To represent "choose not to disclose", set nullFlavor="ASKU". To represent "Don't know", set nullFlavor="UNK"</p> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Sexual Orientation<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.33/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.33</a></b><b> DYNAMIC</b><b> (CONF:4515-187)</b>.<ul><li>This value <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>, which <b>SHOULD</b> be selected from ValueSet Other or unknown or refused to answer<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.103/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.103</a></b><b> DYNAMIC</b><b> (CONF:4515-192)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Social History Observation (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.4.38:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:4515-193)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4515-194)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-185)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.501"</b><b>
+              (CONF:4515-188)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-189)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-186)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"76690-7"</b> Sexual Orientation<b>
+              (CONF:4515-190)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:4515-191)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-32881)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:4515-32883)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime represents the relevant time of the observation. A patient's "sexual orientation" may
+          change and using effectiveTime/low and effectiveTime/high defines the time during which the patient had
+          identified their emotional, romantic, sexual, or affectional attraction to another person.</p> <b>SHALL</b>
+        contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-32882)</b>.<ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-32884)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-32885)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>To represent additional orientations, set nullFlavor="OTH". To represent "choose not to disclose", set
+          nullFlavor="ASKU". To represent "Don't know", set nullFlavor="UNK"</p> <b>SHALL</b> contain exactly one [1..1]
+        <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Sexual Orientation<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.33/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.33</a></b><b> DYNAMIC</b><b>
+          (CONF:4515-187)</b>.<ul>
+          <li>This value <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>, which <b>SHOULD</b> be selected from
+            ValueSet Other or unknown or refused to answer<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.103/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.103</a></b><b>
+              DYNAMIC</b><b> (CONF:4515-192)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Sexual%20Orientation%20Observation_2.16.840.1.113883.10.20.22.4.501/Sexual%20Orientation%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Sexual Orientation Observation Example</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Sexual%20Orientation%20Observation_2.16.840.1.113883.10.20.22.4.501/Sexual%20Orientation%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Sexual Orientation Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social History</a></li></ul>
-  
-  </ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social
+          History</a></li>
+    </ul>
+
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.502.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.502.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,78 +24,153 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Date of Diagnosis Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.502, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.502.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Date of Diagnosis Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.502, release
+        2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.502.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the Date of Diagnosis, which is the date of first determination by a qualified professional of the presence of a problem or condition affecting a patient.</p><p>The date of diagnosis is usually not the same date as the date of condition onset. A patient may have a condition for some time before it is formally diagnosed.</p></div>
+    <div id="description">
+      <p>This template represents the Date of Diagnosis, which is the date of first determination by a qualified
+        professional of the presence of a problem or condition affecting a patient.</p>
+      <p>The date of diagnosis is usually not the same date as the date of condition onset. A patient may have a
+        condition for some time before it is formally diagnosed.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V4)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V4)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:4515-33010)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:4515-33011)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-33000)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.502"</b><b> (CONF:4515-33002)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-33003)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-33001)</b>.<ul><li>This code <b>SHALL</b> contain zero or one [0..1] <b>@code</b>=<b>"77975-1"</b> Earliest date of diagnosis<b> (CONF:4515-33004)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> LOINC<b> (CONF:4515-33005)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:4515-33006)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-33007)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4515-33008)</b>.</li><ul><li><p><strong>SHALL</strong> be precise to at least the year (CONF:4515-33009).</p></li></ul></ul><ul><li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>low</b><b> (CONF:4515-33016)</b>.</li></ul><ul><li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>high</b><b> (CONF:4515-33017)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+          (CONF:4515-33010)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b>
+          (CONF:4515-33011)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-33000)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.502"</b><b>
+              (CONF:4515-33002)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-33003)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-33001)</b>.<ul>
+          <li>This code <b>SHALL</b> contain zero or one [0..1] <b>@code</b>=<b>"77975-1"</b> Earliest date of
+            diagnosis<b> (CONF:4515-33004)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            LOINC<b> (CONF:4515-33005)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b>=<b>"completed"</b>
+        Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b>
+          (CONF:4515-33006)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:4515-33007)</b>.<ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:4515-33008)</b>.</li>
+          <ul>
+            <li>
+              <p><strong>SHALL</strong> be precise to at least the year (CONF:4515-33009).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>low</b><b> (CONF:4515-33016)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>high</b><b> (CONF:4515-33017)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Date%20of%20Diagnosis%20Act_2.16.840.1.113883.10.20.22.4.502/Date%20of%20Diagnosis%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Date of Diagnosis Act Example</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Date%20of%20Diagnosis%20Act_2.16.840.1.113883.10.20.22.4.502/Date%20of%20Diagnosis%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Date of Diagnosis Act Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a></li></ul>
-  
-  </ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a>
+      </li>
+    </ul>
+
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.51.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.51.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,110 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Postprocedure Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.51, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.51.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Postprocedure Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.51, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.51.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the diagnosis or diagnoses discovered or confirmed during the procedure. They may be the same as preprocedure diagnoses or indications.</p></div>
+    <div id="description">
+      <p>This template represents the diagnosis or diagnoses discovered or confirmed during the procedure. They may be
+        the same as preprocedure diagnoses or indications.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.36.html">Postprocedure Diagnosis Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.36.html">Postprocedure Diagnosis Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b><b> (CONF:1198-8756)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b><b> (CONF:1198-8757)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16766)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.51"</b><b> (CONF:1198-16767)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32539)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19151)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59769-0"</b> Postprocedure diagnosis<b> (CONF:1198-19152)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32166)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-8759)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8760)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15583)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b><b>
+          (CONF:1198-8756)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b><b>
+          (CONF:1198-8757)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16766)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.51"</b><b>
+              (CONF:1198-16767)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32539)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19151)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"59769-0"</b> Postprocedure diagnosis<b>
+              (CONF:1198-19152)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32166)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-8759)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8760)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15583)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Postprocedure%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.51/Postprocedure%20Diagnosis%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Postprocedure Diagnosis (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Postprocedure%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.51/Postprocedure%20Diagnosis%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Postprocedure Diagnosis (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.52.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.52.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,71 +52,314 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Immunization Activity (V3) <small class="text-muted">[substanceAdministration, 2.16.840.1.113883.10.20.22.4.52, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.52.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Immunization Activity (V3) <small class="text-muted">[substanceAdministration,
+        2.16.840.1.113883.10.20.22.4.52, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.52.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>An Immunization Activity describes immunization substance administrations that have actually occurred or are intended to occur. Immunization Activities in "INT" mood are reflections of immunizations a clinician intends a patient to receive. Immunization Activities in "EVN" mood reflect immunizations actually received.An Immunization Activity is very similar to a Medication Activity with some key differentiators. The drug code system is constrained to CVX codes. Administration timing is less complex. Patient refusal reasons should be captured. All vaccines administered should be fully documented in the patient's permanent medical record. Healthcare providers who administer vaccines covered by the National Childhood Vaccine Injury Act are required to ensure that the permanent medical record of the recipient indicates:</p><ol><li>Date of administration</li><li>Vaccine manufacturer</li><li>Vaccine lot number</li><li>Name and title of the person who administered the vaccine and the address of the clinic or facility where the permanent record will reside</li><li>Vaccine information statement (VIS)<ol type="a"><li>Date printed on the VIS</li><li>Date VIS given to patient or parent/guardian.</li></ol></li></ol><p>This information should be included in an Immunization Activity when available. (Reference: [https://www.cdc.gov/vaccines/pubs/pinkbook/downloads/appendices/c/vis-instruct.pdf])</p></div>
+    <div id="description">
+      <p>An Immunization Activity describes immunization substance administrations that have actually occurred or are
+        intended to occur. Immunization Activities in "INT" mood are reflections of immunizations a clinician intends a
+        patient to receive. Immunization Activities in "EVN" mood reflect immunizations actually received.An
+        Immunization Activity is very similar to a Medication Activity with some key differentiators. The drug code
+        system is constrained to CVX codes. Administration timing is less complex. Patient refusal reasons should be
+        captured. All vaccines administered should be fully documented in the patient's permanent medical record.
+        Healthcare providers who administer vaccines covered by the National Childhood Vaccine Injury Act are required
+        to ensure that the permanent medical record of the recipient indicates:</p>
+      <ol>
+        <li>Date of administration</li>
+        <li>Vaccine manufacturer</li>
+        <li>Vaccine lot number</li>
+        <li>Name and title of the person who administered the vaccine and the address of the clinic or facility where
+          the permanent record will reside</li>
+        <li>Vaccine information statement (VIS)<ol type="a">
+            <li>Date printed on the VIS</li>
+            <li>Date VIS given to patient or parent/guardian.</li>
+          </ol>
+        </li>
+      </ol>
+      <p>This information should be included in an Immunization Activity when available. (Reference:
+        [https://www.cdc.gov/vaccines/pubs/pinkbook/downloads/appendices/c/vis-instruct.pdf])</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.2.1.html">Immunizations Section (entries required) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional) (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.24.html">Drug Vehicle</a><br><a href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.53.html">Immunization Refusal Reason</a><br><a href="2.16.840.1.113883.10.20.22.4.25.html">Precondition for Substance Administration (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.118.html">Substance Administered Act</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.2.1.html">Immunizations Section (entries required)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.2.html">Immunizations Section (entries optional)
+              (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.146.html">Planned Intervention Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.131.html">Intervention Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.54.html">Immunization Medication Information
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.24.html">Drug Vehicle</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.19.html">Indication (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.20.html">Instruction (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.53.html">Immunization Refusal Reason</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.25.html">Precondition for Substance Administration (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.118.html">Substance Administered Act</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-8826)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be selected from ValueSet MoodCodeEvnInt<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.18/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.18</a></b><b> STATIC</b><b> (CONF:1198-8827)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@negationInd</b><b> (CONF:1198-8985)</b>.<br>Note: Use negationInd="true" to indicate that the immunization was not given.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8828)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.52"</b><b> (CONF:1198-10498)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32528)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8829)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-8830)</b>.<br>Note: SubstanceAdministration.code is an optional field. Per HL7 Pharmacy Committee, "this is intended to further specify the nature of the substance administration act. To date the committee has made no use of this attribute". Because the type of substance administration is generally implicit in the routeCode, in the consumable participant, etc., the field is generally not used and there is no defined value set.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8833)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet ActStatus<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b> DYNAMIC</b><b> (CONF:1198-32359)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-8834)</b>.</li>
-<li class="list-group-item"><p>In "INT" (intent) mood, the repeatNumber defines the number of allowed administrations. For example, a repeatNumber of "3" means that the substance can be administered up to 3 times. In "EVN" (event) mood, the repeatNumber is the number of occurrences. For example, a repeatNumber of "3" in a substance administration event means that the current administration is the 3rd in a series.<br></p> <b>MAY</b> contain zero or one [0..1] <b>repeatNumber</b><b> (CONF:1198-8838)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>routeCode</b>, which <b>SHALL</b> be selected from ValueSet SPL Drug Route of Administration Terminology<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.7/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.7</a></b><b> DYNAMIC</b><b> (CONF:1198-8839)</b>.<ul><li>The routeCode, if present, <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which <b>SHALL</b> be selected from ValueSet Medication Route<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.12/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.12</a></b><b> DYNAMIC</b><b> (CONF:1198-32960)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>approachSiteCode</b>, where the code <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b> DYNAMIC</b><b> (CONF:1198-8840)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>doseQuantity</b><b> (CONF:1198-8841)</b>.<ul><li>The doseQuantity, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b> DYNAMIC</b><b> (CONF:1198-8842)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>administrationUnitCode</b>, which <b>SHALL</b> be selected from ValueSet AdministrationUnitDoseForm<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.30/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.30</a></b><b> DYNAMIC</b><b> (CONF:1198-8846)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:1198-8847)</b>.<ul><li>This consumable <b>SHALL</b> contain exactly one [1..1]  Immunization Medication Information (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1198-15546)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>performer</b><b> (CONF:1198-8849)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31151)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8850)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CSM"</b> (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8851)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Drug Vehicle<b> (identifier: 2.16.840.1.113883.10.20.22.4.24)</b><b> (CONF:1198-15547)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-8853)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8854)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Indication (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1198-15537)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1198-8856)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8857)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1198-8858)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Instruction (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1198-31392)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1198-8860)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8861)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Supply Order (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.17)</b><b> (CONF:1198-15539)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1198-8863)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8864)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Dispense (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.18)</b><b> (CONF:1198-15540)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1198-8866)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CAUS"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8867)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Reaction Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1198-15541)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1198-8988)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8989)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Immunization Refusal Reason<b> (identifier: 2.16.840.1.113883.10.20.22.4.53)</b><b> (CONF:1198-15542)</b>.</li></ul></li>
-<li class="list-group-item"><p>The following entryRelationship is used to indicate a given immunization's order in a series. The nested Substance Administered Act identifies an administration in the series. The entryRelationship/sequenceNumber shows the order of this particular administration in that series.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-31510)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1198-31511)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b><b> (CONF:1198-31512)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>sequenceNumber</b><b> (CONF:1198-31513)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Substance Administered Act<b> (identifier: 2.16.840.1.113883.10.20.22.4.118)</b><b> (CONF:1198-31514)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>precondition</b><b> (CONF:1198-8869)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRCN"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8870)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Precondition for Substance Administration (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.25)</b><b> (CONF:1198-15548)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"SBADM"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1198-8826)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>, which <b>SHALL</b> be
+        selected from ValueSet MoodCodeEvnInt<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.18/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.18</a></b><b> STATIC</b><b>
+          (CONF:1198-8827)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@negationInd</b><b>
+          (CONF:1198-8985)</b>.<br>Note: Use negationInd="true" to indicate that the immunization was not given.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8828)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.52"</b><b>
+              (CONF:1198-10498)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32528)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8829)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-8830)</b>.<br>Note:
+        SubstanceAdministration.code is an optional field. Per HL7 Pharmacy Committee, "this is intended to further
+        specify the nature of the substance administration act. To date the committee has made no use of this
+        attribute". Because the type of substance administration is generally implicit in the routeCode, in the
+        consumable participant, etc., the field is generally not used and there is no defined value set.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8833)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet ActStatus<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15933</a></b><b>
+              DYNAMIC</b><b> (CONF:1198-32359)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-8834)</b>.
+      </li>
+      <li class="list-group-item">
+        <p>In "INT" (intent) mood, the repeatNumber defines the number of allowed administrations. For example, a
+          repeatNumber of "3" means that the substance can be administered up to 3 times. In "EVN" (event) mood, the
+          repeatNumber is the number of occurrences. For example, a repeatNumber of "3" in a substance administration
+          event means that the current administration is the 3rd in a series.<br></p> <b>MAY</b> contain zero or one
+        [0..1] <b>repeatNumber</b><b> (CONF:1198-8838)</b>.
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>routeCode</b>, which <b>SHALL</b> be
+        selected from ValueSet SPL Drug Route of Administration Terminology<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.7/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.7</a></b><b>
+          DYNAMIC</b><b> (CONF:1198-8839)</b>.<ul>
+          <li>The routeCode, if present, <b>SHOULD</b> contain zero or more [0..*] <b>translation</b>, which
+            <b>SHALL</b> be selected from ValueSet Medication Route<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.12/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1099.12</a></b><b>
+              DYNAMIC</b><b> (CONF:1198-32960)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>approachSiteCode</b>, where the code
+        <b>SHALL</b> be selected from ValueSet Body Site Value Set<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.8.9/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.8.9</a></b><b>
+          DYNAMIC</b><b> (CONF:1198-8840)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>doseQuantity</b><b> (CONF:1198-8841)</b>.
+        <ul>
+          <li>The doseQuantity, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@unit</b>, which <b>SHALL</b> be
+            selected from ValueSet UnitsOfMeasureCaseSensitive<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.12839/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.12839</a></b><b>
+              DYNAMIC</b><b> (CONF:1198-8842)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>administrationUnitCode</b>, which
+        <b>SHALL</b> be selected from ValueSet AdministrationUnitDoseForm<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.30/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.30</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-8846)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>consumable</b><b> (CONF:1198-8847)</b>.
+        <ul>
+          <li>This consumable <b>SHALL</b> contain exactly one [1..1] Immunization Medication Information (V2)<b>
+              (identifier: 2.16.840.1.113883.10.20.22.4.54)</b><b> (CONF:1198-15546)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>performer</b><b> (CONF:1198-8849)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-31151)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-8850)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CSM"</b> (CodeSystem: <b>HL7ParticipationType
+              <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b>
+              (CONF:1198-8851)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Drug Vehicle<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.24)</b><b> (CONF:1198-15547)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-8853)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8854)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Indication (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.19)</b><b> (CONF:1198-15537)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1198-8856)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8857)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1198-8858)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Instruction (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.20)</b><b> (CONF:1198-31392)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1198-8860)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8861)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Supply Order (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.17)</b><b> (CONF:1198-15539)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1198-8863)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8864)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Dispense (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.18)</b><b> (CONF:1198-15540)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1198-8866)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CAUS"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8867)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Reaction Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1198-15541)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1198-8988)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8989)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Immunization Refusal Reason<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.53)</b><b> (CONF:1198-15542)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The following entryRelationship is used to indicate a given immunization's order in a series. The nested
+          Substance Administered Act identifies an administration in the series. The entryRelationship/sequenceNumber
+          shows the order of this particular administration in that series.<br></p> <b>SHOULD</b> contain zero or more
+        [0..*] <b>entryRelationship</b><b> (CONF:1198-31510)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1198-31511)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b><b> (CONF:1198-31512)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>sequenceNumber</b><b> (CONF:1198-31513)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Substance Administered Act<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.118)</b><b> (CONF:1198-31514)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>precondition</b><b> (CONF:1198-8869)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRCN"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8870)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Precondition for Substance Administration (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.25)</b><b> (CONF:1198-15548)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Immunization%20Activity%20(V3)_2.16.840.1.113883.10.20.22.4.52/Immunization%20Activity%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Immunization Activity (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Immunization%20Activity%20(V3)_2.16.840.1.113883.10.20.22.4.52/Immunization%20Activity%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Immunization Activity (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i> Immunizations</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i>
+          Immunizations</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.53.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.53.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,100 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Immunization Refusal Reason <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.53, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.53.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Immunization Refusal Reason <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.53,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.53.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Immunization Refusal Reason documents the rationale for the patient declining an immunization.</p></div>
+    <div id="description">
+      <p>The Immunization Refusal Reason documents the rationale for the patient declining an immunization.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-8991)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-8992)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8993)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.53"</b><b> (CONF:81-10500)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-8994)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet No Immunization Reason<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.19717/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.19717</a></b><b> DYNAMIC</b><b> (CONF:81-8995)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-8996)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:81-19104)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-8991)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-8992)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8993)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.53"</b><b>
+              (CONF:81-10500)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-8994)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected
+        from ValueSet No Immunization Reason<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.19717/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.19717</a></b><b> DYNAMIC</b><b>
+          (CONF:81-8995)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-8996)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:81-19104)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Immunization%20Refusal%20Reason_2.16.840.1.113883.10.20.22.4.53/Immunization%20Refusal%20Reason%20Example.xml"><i class="fab fa-github"></i>&nbsp;Immunization Refusal Reason Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Immunization%20Refusal%20Reason_2.16.840.1.113883.10.20.22.4.53/Immunization%20Refusal%20Reason%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Immunization Refusal Reason Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i> Immunizations</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i>
+          Immunizations</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.54.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.54.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,121 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Immunization Medication Information (V2) <small class="text-muted">[manufacturedProduct, 2.16.840.1.113883.10.20.22.4.54, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.54.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Immunization Medication Information (V2) <small class="text-muted">[manufacturedProduct,
+        2.16.840.1.113883.10.20.22.4.54, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.54.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Immunization Medication Information represents product information about the immunization substance. The vaccine manufacturer and vaccine lot number are typically recorded in the medical record and should be included if known.</p></div>
+    <div id="description">
+      <p>The Immunization Medication Information represents product information about the immunization substance. The
+        vaccine manufacturer and vaccine lot number are typically recorded in the medical record and should be included
+        if known.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.43.html">Planned Supply (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.17.html">Medication Supply Order (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.120.html">Planned Immunization Activity</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b> (CONF:1098-9002)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-9004)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.54"</b><b> (CONF:1098-10499)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32602)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>id</b><b> (CONF:1098-9005)</b>.</li>
-<li class="list-group-item"><p>lotNumberText should be included if known. It may not be known for historical immunizations, planned immunizations, or refused/deferred immunizations.</p> <b>SHALL</b> contain exactly one [1..1] <b>manufacturedMaterial</b><b> (CONF:1098-9006)</b>.<ul><li>This manufacturedMaterial <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet CVX Vaccines Administered Vaccine Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.6/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.6</a></b><b> DYNAMIC</b><b> (CONF:1098-9007)</b>.</li><ul><li>This code <b>MAY</b> contain zero or more [0..*] <b>translation</b>, which <b>MAY</b> be selected from ValueSet Vaccine Clinical Drug<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.8/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.8</a></b><b> DYNAMIC</b><b> (CONF:1098-31543)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or more [0..*] <b>translation</b><b> (CONF:1098-31881)</b>.</li></ul></ul><ul><li>This manufacturedMaterial <b>SHOULD</b> contain zero or one [0..1] <b>lotNumberText</b><b> (CONF:1098-9014)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>manufacturerOrganization</b><b> (CONF:1098-9012)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> (CodeSystem:
+        <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b>
+          (CONF:1098-9002)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-9004)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.54"</b><b>
+              (CONF:1098-10499)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32602)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>id</b><b> (CONF:1098-9005)</b>.</li>
+      <li class="list-group-item">
+        <p>lotNumberText should be included if known. It may not be known for historical immunizations, planned
+          immunizations, or refused/deferred immunizations.</p> <b>SHALL</b> contain exactly one [1..1]
+        <b>manufacturedMaterial</b><b> (CONF:1098-9006)</b>.<ul>
+          <li>This manufacturedMaterial <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be
+            selected from ValueSet CVX Vaccines Administered Vaccine Set<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.6/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.6</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-9007)</b>.</li>
+          <ul>
+            <li>This code <b>MAY</b> contain zero or more [0..*] <b>translation</b>, which <b>MAY</b> be selected from
+              ValueSet Vaccine Clinical Drug<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.8/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.8</a></b><b>
+                DYNAMIC</b><b> (CONF:1098-31543)</b>.</li>
+          </ul>
+          <ul>
+            <li>This code <b>MAY</b> contain zero or more [0..*] <b>translation</b><b> (CONF:1098-31881)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This manufacturedMaterial <b>SHOULD</b> contain zero or one [0..1] <b>lotNumberText</b><b>
+              (CONF:1098-9014)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>manufacturerOrganization</b><b>
+          (CONF:1098-9012)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Immunization%20Medication%20Information%20(V2)_2.16.840.1.113883.10.20.22.4.54/Immunization%20Medication%20Information%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Immunization Medication Information (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Immunization%20Medication%20Information%20(V2)_2.16.840.1.113883.10.20.22.4.54/Immunization%20Medication%20Information%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Immunization Medication Information (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i> Immunizations</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Immunizations"><i class="fas fa-external-link-alt"></i>
+          Immunizations</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.6.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.6.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,105 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Problem Status <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.6, release 2019-06-20, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.6.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Problem Status <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.6, release
+        2019-06-20, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.6.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Problem Status records the clinical status attributed to the problem.</p></div>
+    <div id="description">
+      <p>The Problem Status records the clinical status attributed to the problem.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-7357)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-7358)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7359)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.6"</b><b> (CONF:1198-10518)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-20"</b><b> (CONF:1198-32961)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19162)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"33999-4"</b> Status (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-19163)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7364)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19113)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Problem Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.68/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.68</a></b><b> DYNAMIC</b><b> (CONF:1198-7365)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-7357)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-7358)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-7359)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.6"</b><b>
+              (CONF:1198-10518)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-06-20"</b><b> (CONF:1198-32961)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19162)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"33999-4"</b> Status (CodeSystem:
+            <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-19163)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-7364)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19113)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Problem Status<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.80.68/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.80.68</a></b><b> DYNAMIC</b><b>
+          (CONF:1198-7365)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Problems"><i class="fas fa-external-link-alt"></i> Problems</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.60.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.60.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,130 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Coverage Activity (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.60, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.60.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Coverage Activity (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.60, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.60.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Coverage Activity groups the policy and authorization acts within a Payers Section to order the payment sources. A Coverage Activity contains one or more Policy Activities, each of which contains zero or more Authorization Activities. The Coverage Activity id is the ID from the patient's insurance card. The sequenceNumber/@value shows the policy order of preference.</p></div>
+    <div id="description">
+      <p>A Coverage Activity groups the policy and authorization acts within a Payers Section to order the payment
+        sources. A Coverage Activity contains one or more Policy Activities, each of which contains zero or more
+        Authorization Activities. The Coverage Activity id is the ID from the patient's insurance card. The
+        sequenceNumber/@value shows the policy order of preference.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.18.html">Payers Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.61.html">Policy Activity (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.18.html">Payers Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.61.html">Policy Activity (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-8872)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-8873)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8897)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.60"</b><b> (CONF:1198-10492)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32596)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8874)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-8876)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48768-6"</b> Payment sources<b> (CONF:1198-19160)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32156)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8875)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19094)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-8878)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8879)</b>.</li></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>sequenceNumber</b><b> (CONF:1198-17174)</b>.</li><ul><li>The sequenceNumber, if present, <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:1198-17175)</b>.</li></ul></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Policy Activity (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.61)</b><b> (CONF:1198-15528)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-8872)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-8873)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8897)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.60"</b><b>
+              (CONF:1198-10492)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32596)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8874)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-8876)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48768-6"</b> Payment sources<b>
+              (CONF:1198-19160)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32156)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8875)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19094)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-8878)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8879)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>sequenceNumber</b><b> (CONF:1198-17174)</b>.</li>
+          <ul>
+            <li>The sequenceNumber, if present, <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b>
+                (CONF:1198-17175)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Policy Activity (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.61)</b><b> (CONF:1198-15528)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Coverage%20Activity%20(V3)_2.16.840.1.113883.10.20.22.4.60/Coverage%20Activity%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Coverage Activity (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Coverage%20Activity%20(V3)_2.16.840.1.113883.10.20.22.4.60/Coverage%20Activity%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Coverage Activity (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.61.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.61.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,59 +52,353 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Policy Activity (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.61, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.61.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Policy Activity (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.61, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.61.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A policy activity represents the policy or program providing the coverage. The person for whom payment is being provided (i.e., the patient) is the covered party. The subscriber of the policy or program is represented as a participant that is the holder of the coverage. The payer is represented as the performer of the policy activity.</p></div>
+    <div id="description">
+      <p>A policy activity represents the policy or program providing the coverage. The person for whom payment is being
+        provided (i.e., the patient) is the covered party. The subscriber of the policy or program is represented as a
+        participant that is the holder of the coverage. The payer is represented as the performer of the policy
+        activity.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.60.html">Coverage Activity (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address (AD.US.FIELDED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.60.html">Coverage Activity (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address (AD.US.FIELDED)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-8898)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-8899)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8900)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.61"</b><b> (CONF:1198-10516)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32595)</b>.</li></ul></li>
-<li class="list-group-item"><p>This id is a unique identifier for the policy or program providing the coverage<br></p> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8901)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Health Insurance Type<b> 2.16.840.1.113883.3.88.12.3221.5.2</b><b> DYNAMIC</b><b> (CONF:1198-8903)</b>.<ul><li>This code <b>SHALL</b> contain at least one [1..*] <b>translation</b>, which <b>SHOULD</b> be selected from ValueSet Payer<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.3591/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.3591</a></b><b> (CONF:1198-32852)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8902)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19109)</b>.</li></ul></li>
-<li class="list-group-item"><p>This performer represents the Payer.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>performer</b><b> (CONF:1198-8906)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRF"</b> Performer (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8907)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16808)</b>.</li><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.87"</b> Payer Performer<b> (CONF:1198-16809)</b>.</li></ul></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-8908)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8909)</b>.</li></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-8914)</b>.</li><ul><li>The code, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Financially Responsible Party Type Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.10416/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.10416</a></b><b> DYNAMIC</b><b> (CONF:1198-15992)</b>.</li></ul></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-8910)</b>.</li></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1198-8911)</b>.</li></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>representedOrganization</b><b> (CONF:1198-8912)</b>.</li><ul><li>The representedOrganization, if present, <b>SHOULD</b> contain zero or one [0..1] <b>name</b><b> (CONF:1198-8913)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>This performer represents the Guarantor.<br></p> <b>SHOULD</b> contain zero or more [0..*] <b>performer</b>=<b>"PRF"</b> Performer (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8961)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16810)</b>.</li><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.88"</b> Guarantor Performer<b> (CONF:1198-16811)</b>.</li></ul></ul><ul><li><b>SHOULD</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-8963)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-8962)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-8968)</b>.</li><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"GUAR"</b> Guarantor<b> (CONF:1198-16096)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a>"</b><b> (CONF:1198-32165)</b>.</li></ul></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-8964)</b>.</li></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1198-8965)</b>.</li></ul><ul><li><p><strong>SHOULD</strong> include assignedEntity/assignedPerson/name AND/OR assignedEntity/representedOrganization/name (CONF:1198-8967).</p></li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>participant</b><b> (CONF:1198-8916)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COV"</b> Coverage target (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8917)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16812)</b>.</li><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.89"</b> Covered Party Participant<b> (CONF:1198-16814)</b>.</li></ul></ul><ul><li><b>SHOULD</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-8918)</b>.</li><ul><li>The time, if present, <b>SHOULD</b> contain zero or one [0..1] <b>low</b><b> (CONF:1198-8919)</b>.</li></ul><ul><li>The time, if present, <b>SHOULD</b> contain zero or one [0..1] <b>high</b><b> (CONF:1198-8920)</b>.</li></ul></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1198-8921)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8922)</b>.</li><ul><li><p>This id is a unique identifier for  the covered party member. Implementers <strong>SHOULD</strong> use the same GUID for each instance of a member identifier from the same health plan (CONF:1198-8984).</p></li></ul></ul><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-8923)</b>.</li><ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Coverage Role Type Value Set<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.18877/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.18877</a></b><b> DYNAMIC</b><b> (CONF:1198-16078)</b>.</li></ul></ul><ul><li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>addr</b><b> (CONF:1198-8956)</b>.</li><ul><li><p>The content of addr <strong>SHALL</strong> be a conformant US Realm Address (AD.US.FIELDED) (2.16.840.1.113883.10.20.22.5.2) (CONF:1198-10484).</p></li></ul></ul><ul><li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>playingEntity</b><b> (CONF:1198-8932)</b>.</li><ul><li>The playingEntity, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:1198-8930)</b>.</li></ul><ul><li>The playingEntity, if present, <b>SHALL</b> contain exactly one [1..1] <b>sdtc:birthTime</b><b> (CONF:1198-31344)</b>.</li><ul><li><p>The prefix sdtc: <strong>SHALL</strong> be bound to the namespace urn:hl7-org:sdtc. The use of the namespace provides a necessary extension to CDA R2 for the use of the birthTime element (CONF:1198-31345).</p></li></ul></ul></ul></ul></li>
-<li class="list-group-item"><p>When the Subscriber is the patient, the participant element describing the subscriber *SHALL NOT* be present. This information will be recorded instead in the data elements used to record member information.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>participant</b><b> (CONF:1198-8934)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"HLD"</b> Holder (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1198-8935)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16813)</b>.</li><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.90"</b> Policy Holder Participant<b> (CONF:1198-16815)</b>.</li></ul></ul><ul><li><b>MAY</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-8938)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1198-8936)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8937)</b>.</li><ul><li><p>This id is a unique identifier for the subscriber of the coverage (CONF:1198-10120).</p></li></ul></ul><ul><li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>addr</b><b> (CONF:1198-8925)</b>.</li><ul><li><p>The content of addr <strong>SHALL</strong> be a conformant US Realm Address (AD.US.FIELDED) (2.16.840.1.113883.10.20.22.5.2) (CONF:1198-10483).</p></li></ul></ul></ul><ul><li><p>When the Subscriber is the patient, the participant element describing the subscriber <strong>SHALL NOT</strong> be present. This information will be recorded instead in the data elements used to record member information (CONF:1198-17139).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-8939)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-8940)</b>.</li></ul><ul><li><p>The target of a policy activity with act/entryRelationship/@typeCode="REFR" <strong>SHALL</strong> be an authorization activity (templateId 2.16.840.1.113883.10.20.1.19) <em>OR</em> an act, with act[@classCode="ACT"] and act[@moodCode="DEF"], representing a description of the coverage plan (CONF:1198-8942).</p></li></ul><ul><li><p>A description of the coverage plan <strong>SHALL</strong> contain one or more act/id, to represent the plan identifier, and an act/text with the name of the plan (CONF:1198-8943).</p></li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-8898)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-8899)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-8900)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.61"</b><b>
+              (CONF:1198-10516)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32595)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This id is a unique identifier for the policy or program providing the coverage<br></p> <b>SHALL</b> contain
+        at least one [1..*] <b>id</b><b> (CONF:1198-8901)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHOULD</b> be selected
+        from ValueSet Health Insurance Type<b> 2.16.840.1.113883.3.88.12.3221.5.2</b><b> DYNAMIC</b><b>
+          (CONF:1198-8903)</b>.<ul>
+          <li>This code <b>SHALL</b> contain at least one [1..*] <b>translation</b>, which <b>SHOULD</b> be selected
+            from ValueSet Payer<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.3591/expansion/Latest" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.3591</a></b><b> (CONF:1198-32852)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-8902)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19109)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This performer represents the Payer.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>performer</b><b>
+          (CONF:1198-8906)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRF"</b> Performer (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1198-8907)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16808)</b>.</li>
+          <ul>
+            <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+              <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.87"</b> Payer Performer<b> (CONF:1198-16809)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-8908)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8909)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-8914)</b>.</li>
+            <ul>
+              <li>The code, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be
+                selected from ValueSet Financially Responsible Party Type Value Set<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.10416/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.10416</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-15992)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-8910)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1198-8911)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>representedOrganization</b><b>
+                (CONF:1198-8912)</b>.</li>
+            <ul>
+              <li>The representedOrganization, if present, <b>SHOULD</b> contain zero or one [0..1] <b>name</b><b>
+                  (CONF:1198-8913)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This performer represents the Guarantor.<br></p> <b>SHOULD</b> contain zero or more [0..*]
+        <b>performer</b>=<b>"PRF"</b> Performer (CodeSystem: <b>HL7ParticipationType <a
+            href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b>
+          (CONF:1198-8961)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16810)</b>.</li>
+          <ul>
+            <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+              <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.88"</b> Guarantor Performer<b> (CONF:1198-16811)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>SHOULD</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-8963)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-8962)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-8968)</b>.</li>
+            <ul>
+              <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"GUAR"</b> Guarantor<b>
+                  (CONF:1198-16096)</b>.</li>
+            </ul>
+            <ul>
+              <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"<a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a>"</b><b> (CONF:1198-32165)</b>.
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:1198-8964)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:1198-8965)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>
+              <p><strong>SHOULD</strong> include assignedEntity/assignedPerson/name AND/OR
+                assignedEntity/representedOrganization/name (CONF:1198-8967).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>participant</b><b> (CONF:1198-8916)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COV"</b> Coverage target (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1198-8917)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16812)</b>.</li>
+          <ul>
+            <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+              <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.89"</b> Covered Party Participant<b> (CONF:1198-16814)</b>.
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>SHOULD</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-8918)</b>.</li>
+          <ul>
+            <li>The time, if present, <b>SHOULD</b> contain zero or one [0..1] <b>low</b><b> (CONF:1198-8919)</b>.</li>
+          </ul>
+          <ul>
+            <li>The time, if present, <b>SHOULD</b> contain zero or one [0..1] <b>high</b><b> (CONF:1198-8920)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1198-8921)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8922)</b>.</li>
+            <ul>
+              <li>
+                <p>This id is a unique identifier for the covered party member. Implementers <strong>SHOULD</strong> use
+                  the same GUID for each instance of a member identifier from the same health plan (CONF:1198-8984).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-8923)</b>.</li>
+            <ul>
+              <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from
+                ValueSet Coverage Role Type Value Set<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.18877/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.18877</a></b><b>
+                  DYNAMIC</b><b> (CONF:1198-16078)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>addr</b><b> (CONF:1198-8956)</b>.</li>
+            <ul>
+              <li>
+                <p>The content of addr <strong>SHALL</strong> be a conformant US Realm Address (AD.US.FIELDED)
+                  (2.16.840.1.113883.10.20.22.5.2) (CONF:1198-10484).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>playingEntity</b><b>
+                (CONF:1198-8932)</b>.</li>
+            <ul>
+              <li>The playingEntity, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b>
+                  (CONF:1198-8930)</b>.</li>
+            </ul>
+            <ul>
+              <li>The playingEntity, if present, <b>SHALL</b> contain exactly one [1..1] <b>sdtc:birthTime</b><b>
+                  (CONF:1198-31344)</b>.</li>
+              <ul>
+                <li>
+                  <p>The prefix sdtc: <strong>SHALL</strong> be bound to the namespace urn:hl7-org:sdtc. The use of the
+                    namespace provides a necessary extension to CDA R2 for the use of the birthTime element
+                    (CONF:1198-31345).</p>
+                </li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>When the Subscriber is the patient, the participant element describing the subscriber *SHALL NOT* be present.
+          This information will be recorded instead in the data elements used to record member information.<br></p>
+        <b>SHOULD</b> contain zero or one [0..1] <b>participant</b><b> (CONF:1198-8934)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"HLD"</b> Holder (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1198-8935)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16813)</b>.</li>
+          <ul>
+            <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+              <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.90"</b> Policy Holder Participant<b> (CONF:1198-16815)</b>.
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li><b>MAY</b> contain zero or one [0..1] <b>time</b><b> (CONF:1198-8938)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1198-8936)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-8937)</b>.</li>
+            <ul>
+              <li>
+                <p>This id is a unique identifier for the subscriber of the coverage (CONF:1198-10120).</p>
+              </li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHOULD</b> contain zero or one [0..1] <b>addr</b><b> (CONF:1198-8925)</b>.</li>
+            <ul>
+              <li>
+                <p>The content of addr <strong>SHALL</strong> be a conformant US Realm Address (AD.US.FIELDED)
+                  (2.16.840.1.113883.10.20.22.5.2) (CONF:1198-10483).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+        <ul>
+          <li>
+            <p>When the Subscriber is the patient, the participant element describing the subscriber <strong>SHALL
+                NOT</strong> be present. This information will be recorded instead in the data elements used to record
+              member information (CONF:1198-17139).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-8939)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> Refers to (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-8940)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>The target of a policy activity with act/entryRelationship/@typeCode="REFR" <strong>SHALL</strong> be an
+              authorization activity (templateId 2.16.840.1.113883.10.20.1.19) <em>OR</em> an act, with
+              act[@classCode="ACT"] and act[@moodCode="DEF"], representing a description of the coverage plan
+              (CONF:1198-8942).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>A description of the coverage plan <strong>SHALL</strong> contain one or more act/id, to represent the
+              plan identifier, and an act/text with the name of the plan (CONF:1198-8943).</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Policy%20Activity%20(V3)_2.16.840.1.113883.10.20.22.4.61/Policy%20Activity%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Policy Activity (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Policy%20Activity%20(V3)_2.16.840.1.113883.10.20.22.4.61/Policy%20Activity%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Policy Activity (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.63.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.63.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,137 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Series Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.63, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.63.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Series Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.63, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.63.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Series Act contains the DICOM series information for referenced DICOM composite objects. The series information defines the attributes that are used to group composite instances into distinct logical sets. Each series is associated with exactly one study. Series Act clinical statements are only instantiated in the DICOM Object Catalog section inside a Study Act, and thus do not require a separate templateId; in other sections, the SOP Instance Observation is included directly.</p></div>
+    <div id="description">
+      <p>A Series Act contains the DICOM series information for referenced DICOM composite objects. The series
+        information defines the attributes that are used to group composite instances into distinct logical sets. Each
+        series is associated with exactly one study. Series Act clinical statements are only instantiated in the DICOM
+        Object Catalog section inside a Study Act, and thus do not require a separate templateId; in other sections, the
+        SOP Instance Observation is included directly.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.6.html">Study Act</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.6.html">Study Act</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9222)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-9223)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-10918)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.63"</b><b> (CONF:81-10919)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-9224)</b>.<ul><li>Such ids <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:81-9225)</b>.</li></ul><ul><li>Such ids <b>SHALL NOT</b> contain [0..0] <b>@extension</b><b> (CONF:81-9226)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19166)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"113015"</b><b> (CONF:81-19167)</b>.</li></ul><ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b> (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26461)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>qualifier</b><b> (CONF:81-26462)</b>.</li><ul><li>This qualifier <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:81-26463)</b>.</li><ul><li>This name <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"121139"</b> Modality<b> (CONF:81-26464)</b>.</li></ul><ul><li>This name <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b> (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26465)</b>.</li></ul></ul><ul><li>This qualifier <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:81-26466)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>text</b><b> (CONF:81-9233)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9235)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:81-9237)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9238)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  SOP Instance Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:81-15927)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-9222)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-9223)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-10918)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.63"</b><b>
+              (CONF:81-10919)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-9224)</b>.<ul>
+          <li>Such ids <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:81-9225)</b>.</li>
+        </ul>
+        <ul>
+          <li>Such ids <b>SHALL NOT</b> contain [0..0] <b>@extension</b><b> (CONF:81-9226)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19166)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"113015"</b><b> (CONF:81-19167)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b>
+            (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26461)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>qualifier</b><b> (CONF:81-26462)</b>.</li>
+          <ul>
+            <li>This qualifier <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:81-26463)</b>.</li>
+            <ul>
+              <li>This name <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"121139"</b> Modality<b>
+                  (CONF:81-26464)</b>.</li>
+            </ul>
+            <ul>
+              <li>This name <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b>
+                (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26465)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This qualifier <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:81-26466)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>text</b><b> (CONF:81-9233)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9235)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:81-9237)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9238)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] SOP Instance Observation<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:81-15927)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Series%20Act_2.16.840.1.113883.10.20.22.4.63/Series%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Series Act Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Series%20Act_2.16.840.1.113883.10.20.22.4.63/Series%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Series Act Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.64.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.64.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,118 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Comment Activity <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.64, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.64.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Comment Activity <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.64, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.64.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>Comments are free text data that cannot otherwise be recorded using data elements already defined by this specification. They are not to be used to record information that can be recorded elsewhere. For example, a free text description of the severity of an allergic reaction would not be recorded in a comment.</p></div>
+    <div id="description">
+      <p>Comments are free text data that cannot otherwise be recorded using data elements already defined by this
+        specification. They are not to be used to record information that can be recorded elsewhere. For example, a free
+        text description of the severity of an allergic reaction would not be recorded in a comment.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9425)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-9426)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9427)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.64"</b><b> (CONF:81-10491)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9428)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48767-8"</b> Annotation Comment<b> (CONF:81-19159)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26501)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-9430)</b>.<ul><li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:81-15967)</b>.</li><ul><li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:81-15968)</b>.</li><ul><li><p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:81-15969).</p></li></ul></ul></ul><ul><li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference/@value</b><b> (CONF:81-9431)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:81-9433)</b>.</li>
-<li class="list-group-item"> <p>Data elements defined elsewhere in the specification SHALL NOT be recorded using the Comment Activity (CONF:81-9429).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> Act
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-9425)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-9426)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9427)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.64"</b><b>
+              (CONF:81-10491)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9428)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"48767-8"</b> Annotation Comment<b>
+              (CONF:81-19159)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26501)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-9430)</b>.<ul>
+          <li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:81-15967)</b>.</li>
+          <ul>
+            <li>This reference <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:81-15968)</b>.</li>
+            <ul>
+              <li>
+                <p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using
+                  the approach defined in CDA Release 2, section 4.3.5.1) (CONF:81-15969).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+        <ul>
+          <li>This text <b>SHALL</b> contain exactly one [1..1] <b>reference/@value</b><b> (CONF:81-9431)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:81-9433)</b>.</li>
+      <li class="list-group-item">
+        <p>Data elements defined elsewhere in the specification SHALL NOT be recorded using the Comment Activity
+          (CONF:81-9429).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Comment%20Activity_2.16.840.1.113883.10.20.22.4.64/Comment%20Activity%20Example.xml"><i class="fab fa-github"></i>&nbsp;Comment Activity Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Comment%20Activity_2.16.840.1.113883.10.20.22.4.64/Comment%20Activity%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Comment Activity Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.65.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.65.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,111 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Preoperative Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.65, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.65.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Preoperative Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.65, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.65.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the surgical diagnosis or diagnoses assigned to the patient before the surgical procedure and is the reason for the surgery. The preoperative diagnosis is, in the opinion of the surgeon, the diagnosis that will be confirmed during surgery.</p></div>
+    <div id="description">
+      <p>This template represents the surgical diagnosis or diagnoses assigned to the patient before the surgical
+        procedure and is the reason for the surgery. The preoperative diagnosis is, in the opinion of the surgeon, the
+        diagnosis that will be confirmed during surgery.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.34.html">Preoperative Diagnosis Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.34.html">Preoperative Diagnosis Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b><b> (CONF:1198-10090)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b><b> (CONF:1198-10091)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16770)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.65"</b><b> (CONF:1198-16771)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32540)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19155)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10219-4"</b> Preoperative Diagnosis<b> (CONF:1198-19156)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32167)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-10093)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-10094)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15605)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b><b>
+          (CONF:1198-10090)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b><b>
+          (CONF:1198-10091)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-16770)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.65"</b><b>
+              (CONF:1198-16771)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32540)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19155)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10219-4"</b> Preoperative Diagnosis<b>
+              (CONF:1198-19156)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32167)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-10093)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-10094)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-15605)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Preoperative%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.65/Preoperative%20Diagnosis%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Preoperative Diagnosis (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Preoperative%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.65/Preoperative%20Diagnosis%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Preoperative Diagnosis (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.66.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.66.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,127 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Functional Status Organizer (V2) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.66, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.66.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Functional Status Organizer (V2) <small class="text-muted">[organizer,
+        2.16.840.1.113883.10.20.22.4.66, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.66.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template groups related functional status observations into categories (e.g., mobility, self-care).</p></div>
+    <div id="description">
+      <p>This template groups related functional status observations into categories (e.g., mobility, self-care).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.128.html">Self-Care Activities (ADL and IADL)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> Cluster (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1098-14355)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-14357)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14361)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.66"</b><b> (CONF:1098-14362)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32569)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-14363)</b>.</li>
-<li class="list-group-item"><p>The code selected should indicate the category that groups the contained functional status evaluation observations (e.g., mobility, self-care, communication).<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14364)</b>.<ul><li><p><strong>SHOULD</strong> be selected from ICF (codeSystem 2.16.840.1.113883.6.254) <em>OR</em> LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) (CONF:1098-31417).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14358)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31434)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31585)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1098-14359)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Functional Status Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.67)</b><b> (CONF:1098-14368)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1098-31432)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Self-Care Activities (ADL and IADL)<b> (identifier: 2.16.840.1.113883.10.20.22.4.128)</b><b> (CONF:1098-31433)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> Cluster
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+          (CONF:1098-14355)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-14357)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14361)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.66"</b><b>
+              (CONF:1098-14362)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32569)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-14363)</b>.</li>
+      <li class="list-group-item">
+        <p>The code selected should indicate the category that groups the contained functional status evaluation
+          observations (e.g., mobility, self-care, communication).<br></p> <b>SHALL</b> contain exactly one [1..1]
+        <b>code</b><b> (CONF:1098-14364)</b>.<ul>
+          <li>
+            <p><strong>SHOULD</strong> be selected from ICF (codeSystem 2.16.840.1.113883.6.254) <em>OR</em> LOINC (<a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) (CONF:1098-31417).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14358)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-31434)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31585)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1098-14359)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Functional Status Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.67)</b><b> (CONF:1098-14368)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1098-31432)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Self-Care Activities (ADL and IADL)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.128)</b><b> (CONF:1098-31433)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Functional%20Status%20Organizer%20(V2)_2.16.840.1.113883.10.20.22.4.66/Functional%20Status%20Organizer%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Functional Status Organizer (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Functional%20Status%20Organizer%20(V2)_2.16.840.1.113883.10.20.22.4.66/Functional%20Status%20Organizer%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Functional Status Organizer (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Functional%20Status"><i class="fas fa-external-link-alt"></i> Functional Status</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Functional%20Status"><i class="fas fa-external-link-alt"></i>
+          Functional Status</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.67.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.67.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,59 +52,164 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Functional Status Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.67, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.67.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Functional Status Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.67, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.67.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the patient's physical function (e.g., mobility status, instrumental activities of daily living, self-care status) and problems that limit function (dyspnea, dysphagia). The template may include assessment scale observations, identify supporting caregivers, and provide information about non-medicinal supplies. This template is used to represent physical or developmental function of all patient populations.</p></div>
+    <div id="description">
+      <p>This template represents the patient's physical function (e.g., mobility status, instrumental activities of
+        daily living, self-care status) and problems that limit function (dyspnea, dysphagia). The template may include
+        assessment scale observations, identify supporting caregivers, and provide information about non-medicinal
+        supplies. This template is used to represent physical or developmental function of all patient populations.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.66.html">Functional Status Organizer (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.66.html">Functional Status Organizer (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.50.html">Non-Medicinal Supply Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.72.html">Caregiver Characteristics</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-13905)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-13906)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-13889)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.67"</b><b> (CONF:1098-13890)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32568)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-13907)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-13908)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"54522-8"</b> Functional status<b> (CONF:1098-31522)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31523)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-13929)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19101)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-13930)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-13932)</b>.<ul><li><p>If xsi:type="CD", <strong>SHOULD</strong> contain a code from SNOMED CT (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1098-14234).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-13936)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-13892)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> refers to<b> (CONF:1098-14596)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Non-Medicinal Supply Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1098-14218)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-13895)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> refers to<b> (CONF:1098-14597)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Caregiver Characteristics<b> (identifier: 2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:1098-13897)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-14465)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component<b> (CONF:1098-14598)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1098-14466)</b>.</li></ul></li>
-<li class="list-group-item"><p>referenceRange could be used to represent normal or expected capability for the function being evaluated.<br></p> <b>MAY</b> contain zero or more [0..*] <b>referenceRange</b><b> (CONF:1098-13937)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-13905)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-13906)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-13889)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.67"</b><b>
+              (CONF:1098-13890)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32568)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-13907)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-13908)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"54522-8"</b> Functional status<b>
+              (CONF:1098-31522)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-31523)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-13929)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19101)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-13930)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-13932)</b>.<ul>
+          <li>
+            <p>If xsi:type="CD", <strong>SHOULD</strong> contain a code from SNOMED CT (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1098-14234).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-13936)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-13892)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> refers to<b> (CONF:1098-14596)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Non-Medicinal Supply Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.50)</b><b> (CONF:1098-14218)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-13895)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"REFR"</b> refers to<b> (CONF:1098-14597)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Caregiver Characteristics<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.72)</b><b> (CONF:1098-13897)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-14465)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component<b>
+              (CONF:1098-14598)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1098-14466)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>referenceRange could be used to represent normal or expected capability for the function being evaluated.<br>
+        </p> <b>MAY</b> contain zero or more [0..*] <b>referenceRange</b><b> (CONF:1098-13937)</b>.
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Functional%20Status%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.67/Functional%20Status%20Observation%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Functional Status Observation (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Functional%20Status%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.67/Functional%20Status%20Observation%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Functional Status Observation (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Functional%20Status"><i class="fas fa-external-link-alt"></i> Functional Status</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Functional%20Status"><i class="fas fa-external-link-alt"></i>
+          Functional Status</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.68.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.68.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,58 +52,159 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Functional Status Problem Observation (DEPRECATED) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.68, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.68.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Functional Status Problem Observation (DEPRECATED) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.68, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.68.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A functional status problem observation is a clinical statement that represents a patient's functional perfomance and ability.</p><p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p><p><em>Reason for deprecation</em>: Functional Status Problem Observation has been merged, without loss of expressivity, into Functional Status Observation (2.16.840.1.113883.10.20.22.4.67).</p></div>
+    <div id="description">
+      <p>A functional status problem observation is a clinical statement that represents a patient's functional
+        perfomance and ability.</p>
+      <p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION
+        GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p>
+      <p><em>Reason for deprecation</em>: Functional Status Problem Observation has been merged, without loss of
+        expressivity, into Functional Status Observation (2.16.840.1.113883.10.20.22.4.67).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br>
+          </td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-14282)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-14283)</b>.</li>
-<li class="list-group-item"><p>Use negationInd="true" to indicate that the problem was not observed.<br></p> <b>MAY</b> contain zero or one [0..1] <b>@negationInd</b><b> (CONF:1098-14307)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14312)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.68"</b><b> (CONF:1098-14313)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32601)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-14284)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14314)</b>.<ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>=<b>"248536006"</b> finding of functional performance and activity (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14315)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:1098-14304)</b>.<ul><li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1098-15552)</b>.</li><ul><li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:1098-15553)</b>.</li><ul><li><p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:1098-15554).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14286)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19100)</b>.</li></ul></li>
-<li class="list-group-item"><p>The value of effectiveTime/low represents onset date.</p><p>If the problem is resolved, record the resolution date in effectiveTime/high. If the problem is known to be resolved but the resolution date is not known, use @nullFlavor="UNK". If the problem is not resolved, do not include the high element.</p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-14287)</b>.<ul><li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-26456)</b>.</li></ul><ul><li>The effectiveTime, if present, <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-26457)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Problem<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b> DYNAMIC</b><b> (CONF:1098-14291)</b>.<ul><li>This value <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b><b> (CONF:1098-14292)</b>.</li><ul><li><p>If the diagnosis is unknown or the SNOMED code is unknown, @nullFlavor SHOULD be "UNK".  If the diagnosis is known but the code cannot be found in the Value Set, @nullFlavor SHOULD be "OTH" and the known diagnosis code SHOULD be placed in the translation element (CONF:1098-14293).</p></li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1098-14316)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-14282)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-14283)</b>.</li>
+      <li class="list-group-item">
+        <p>Use negationInd="true" to indicate that the problem was not observed.<br></p> <b>MAY</b> contain zero or one
+        [0..1] <b>@negationInd</b><b> (CONF:1098-14307)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14312)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.68"</b><b>
+              (CONF:1098-14313)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32601)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-14284)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14314)</b>.<ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>=<b>"248536006"</b> finding of functional
+            performance and activity (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b>
+              (CONF:1098-14315)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:1098-14304)</b>.<ul>
+          <li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1098-15552)</b>.
+          </li>
+          <ul>
+            <li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b>
+                (CONF:1098-15553)</b>.</li>
+            <ul>
+              <li>
+                <p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using
+                  the approach defined in CDA Release 2, section 4.3.5.1) (CONF:1098-15554).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14286)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19100)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The value of effectiveTime/low represents onset date.</p>
+        <p>If the problem is resolved, record the resolution date in effectiveTime/high. If the problem is known to be
+          resolved but the resolution date is not known, use @nullFlavor="UNK". If the problem is not resolved, do not
+          include the high element.</p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-14287)</b>.<ul>
+          <li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>low</b><b>
+              (CONF:1098-26456)</b>.</li>
+        </ul>
+        <ul>
+          <li>The effectiveTime, if present, <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-26457)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet Problem<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-14291)</b>.<ul>
+          <li>This value <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b><b> (CONF:1098-14292)</b>.</li>
+          <ul>
+            <li>
+              <p>If the diagnosis is unknown or the SNOMED code is unknown, @nullFlavor SHOULD be "UNK". If the
+                diagnosis is known but the code cannot be found in the Value Set, @nullFlavor SHOULD be "OTH" and the
+                known diagnosis code SHOULD be placed in the translation element (CONF:1098-14293).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>methodCode</b><b> (CONF:1098-14316)</b>.
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Functional%20Status"><i class="fas fa-external-link-alt"></i> Functional Status</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Functional%20Status"><i class="fas fa-external-link-alt"></i>
+          Functional Status</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
 
-</body></html>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.69.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.69.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,86 +24,200 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Assessment Scale Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.69, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.69.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Assessment Scale Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.69, release 2022-06-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.69.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>An assessment scale is a collection of observations that together can yield a calculated or non-calculated summary evaluation of a one or more conditions. Examples include the Braden Scale (assesses pressure ulcer risk), APACHE Score (estimates mortality in critically ill patients), Mini-Mental Status Exam (assesses cognitive function), APGAR Score (assesses the health of a newborn), Glasgow Coma Scale (assesses coma and impaired consciousness), and WE CARE (Well Child Care, Evaluation, Community Resources, Advocacy, Referral, Education - a clinic-based screening and referral system developed for pediatric settings).</p><p>When an Assessment Scale Observation is contained in a Problem Observation, a Social History Observation or a Procedure instance that is Social Determinant of Health focused, that Assessment scale <strong>MAY</strong> contain assessment scale observations that represent question and answer pairs from SDOH screening instruments that are represented in LOINC. Note that guidance on the use of LOINC in assessment scales already exists in Assessment Scale Observation constraints and Assessment Scale Supporting Observations constraints.</p></div>
+    <div id="description">
+      <p>An assessment scale is a collection of observations that together can yield a calculated or non-calculated
+        summary evaluation of a one or more conditions. Examples include the Braden Scale (assesses pressure ulcer
+        risk), APACHE Score (estimates mortality in critically ill patients), Mini-Mental Status Exam (assesses
+        cognitive function), APGAR Score (assesses the health of a newborn), Glasgow Coma Scale (assesses coma and
+        impaired consciousness), and WE CARE (Well Child Care, Evaluation, Community Resources, Advocacy, Referral,
+        Education - a clinic-based screening and referral system developed for pediatric settings).</p>
+      <p>When an Assessment Scale Observation is contained in a Problem Observation, a Social History Observation or a
+        Procedure instance that is Social Determinant of Health focused, that Assessment scale <strong>MAY</strong>
+        contain assessment scale observations that represent question and answer pairs from SDOH screening instruments
+        that are represented in LOINC. Note that guidance on the use of LOINC in assessment scales already exists in
+        Assessment Scale Observation constraints and Assessment Scale Supporting Observations constraints.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.86.html">Assessment Scale Supporting Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.86.html">Assessment Scale Supporting
+              Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-14434)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-14435)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-14436)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.69"</b><b> (CONF:4515-14437)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-33037)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-14438)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> DYNAMIC</b><b> (CONF:4515-14439)</b>.</li>
-<li class="list-group-item"><p>Such derivation expression can contain a text calculation of how the components total up to the summed score <br></p> <b>MAY</b> contain zero or one [0..1] <b>derivationExpr</b><b> (CONF:4515-14637)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-14444)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:4515-19088)</b>.</li></ul></li>
-<li class="list-group-item"><p>Represents clinically effective time of the measurement, which may be when the measurement was performed (e.g., a BP measurement), or may be when sample was taken (and measured some time afterwards) <br></p> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-14445)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:4515-14450)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>interpretationCode</b><b> (CONF:4515-14459)</b>.<ul><li>The interpretationCode, if present, <b>MAY</b> contain zero or more [0..*] <b>translation</b><b> (CONF:4515-14888)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>author</b><b> (CONF:4515-14460)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:4515-14451)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component<b> (CONF:4515-16741)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Supporting Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.86)</b><b> (CONF:4515-16742)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>referenceRange</b><b> (CONF:4515-16799)</b>.<ul><li>The referenceRange, if present, <b>SHALL</b> contain exactly one [1..1] <b>observationRange</b><b> (CONF:4515-16800)</b>.</li><ul><li>The text may contain a description of the scale (e.g., for a Pain Scale 1 to 10: 1 to 3 = little pain, 4 to 7= moderate pain, 8 to 10 = severe pain) <br/>This observationRange <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:4515-16801)</b>.</li><ul><li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:4515-16802)</b>.</li><ul><li>The reference, if present, <b>MAY</b> contain zero or one [0..1] <b>@value</b><b> (CONF:4515-16803)</b>.</li><ul><li><p>This reference/@value <b>SHALL</b> begin with a '#' and <b>SHALL</b> point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:4515-16804).</p></li></ul></ul></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:4515-14434)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4515-14435)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-14436)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.69"</b><b>
+              (CONF:4515-14437)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-33037)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-14438)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected
+        from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> DYNAMIC</b><b>
+          (CONF:4515-14439)</b>.</li>
+      <li class="list-group-item">
+        <p>Such derivation expression can contain a text calculation of how the components total up to the summed score
+          <br></p> <b>MAY</b> contain zero or one [0..1] <b>derivationExpr</b><b> (CONF:4515-14637)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-14444)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:4515-19088)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Represents clinically effective time of the measurement, which may be when the measurement was performed
+          (e.g., a BP measurement), or may be when sample was taken (and measured some time afterwards) <br></p>
+        <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-14445)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:4515-14450)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>interpretationCode</b><b>
+          (CONF:4515-14459)</b>.<ul>
+          <li>The interpretationCode, if present, <b>MAY</b> contain zero or more [0..*] <b>translation</b><b>
+              (CONF:4515-14888)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>author</b><b> (CONF:4515-14460)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:4515-14451)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component<b>
+              (CONF:4515-16741)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Supporting Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.86)</b><b> (CONF:4515-16742)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>referenceRange</b><b>
+          (CONF:4515-16799)</b>.<ul>
+          <li>The referenceRange, if present, <b>SHALL</b> contain exactly one [1..1] <b>observationRange</b><b>
+              (CONF:4515-16800)</b>.</li>
+          <ul>
+            <li>The text may contain a description of the scale (e.g., for a Pain Scale 1 to 10: 1 to 3 = little pain, 4
+              to 7= moderate pain, 8 to 10 = severe pain) <br />This observationRange <b>SHOULD</b> contain zero or one
+              [0..1] <b>text</b><b> (CONF:4515-16801)</b>.</li>
+            <ul>
+              <li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b>
+                  (CONF:4515-16802)</b>.</li>
+              <ul>
+                <li>The reference, if present, <b>MAY</b> contain zero or one [0..1] <b>@value</b><b>
+                    (CONF:4515-16803)</b>.</li>
+                <ul>
+                  <li>
+                    <p>This reference/@value <b>SHALL</b> begin with a '#' and <b>SHALL</b> point to its corresponding
+                      narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:4515-16804).</p>
+                  </li>
+                </ul>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	    <ul id="guide_examples">
-        <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20Scale%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.69/Assessment%20Scale%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Assessment Scale Observation Example</a></li>
-        <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20Scale%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.69/Assessment%20Scale%20Observation%20-%20Hunger%20Vital%20Signs%20Example.xml"><i class="fab fa-github"></i>&nbsp;Assessment Scale Observation - Hunger Vital Signs Example</a></li>
-      </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20Scale%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.69/Assessment%20Scale%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Assessment Scale Observation Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20Scale%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.69/Assessment%20Scale%20Observation%20-%20Hunger%20Vital%20Signs%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Assessment Scale Observation - Hunger Vital Signs Example</a></li>
+    </ul>
     <br>
 
     <h4 id="cdasearch">CDA Search Examples</h4>
-    <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Mental%20Status"><i class="fas fa-external-link-alt"></i>Mental Status (contains examples with Assessment Scale)</a></li></ul>
-  
-  </ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Mental%20Status"><i class="fas fa-external-link-alt"></i>Mental
+          Status (contains examples with Assessment Scale)</a></li>
+    </ul>
+
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.7.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.7.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,62 +52,257 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Allergy - Intolerance Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.7, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.7.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Allergy - Intolerance Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.7, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.7.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template reflects a discrete observation about a patient's allergy or intolerance. Because it is a discrete observation, it will have a statusCode of "completed". The effectiveTime, also referred to as the "biologically relevant time" is the time at which the observation holds for the patient. For a provider seeing a patient in the clinic today, observing a history of penicillin allergy that developed five years ago, the effectiveTime is five years ago.</p><p>The effectiveTime of the Allergy - Intolerance Observation is the definitive indication of whether or not the underlying allergy/intolerance is resolved. If known to be resolved, then an effectiveTime/high would be present. If the date of resolution is not known, then effectiveTime/high will be present with a nullFlavor of "UNK".</p><p>The agent responsible for an allergy or adverse reaction is not always a manufactured material (for example, food allergies), nor is it necessarily consumed. The following constraints reflect limitations in the base CDA R2 specification, and should be used to represent any type of responsible agent, i.e., use playingEntity classCode = "MMAT" for all agents, manufactured or not.</p></div>
+    <div id="description">
+      <p>This template reflects a discrete observation about a patient's allergy or intolerance. Because it is a
+        discrete observation, it will have a statusCode of "completed". The effectiveTime, also referred to as the
+        "biologically relevant time" is the time at which the observation holds for the patient. For a provider seeing a
+        patient in the clinic today, observing a history of penicillin allergy that developed five years ago, the
+        effectiveTime is five years ago.</p>
+      <p>The effectiveTime of the Allergy - Intolerance Observation is the definitive indication of whether or not the
+        underlying allergy/intolerance is resolved. If known to be resolved, then an effectiveTime/high would be
+        present. If the date of resolution is not known, then effectiveTime/high will be present with a nullFlavor of
+        "UNK".</p>
+      <p>The agent responsible for an allergy or adverse reaction is not always a manufactured material (for example,
+        food allergies), nor is it necessarily consumed. The following constraints reflect limitations in the base CDA
+        R2 specification, and should be used to represent any type of responsible agent, i.e., use playingEntity
+        classCode = "MMAT" for all agents, manufactured or not.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.30.html">Allergy Concern Act (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.8.html">Severity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.145.html">Criticality Observation </a><br><a href="2.16.840.1.113883.10.20.22.4.28.html">Allergy Status Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.30.html">Allergy Concern Act (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.8.html">Severity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.145.html">Criticality Observation </a><br><a
+              href="2.16.840.1.113883.10.20.22.4.28.html">Allergy Status Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Substance or Device Allergy - Intolerance Observation (V2) template (urn:hl7ii:2.16.840.1.113883.10.20.24.3.90:2014-06-09)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7379)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-7380)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@negationInd</b><b> (CONF:1098-31526)</b>.<br>Note: Use negationInd="true" to indicate that the allergy was not observed.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7381)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.7"</b><b> (CONF:1098-10488)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32526)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7382)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15947)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b> (CONF:1098-15948)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-32153)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-19084)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19085)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-7387)</b>.<br>Note: If the allergy/intolerance is known to be resolved, but the date of resolution is not known, then the high element SHALL be present, and the nullFlavor attribute SHALL be set to 'UNK'. <ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-31538)</b>.<br>Note: The effectiveTime/low (a.k.a. "onset date") asserts when the allergy/intolerance became biologically active.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-31539)</b>.<br>Note: The effectiveTime/high (a.k.a. "resolution date") asserts when the allergy/intolerance became biologically resolved.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Allergy and Intolerance Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.6.2/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.6.2</a></b><b> DYNAMIC</b><b> (CONF:1098-7390)</b>.<br>Note: The consumable participant points to the precise allergen or substance of intolerance. Because the consumable and the reaction are more clinically relevant than a categorization of the allergy/adverse event type, many systems will simply assign a fixed value here (e.g., "allergy to substance"). </li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31143)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>participant</b><b> (CONF:1098-7402)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CSM"</b> Consumable (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1098-7403)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1098-7404)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> Manufactured Product (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b> (CONF:1098-7405)</b>.</li></ul><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b> (CONF:1098-7406)</b>.</li><ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MMAT"</b> Manufactured Material (CodeSystem: <b>HL7EntityClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b><b> STATIC</b>)<b> (CONF:1098-7407)</b>.</li></ul><ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Substance Reactant for Intolerance<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.1</a></b><b> DYNAMIC</b><b> (CONF:1098-7419)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-32939)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32940)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-32941)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergy Status Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.28)</b><b> (CONF:1098-32942)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD NOT</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-9961)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-9962)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-9964)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Severity Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.8)</b><b> (CONF:1098-15956)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-7447)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"MFST"</b> Is Manifestation of (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7907)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7449)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Reaction Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1098-15955)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-32910)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32911)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-32912)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Criticality Observation <b> (identifier: 2.16.840.1.113883.10.20.22.4.145)</b><b> (CONF:1098-32913)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Substance or Device Allergy - Intolerance Observation (V2) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.24.3.90:2014-06-09)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-7379)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7380)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@negationInd</b><b>
+          (CONF:1098-31526)</b>.<br>Note: Use negationInd="true" to indicate that the allergy was not observed.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7381)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.7"</b><b>
+              (CONF:1098-10488)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32526)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7382)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-15947)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b>
+              (CONF:1098-15948)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:1098-32153)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-19084)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19085)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-7387)</b>.<br>Note: If the allergy/intolerance is known to be resolved, but the date of resolution
+        is not known, then the high element SHALL be present, and the nullFlavor attribute SHALL be set to 'UNK'. <ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-31538)</b>.<br>Note:
+            The effectiveTime/low (a.k.a. "onset date") asserts when the allergy/intolerance became biologically active.
+          </li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-31539)</b>.<br>Note:
+            The effectiveTime/high (a.k.a. "resolution date") asserts when the allergy/intolerance became biologically
+            resolved.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Allergy and Intolerance Type<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.6.2/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.6.2</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-7390)</b>.<br>Note: The consumable participant points to the precise allergen or
+        substance of intolerance. Because the consumable and the reaction are more clinically relevant than a
+        categorization of the allergy/adverse event type, many systems will simply assign a fixed value here (e.g.,
+        "allergy to substance"). </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31143)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>participant</b><b> (CONF:1098-7402)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CSM"</b> Consumable (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1098-7403)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1098-7404)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b>
+              Manufactured Product (CodeSystem: <b>HL7RoleClass <a
+                  href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b>
+                (CONF:1098-7405)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b>
+                (CONF:1098-7406)</b>.</li>
+            <ul>
+              <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MMAT"</b>
+                Manufactured Material (CodeSystem: <b>HL7EntityClass <a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b><b> STATIC</b>)<b>
+                  (CONF:1098-7407)</b>.</li>
+            </ul>
+            <ul>
+              <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected
+                from ValueSet Substance Reactant for Intolerance<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.1/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.1</a></b><b>
+                  DYNAMIC</b><b> (CONF:1098-7419)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-32939)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32940)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-32941)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Allergy Status Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.28)</b><b> (CONF:1098-32942)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD NOT</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-9961)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-9962)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-9964)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Severity Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.8)</b><b> (CONF:1098-15956)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-7447)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"MFST"</b> Is Manifestation of (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7907)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7449)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Reaction Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1098-15955)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-32910)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32911)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-32912)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Criticality Observation <b> (identifier:
+              2.16.840.1.113883.10.20.22.4.145)</b><b> (CONF:1098-32913)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Allergy%20-%20Intolerance%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.7/Allergy%20-%20Intolerance%20Observation%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Allergy - Intolerance Observation (V2) ExampleAllergy Concern Act (V3)_2.16.840.1.113883.10.20.22.4.30</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Allergy%20-%20Intolerance%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.7/Allergy%20-%20Intolerance%20Observation%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Allergy - Intolerance Observation (V2) ExampleAllergy Concern Act
+          (V3)_2.16.840.1.113883.10.20.22.4.30</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Allergies"><i class="fas fa-external-link-alt"></i> Allergies</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.70.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.70.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,62 +52,263 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Pressure Ulcer Observation (DEPRECATED) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.70, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.70.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Pressure Ulcer Observation (DEPRECATED) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.70, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.70.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The pressure ulcer observation contains details about the pressure ulcer such as the stage of the ulcer, location, and dimensions. If the pressure ulcer is a diagnosis, you may find this on the problem list. An example of how this would appear is in the Problem Section.</p><p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p><p><em>Reason for deprecation</em>: This template has been replaced by Longitudinal Care Wound Observation (2.16.840.1.113883.10.20.22.4.114).</p></div>
+    <div id="description">
+      <p>The pressure ulcer observation contains details about the pressure ulcer such as the stage of the ulcer,
+        location, and dimensions. If the pressure ulcer is a diagnosis, you may find this on the problem list. An
+        example of how this would appear is in the Problem Section.</p>
+      <p>THIS TEMPLATE HAS BEEN DEPRECATED IN C-CDA R2 AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION
+        GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p>
+      <p><em>Reason for deprecation</em>: This template has been replaced by Longitudinal Care Wound Observation
+        (2.16.840.1.113883.10.20.22.4.114).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br>
+          </td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-14383)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-14384)</b>.</li>
-<li class="list-group-item"><p>Use negationInd="true" to indicate that the problem was not observed.<br></p> <b>MAY</b> contain zero or one [0..1] <b>@negationInd</b><b> (CONF:1098-14385)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14387)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.70"</b><b> (CONF:1098-14388)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32594)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-14389)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14759)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-14760)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:1098-14391)</b>.<ul><li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1098-14392)</b>.</li><ul><li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:1098-15585)</b>.</li><ul><li><p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:1098-15586).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14394)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19111)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-14395)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Pressure Ulcer Stage<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.35/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.35</a></b><b> STATIC</b> 2014-09-01<b> (CONF:1098-14396)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>targetSiteCode</b><b> (CONF:1098-14797)</b>.<ul><li>The targetSiteCode, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Pressure Point <b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.36/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.36</a></b><b> STATIC</b><b> (CONF:1098-14798)</b>.</li></ul><ul><li>The targetSiteCode, if present, <b>SHOULD</b> contain zero or one [0..1] <b>qualifier</b><b> (CONF:1098-14799)</b>.</li><ul><li>The qualifier, if present, <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:1098-14800)</b>.</li><ul><li>This name <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>=<b>"272741003"</b> laterality (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14801)</b>.</li></ul></ul><ul><li>The qualifier, if present, <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1098-14802)</b>.</li><ul><li>This value <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet TargetSite Qualifiers<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.37/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.37</a></b><b> STATIC</b> 2014-09-01<b> (CONF:1098-14803)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-14410)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-14411)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1098-14619)</b>.</li><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-14685)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-14686)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14620)</b>.</li><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"401238003"</b> Length of Wound (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14621)</b>.</li></ul></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b> (CONF:1098-14622)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-14601)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b><b> (CONF:1098-14602)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1098-14623)</b>.</li><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-14687)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-14688)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14624)</b>.</li><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"401239006"</b> Width of Wound (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14625)</b>.</li></ul></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b> (CONF:1098-14626)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-14605)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b><b> (CONF:1098-14606)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1098-14627)</b>.</li><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-14689)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-14690)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14628)</b>.</li><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"425094009"</b> Depth of Wound (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14629)</b>.</li></ul></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b> (CONF:1098-14630)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1098-14383)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-14384)</b>.</li>
+      <li class="list-group-item">
+        <p>Use negationInd="true" to indicate that the problem was not observed.<br></p> <b>MAY</b> contain zero or one
+        [0..1] <b>@negationInd</b><b> (CONF:1098-14385)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14387)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.70"</b><b>
+              (CONF:1098-14388)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32594)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-14389)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14759)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion (CodeSystem:
+            <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b><b> STATIC</b>)<b>
+              (CONF:1098-14760)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:1098-14391)</b>.<ul>
+          <li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1098-14392)</b>.
+          </li>
+          <ul>
+            <li>The reference, if present, <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b>
+                (CONF:1098-15585)</b>.</li>
+            <ul>
+              <li>
+                <p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using
+                  the approach defined in CDA Release 2, section 4.3.5.1) (CONF:1098-15586).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14394)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19111)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-14395)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet Pressure Ulcer Stage<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.35/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.35</a></b><b> STATIC</b> 2014-09-01<b>
+          (CONF:1098-14396)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>targetSiteCode</b><b>
+          (CONF:1098-14797)</b>.<ul>
+          <li>The targetSiteCode, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b>
+            be selected from ValueSet Pressure Point <b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.36/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.36</a></b><b>
+              STATIC</b><b> (CONF:1098-14798)</b>.</li>
+        </ul>
+        <ul>
+          <li>The targetSiteCode, if present, <b>SHOULD</b> contain zero or one [0..1] <b>qualifier</b><b>
+              (CONF:1098-14799)</b>.</li>
+          <ul>
+            <li>The qualifier, if present, <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:1098-14800)</b>.
+            </li>
+            <ul>
+              <li>This name <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>=<b>"272741003"</b> laterality
+                (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14801)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>The qualifier, if present, <b>SHALL</b> contain exactly one [1..1] <b>value</b><b>
+                (CONF:1098-14802)</b>.</li>
+            <ul>
+              <li>This value <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from
+                ValueSet TargetSite Qualifiers<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.37/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.37</a></b><b>
+                  STATIC</b> 2014-09-01<b> (CONF:1098-14803)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-14410)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-14411)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1098-14619)</b>.</li>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+              <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+                (CONF:1098-14685)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+                (CONF:1098-14686)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14620)</b>.</li>
+            <ul>
+              <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"401238003"</b> Length of Wound
+                (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14621)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b>
+                (CONF:1098-14622)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-14601)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b><b> (CONF:1098-14602)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1098-14623)</b>.</li>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+              <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+                (CONF:1098-14687)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+                (CONF:1098-14688)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14624)</b>.</li>
+            <ul>
+              <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"401239006"</b> Width of Wound
+                (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14625)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b>
+                (CONF:1098-14626)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-14605)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b><b> (CONF:1098-14606)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1098-14627)</b>.</li>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+              <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+                (CONF:1098-14689)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+                (CONF:1098-14690)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14628)</b>.</li>
+            <ul>
+              <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"425094009"</b> Depth of Wound
+                (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14629)</b>.</li>
+            </ul>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b>
+                (CONF:1098-14630)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.72.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.72.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,144 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Caregiver Characteristics <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.72, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.72.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Caregiver Characteristics <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.72,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.72.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement represents a caregiver'??s willingness to provide care and the abilities of that caregiver to provide assistance to a patient in relation to a specific need.</p></div>
+    <div id="description">
+      <p>This clinical statement represents a caregiver'??s willingness to provide care and the abilities of that
+        caregiver to provide assistance to a patient in relation to a specific need.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.67.html">Functional Status Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-14219)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-14220)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-14221)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.72"</b><b> (CONF:81-14222)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-14223)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-14230)</b>.<ul><li><p>This code MAY be drawn from LOINC (CodeSystem: LOINC <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)  or MAY be bound to ASSERTION (CodeSystem: ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp; STATIC) (CONF:81-26513).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-14233)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:81-19090)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b> (CONF:81-14599)</b>.<ul><li><p>The code <strong>SHALL</strong> be selected from LOINC (codeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or SNOMED CT (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:81-14600).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>participant</b><b> (CONF:81-14227)</b>.<ul><li>Such participants <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b><b> (CONF:81-26451)</b>.</li></ul><ul><li>Such participants <b>MAY</b> contain zero or one [0..1] <b>time</b><b> (CONF:81-14830)</b>.</li><ul><li>The time, if present, <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:81-14831)</b>.</li></ul><ul><li>The time, if present, <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:81-14832)</b>.</li></ul></ul><ul><li>Such participants <b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:81-14228)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CAREGIVER"</b><b> (CONF:81-14229)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:81-14219)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-14220)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-14221)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.72"</b><b>
+              (CONF:81-14222)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-14223)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-14230)</b>.<ul>
+          <li>
+            <p>This code MAY be drawn from LOINC (CodeSystem: LOINC <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or MAY be bound to ASSERTION
+              (CodeSystem: ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp; STATIC)
+              (CONF:81-26513).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:81-14233)</b>.<ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:81-19090)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b>
+          (CONF:81-14599)</b>.<ul>
+          <li>
+            <p>The code <strong>SHALL</strong> be selected from LOINC (codeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>) or SNOMED CT (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:81-14600).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>participant</b><b> (CONF:81-14227)</b>.
+        <ul>
+          <li>Such participants <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"IND"</b><b>
+              (CONF:81-26451)</b>.</li>
+        </ul>
+        <ul>
+          <li>Such participants <b>MAY</b> contain zero or one [0..1] <b>time</b><b> (CONF:81-14830)</b>.</li>
+          <ul>
+            <li>The time, if present, <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:81-14831)</b>.</li>
+          </ul>
+          <ul>
+            <li>The time, if present, <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:81-14832)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li>Such participants <b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:81-14228)</b>.
+          </li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CAREGIVER"</b><b>
+                (CONF:81-14229)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Caregiver%20Characteristics_2.16.840.1.113883.10.20.22.4.72/Caregiver%20Characteristics%20Example.xml"><i class="fab fa-github"></i>&nbsp;Caregiver Characteristics Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Caregiver%20Characteristics_2.16.840.1.113883.10.20.22.4.72/Caregiver%20Characteristics%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Caregiver Characteristics Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.73.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.73.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,59 +52,150 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Cognitive Status Problem Observation (DEPRECATED) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.73, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.73.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Cognitive Status Problem Observation (DEPRECATED) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.73, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.73.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A cognitive status problem observation is a clinical statement that describes a patient's cognitive condition, findings, or symptoms. Examples of cognitive problem observations are inability to recall, amnesia, dementia, and aggressive behavior.</p><p>A cognitive problem observation is a finding or medical condition. This is different from a cognitive result observation, which is a response to a question that provides insight into the patient's cognitive status, judgement, comprehension ability, or response speed.</p><p>THIS TEMPLATE HAS BEEN DEPRECATED AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION GUIDE. USE OF THIS TEMPLATE IS NOT RECOMMENDED.</p><p><em>Reason for deprecation</em>: Cognitive Status Problem Observation has been merged, without loss of expressivity, into Mental Status Observation (2.16.840.1.113883.10.20.22.4.74).</p></div>
+    <div id="description">
+      <p>A cognitive status problem observation is a clinical statement that describes a patient's cognitive condition,
+        findings, or symptoms. Examples of cognitive problem observations are inability to recall, amnesia, dementia,
+        and aggressive behavior.</p>
+      <p>A cognitive problem observation is a finding or medical condition. This is different from a cognitive result
+        observation, which is a response to a question that provides insight into the patient's cognitive status,
+        judgement, comprehension ability, or response speed.</p>
+      <p>THIS TEMPLATE HAS BEEN DEPRECATED AND MAY BE DELETED FROM A FUTURE RELEASE OF THIS IMPLEMENTATION GUIDE. USE OF
+        THIS TEMPLATE IS NOT RECOMMENDED.</p>
+      <p><em>Reason for deprecation</em>: Cognitive Status Problem Observation has been merged, without loss of
+        expressivity, into Mental Status Observation (2.16.840.1.113883.10.20.22.4.74).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.14.html">Functional Status Section (V2)</a><br>
+          </td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-14319)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-14320)</b>.</li>
-<li class="list-group-item"><p>Use negationInd="true" to indicate that the problem was not observed.<br></p> <b>MAY</b> contain zero or one [0..1] <b>@negationInd</b><b> (CONF:1098-14344)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14346)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.73"</b><b> (CONF:1098-14347)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32600)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-14321)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14804)</b>.<ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>=<b>"373930000"</b> Cognitive function finding   (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14805)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:1098-14341)</b>.<ul><li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1098-15532)</b>.</li><ul><li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:1098-15533)</b>.</li><ul><li><p>SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:1098-15534).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14323)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19091)</b>.</li></ul></li>
-<li class="list-group-item"><p>The value of effectiveTime/low represents onset date.</p><p>If the problem is resolved, record the resolution date in effectiveTime/high. If the problem is known to be resolved but the resolution date is not known, use @nullFlavor="UNK". If the problem is not resolved, do not include the high element.</p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-14324)</b>.<ul><li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-26458)</b>.</li></ul><ul><li>The effectiveTime, if present, <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-26459)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Problem<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b> DYNAMIC</b><b> (CONF:1098-14349)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>methodCode</b><b> (CONF:1098-14693)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-14319)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-14320)</b>.</li>
+      <li class="list-group-item">
+        <p>Use negationInd="true" to indicate that the problem was not observed.<br></p> <b>MAY</b> contain zero or one
+        [0..1] <b>@negationInd</b><b> (CONF:1098-14344)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14346)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.73"</b><b>
+              (CONF:1098-14347)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32600)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-14321)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-14804)</b>.<ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>=<b>"373930000"</b> Cognitive function
+            finding (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1098-14805)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:1098-14341)</b>.<ul>
+          <li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:1098-15532)</b>.
+          </li>
+          <ul>
+            <li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b>
+                (CONF:1098-15533)</b>.</li>
+            <ul>
+              <li>
+                <p>SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in
+                  CDA Release 2, section 4.3.5.1) (CONF:1098-15534).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14323)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19091)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The value of effectiveTime/low represents onset date.</p>
+        <p>If the problem is resolved, record the resolution date in effectiveTime/high. If the problem is known to be
+          resolved but the resolution date is not known, use @nullFlavor="UNK". If the problem is not resolved, do not
+          include the high element.</p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-14324)</b>.<ul>
+          <li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>low</b><b>
+              (CONF:1098-26458)</b>.</li>
+        </ul>
+        <ul>
+          <li>The effectiveTime, if present, <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-26459)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet Problem<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-14349)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>methodCode</b><b> (CONF:1098-14693)</b>.
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.74.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.74.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,156 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Mental Status Observation (V3) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.74, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.74.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Mental Status Observation (V3) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.74, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.74.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Mental Status Observation template represents an observation about mental status that can come from a broad range of subjective and objective information (including measured data) to address those categories described in the Mental Status Section. See also Assessment Scale Observation for specific collections of observations that together yield a summary evaluation of a particular condition.</p></div>
+    <div id="description">
+      <p>The Mental Status Observation template represents an observation about mental status that can come from a broad
+        range of subjective and objective information (including measured data) to address those categories described in
+        the Mental Status Section. See also Assessment Scale Observation for specific collections of observations that
+        together yield a summary evaluation of a particular condition.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.75.html">Mental Status Organizer (V3)</a><br><a href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.75.html">Mental Status Organizer (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.69.html">Assessment Scale Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-14249)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-14250)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14255)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.74"</b><b> (CONF:1198-14256)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32565)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14257)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14591)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"373930000"</b> Cognitive function<b> (CONF:1198-32788)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-32789)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32790)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75275-8"</b> Cognitive Function<b> (CONF:1198-32791)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-32792)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-14254)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19092)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-14261)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1198-14263)</b>.<ul><li><p>If xsi:type="CD", <strong>SHOULD</strong> contain a code from SNOMED CT (CodeSystem: <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1198-14271).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-14266)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1198-14469)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-14595)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Assessment Scale Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1198-14470)</b>.</li></ul></li>
-<li class="list-group-item"><p>The referenceRange could be used to represent normal or expected capability for the mental function being evaluated.<br></p> <b>MAY</b> contain zero or more [0..*] <b>referenceRange</b><b> (CONF:1198-14267)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-14249)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-14250)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14255)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.74"</b><b>
+              (CONF:1198-14256)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32565)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14257)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14591)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"373930000"</b> Cognitive function<b>
+              (CONF:1198-32788)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b>)<b> (CONF:1198-32789)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32790)</b> such that it
+          </li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75275-8"</b> Cognitive Function<b>
+                (CONF:1198-32791)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem:
+              <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:1198-32792)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-14254)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19092)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1198-14261)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:1198-14263)</b>.<ul>
+          <li>
+            <p>If xsi:type="CD", <strong>SHOULD</strong> contain a code from SNOMED CT (CodeSystem: <a
+                href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1198-14271).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1198-14266)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1198-14469)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> has component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-14595)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Assessment Scale Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.69)</b><b> (CONF:1198-14470)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The referenceRange could be used to represent normal or expected capability for the mental function being
+          evaluated.<br></p> <b>MAY</b> contain zero or more [0..*] <b>referenceRange</b><b> (CONF:1198-14267)</b>.
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Mental%20Status%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.74/Mental%20Status%20Observation%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Mental Status Observation (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Mental%20Status%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.74/Mental%20Status%20Observation%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Mental Status Observation (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Mental%20Status"><i class="fas fa-external-link-alt"></i> Mental Status</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Mental%20Status"><i class="fas fa-external-link-alt"></i> Mental
+          Status</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.75.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.75.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,133 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Mental Status Organizer (V3) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.75, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.75.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Mental Status Organizer (V3) <small class="text-muted">[organizer, 2.16.840.1.113883.10.20.22.4.75,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.75.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Mental Status Organizer template may be used to group related Mental Status Observations (e.g., results of mental tests) and associated Assessment Scale Observations into subcategories and/or groupings by time. Subcategories can be things such as Mood and Affect, Behavior, Thought Process, Perception, Cognition, etc.</p></div>
+    <div id="description">
+      <p>The Mental Status Organizer template may be used to group related Mental Status Observations (e.g., results of
+        mental tests) and associated Assessment Scale Observations into subcategories and/or groupings by time.
+        Subcategories can be things such as Mood and Affect, Behavior, Thought Process, Perception, Cognition, etc.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.2.56.html">Mental Status Section (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.74.html">Mental Status Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> Cluster (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:1198-14369)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-14371)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14375)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.75"</b><b> (CONF:1198-14376)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32566)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14377)</b>.</li>
-<li class="list-group-item"><p>The code selected indicates the category that groups the contained mental status observations (e.g., communication, learning and applying knowledge).<br></p> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14378)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:1198-14697)</b>.</li><ul><li><p><strong>SHOULD</strong> be selected from ICF (codeSystem 2.16.840.1.113883.6.254) <em>OR</em> LOINC (codeSystem <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1198-14698).</p></li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-14372)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19093)</b>.</li></ul></li>
-<li class="list-group-item"><p>The effectiveTime is an interval that spans the effectiveTimes of the contained mental status observations. Because all contained mental status observations have a required time stamp, it is not required that this effectiveTime be populated.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1198-32424)</b>.<ul><li><p>The Organizer <strong>SHALL</strong> have at least one of <em>code</em> or <em>effectiveTime</em> (CONF:1198-32426).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-14373)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1]  Mental Status Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:1198-14381)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"CLUSTER"</b> Cluster
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b>
+          (CONF:1198-14369)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-14371)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14375)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.75"</b><b>
+              (CONF:1198-14376)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32566)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14377)</b>.</li>
+      <li class="list-group-item">
+        <p>The code selected indicates the category that groups the contained mental status observations (e.g.,
+          communication, learning and applying knowledge).<br></p> <b>SHALL</b> contain exactly one [1..1]
+        <b>code</b><b> (CONF:1198-14378)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:1198-14697)</b>.</li>
+          <ul>
+            <li>
+              <p><strong>SHOULD</strong> be selected from ICF (codeSystem 2.16.840.1.113883.6.254) <em>OR</em> LOINC
+                (codeSystem <a href="https://terminology.hl7.org/CodeSystem-v3-snomed-CT.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.96</a>) (CONF:1198-14698).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-14372)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19093)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime is an interval that spans the effectiveTimes of the contained mental status observations.
+          Because all contained mental status observations have a required time stamp, it is not required that this
+          effectiveTime be populated.<br></p> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1198-32424)</b>.<ul>
+          <li>
+            <p>The Organizer <strong>SHALL</strong> have at least one of <em>code</em> or <em>effectiveTime</em>
+              (CONF:1198-32426).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>component</b><b> (CONF:1198-14373)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Mental Status Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.74)</b><b> (CONF:1198-14381)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Mental%20Status%20Organizer%20(V3)_2.16.840.1.113883.10.20.22.4.75/Mental%20Status%20Organizer%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Mental Status Organizer (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Mental%20Status%20Organizer%20(V3)_2.16.840.1.113883.10.20.22.4.75/Mental%20Status%20Organizer%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Mental Status Organizer (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Mental%20Status"><i class="fas fa-external-link-alt"></i> Mental Status</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Mental%20Status"><i class="fas fa-external-link-alt"></i> Mental
+          Status</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.76.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.76.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,58 +52,162 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Number of Pressure Ulcers Observation (V3) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.76, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.76.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Number of Pressure Ulcers Observation (V3) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.76, release 2015-08-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.76.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the number of pressure ulcers observed at a particular stage.</p></div>
+    <div id="description">
+      <p>This template represents the number of pressure ulcers observed at a particular stage.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation
+              (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-14705)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-14706)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14707)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.76"</b><b> (CONF:1198-14708)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32604)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14709)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14767)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"2264892003"</b> Number of pressure ulcers<b> (CONF:1198-14768)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b> (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1198-32164)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32849)</b> such that it</li><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75277-4"</b> Number of pressure ulcers<b> (CONF:1198-32850)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32851)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-14714)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19108)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-14715)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="INT"<b> (CONF:1198-14771)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>author</b><b> (CONF:1198-14717)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>entryRelationship</b><b> (CONF:1198-14718)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-14719)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1198-14720)</b>.</li><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-14721)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-14722)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b>=<b>"ASSERTION"</b> Assertion (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1198-31930)</b>.</li></ul><ul><li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet Pressure Ulcer Stage<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.35/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.35</a></b><b> DYNAMIC</b><b> (CONF:1198-14725)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1198-14705)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-14706)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14707)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.76"</b><b>
+              (CONF:1198-14708)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32604)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14709)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14767)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"2264892003"</b> Number of pressure
+            ulcers<b> (CONF:1198-14768)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.96"</b>
+            (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1198-32164)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>translation</b><b> (CONF:1198-32849)</b> such that it
+          </li>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"75277-4"</b> Number of pressure ulcers<b>
+                (CONF:1198-32850)</b>.</li>
+          </ul>
+          <ul>
+            <li><b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem:
+              <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32851)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-14714)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19108)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1198-14715)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="INT"<b>
+          (CONF:1198-14771)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>author</b><b> (CONF:1198-14717)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>entryRelationship</b><b>
+          (CONF:1198-14718)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-14719)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>observation</b><b> (CONF:1198-14720)</b>.</li>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+              <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+                (CONF:1198-14721)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+              <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+                (CONF:1198-14722)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>code</b>=<b>"ASSERTION"</b> Assertion
+              (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+                (CONF:1198-31930)</b>.</li>
+          </ul>
+          <ul>
+            <li>This observation <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+              code <b>SHOULD</b> be selected from ValueSet Pressure Ulcer Stage<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.35/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.35</a></b><b>
+                DYNAMIC</b><b> (CONF:1198-14725)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Number%20of%20Pressure%20Ulcers%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.76/Number%20of%20Pressure%20Ulcers%20Observation%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Number of Pressure Ulcers Observation (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Number%20of%20Pressure%20Ulcers%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.76/Number%20of%20Pressure%20Ulcers%20Observation%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Number of Pressure Ulcers Observation (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.77.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.77.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,95 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Highest Pressure Ulcer Stage <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.77, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.77.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Highest Pressure Ulcer Stage <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.77,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.77.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This observation contains a description of the wound tissue of the most severe or highest staged pressure ulcer observed on a patient.</p></div>
+    <div id="description">
+      <p>This observation contains a description of the wound tissue of the most severe or highest staged pressure ulcer
+        observed on a patient.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.114.html">Longitudinal Care Wound Observation
+              (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-14726)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-14727)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-14728)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.77"</b><b> (CONF:81-14729)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-14730)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-14731)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"420905001"</b> Highest Pressure Ulcer Stage (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:81-14732)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:81-14733)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:81-14726)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-14727)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-14728)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.77"</b><b>
+              (CONF:81-14729)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-14730)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-14731)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"420905001"</b> Highest Pressure Ulcer
+            Stage (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:81-14732)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:81-14733)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Highest%20Pressure%20Ulcer%20Stage_2.16.840.1.113883.10.20.22.4.77/Highest%20Pressure%20Ulcer%20Stage%20Example.xml"><i class="fab fa-github"></i>&nbsp;Highest Pressure Ulcer Stage Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Highest%20Pressure%20Ulcer%20Stage_2.16.840.1.113883.10.20.22.4.77/Highest%20Pressure%20Ulcer%20Stage%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Highest Pressure Ulcer Stage Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.78.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.78.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,155 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Smoking Status - Meaningful Use (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.78, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.78.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Smoking Status - Meaningful Use (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.78, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.78.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the current smoking status of the patient as specified in Meaningful Use (MU) Stage 2 requirements. Historic smoking status observations as well as details about the smoking habit (e.g., how many per day) would be represented in the Tobacco Use template.</p><p>This template represents a "snapshot in time" observation, simply reflecting what the patient's current smoking status is at the time of the observation. As a result, the effectiveTime is constrained to a time stamp, and will approximately correspond with the author/time. Details regarding the time period when the patient is/was smoking would be recorded in the Tobacco Use template.</p><p>If the patient's current smoking status is unknown, the value element must be populated with SNOMED CT code 266927001 to communicate "Unknown if ever smoked" from the Current Smoking Status Value Set.</p></div>
+    <div id="description">
+      <p>This template represents the current smoking status of the patient as specified in Meaningful Use (MU) Stage 2
+        requirements. Historic smoking status observations as well as details about the smoking habit (e.g., how many
+        per day) would be represented in the Tobacco Use template.</p>
+      <p>This template represents a "snapshot in time" observation, simply reflecting what the patient's current smoking
+        status is at the time of the observation. As a result, the effectiveTime is constrained to a time stamp, and
+        will approximately correspond with the author/time. Details regarding the time period when the patient is/was
+        smoking would be recorded in the Tobacco Use template.</p>
+      <p>If the patient's current smoking status is unknown, the value element must be populated with SNOMED CT code
+        266927001 to communicate "Unknown if ever smoked" from the Current Smoking Status Value Set.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-14806)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-14807)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14815)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.78"</b><b> (CONF:1098-14816)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32573)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32401)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19170)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"72166-2"</b> Tobacco smoking status NHIS<b> (CONF:1098-31039)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32157)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14809)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19116)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-31928)</b>.<br>Note: This template represents a "snapshot in time" observation, simply reflecting what the patient's current smoking status is at the time of the observation. As a result, the effectiveTime is constrained to just a time stamp, and will approximately correspond with the author/time.<ul><li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>low</b><b> (CONF:1098-32894)</b>.</li></ul><ul><li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>width</b><b> (CONF:1098-32895)</b>.</li></ul><ul><li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>high</b><b> (CONF:1098-32896)</b>.</li></ul><ul><li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>center</b><b> (CONF:1098-32897)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b> (CONF:1098-14810)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Smoking Status<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.38/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.38</a></b><b> DYNAMIC</b><b> (CONF:1098-14817)</b>.</li></ul><ul><li><p>If the patient's current smoking status is unknown, @code <strong>SHALL</strong> contain '266927001' (Unknown if ever smoked) from ValueSet Current Smoking Status (<a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.38/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.38 </a>STATIC 2014-09-01) (CONF:1098-31019).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31148)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-14806)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-14807)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-14815)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.78"</b><b>
+              (CONF:1098-14816)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32573)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32401)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19170)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"72166-2"</b> Tobacco smoking status
+            NHIS<b> (CONF:1098-31039)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32157)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-14809)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19116)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-31928)</b>.<br>Note: This template represents a "snapshot in time" observation, simply reflecting
+        what the patient's current smoking status is at the time of the observation. As a result, the effectiveTime is
+        constrained to just a time stamp, and will approximately correspond with the author/time.<ul>
+          <li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>low</b><b> (CONF:1098-32894)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>width</b><b> (CONF:1098-32895)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>high</b><b> (CONF:1098-32896)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>SHALL NOT</b> contain [0..0] <b>center</b><b> (CONF:1098-32897)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b>
+          (CONF:1098-14810)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet Smoking Status<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.38/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.38</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-14817)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>If the patient's current smoking status is unknown, @code <strong>SHALL</strong> contain '266927001'
+              (Unknown if ever smoked) from ValueSet Current Smoking Status (<a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.38/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.38 </a>STATIC
+              2014-09-01) (CONF:1098-31019).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31148)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Smoking%20Status%20-%20Meaningful%20Use%20(V2)_2.16.840.1.113883.10.20.22.4.78/Smoking%20Status%20-%20Meaningful%20Use%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Smoking Status - Meaningful Use (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Smoking%20Status%20-%20Meaningful%20Use%20(V2)_2.16.840.1.113883.10.20.22.4.78/Smoking%20Status%20-%20Meaningful%20Use%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Smoking Status - Meaningful Use (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social History</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social
+          History</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.79.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.79.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,139 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Deceased Observation (V3) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.79, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.79.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Deceased Observation (V3) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.79,
+        release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.79.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the observation that a patient has died. It also represents the cause of death, indicated by an entryRelationship type of 'CAUS'. This template allows for more specific representation of data than is available with the use of dischargeDispositionCode.</p></div>
+    <div id="description">
+      <p>This template represents the observation that a patient has died. It also represents the cause of death,
+        indicated by an entryRelationship type of 'CAUS'. This template allows for more specific representation of data
+        than is available with the use of dischargeDispositionCode.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-14851)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-14852)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14871)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.79"</b><b> (CONF:1198-14872)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32541)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14873)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14853)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b> (CONF:1198-19135)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1198-32158)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-14854)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1198-19095)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1198-14855)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-14874)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b> (CONF:1198-14857)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"419099009"</b> Dead (CodeSystem: <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1198-15142)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1198-14868)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CAUS"</b> Is etiology for (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-14875)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1198-32900)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-14870)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1198-14851)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-14852)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14871)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.79"</b><b>
+              (CONF:1198-14872)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32541)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-14873)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-14853)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b>
+              (CONF:1198-19135)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:1198-32158)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1198-14854)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1198-19095)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1198-14855)</b>.<ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1198-14874)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b>
+          (CONF:1198-14857)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"419099009"</b> Dead (CodeSystem:
+            <b>SNOMED CT 2.16.840.1.113883.6.96</b><b> STATIC</b>)<b> (CONF:1198-15142)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1198-14868)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CAUS"</b> Is etiology for (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-14875)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1198-32900)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-14870)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Deceased%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.79/Deceased%20Observation%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Deceased Observation (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Deceased%20Observation%20(V3)_2.16.840.1.113883.10.20.22.4.79/Deceased%20Observation%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Deceased Observation (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.8.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.8.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,54 +52,123 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Severity Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.8, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.8.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Severity Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.8,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.8.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement represents the gravity of the reaction. The Severity Observation characterizes the Reaction Observation. A person may manifest many symptoms in a reaction to a single substance, and each reaction to the substance can be represented. However, each reaction observation can have only one severity observation associated with it. For example, someone may have a rash reaction observation as well as an itching reaction observation, but each can have only one level of severity.</p><p>Note the severity observation is no longer recommended for use with the Allergy and Intolerance Observation. The Criticality Observation is preferred for characterizing the Allergy and Intolerance.</p></div>
+    <div id="description">
+      <p>This clinical statement represents the gravity of the reaction. The Severity Observation characterizes the
+        Reaction Observation. A person may manifest many symptoms in a reaction to a single substance, and each reaction
+        to the substance can be represented. However, each reaction observation can have only one severity observation
+        associated with it. For example, someone may have a rash reaction observation as well as an itching reaction
+        observation, but each can have only one level of severity.</p>
+      <p>Note the severity observation is no longer recommended for use with the Allergy and Intolerance Observation.
+        The Criticality Observation is preferred for characterizing the Allergy and Intolerance.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation (V2)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation
+              (V2)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7345)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-7346)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7347)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.8"</b><b> (CONF:1098-10525)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32577)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19168)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"SEV"</b> Severity<b> (CONF:1098-19169)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-32170)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7352)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19115)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Reaction Severity<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.6.8/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.6.8</a></b><b> DYNAMIC</b><b> (CONF:1098-7356)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-7345)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7346)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7347)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.8"</b><b>
+              (CONF:1098-10525)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32577)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19168)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"SEV"</b> Severity<b>
+              (CONF:1098-19169)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:1098-32170)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7352)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19115)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Reaction Severity<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.6.8/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.6.8</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-7356)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Severity%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.8/Severity%20Observation%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Severity Observation (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Severity%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.8/Severity%20Observation%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Severity Observation (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.80.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.80.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,116 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Encounter Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.80, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.80.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Encounter Diagnosis (V3) <small class="text-muted">[act, 2.16.840.1.113883.10.20.22.4.80, release
+        2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.80.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template wraps relevant problems or diagnoses at the close of a visit or that need to be followed after the visit. If the encounter is associated with a Hospital Discharge, the Hospital Discharge Diagnosis must be used. This entry requires at least one Problem Observation entry.</p></div>
+    <div id="description">
+      <p>This template wraps relevant problems or diagnoses at the close of a visit or that need to be followed after
+        the visit. If the encounter is associated with a Hospital Discharge, the Hospital Discharge Diagnosis must be
+        used. This entry requires at least one Problem Observation entry.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.49.html">Encounter Activity (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.4.html">Problem Observation (V3)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1198-14889)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1198-14890)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14895)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.80"</b><b> (CONF:1198-14896)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32542)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19182)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29308-4"</b> Diagnosis<b> (CONF:1198-19183)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32160)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:1198-14892)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1198-14893)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Problem Observation (V3)<b> (identifier: 2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-14898)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:1198-14889)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1198-14890)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-14895)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.80"</b><b>
+              (CONF:1198-14896)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32542)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1198-19182)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"29308-4"</b> Diagnosis<b>
+              (CONF:1198-19183)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1198-32160)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:1198-14892)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1198-14893)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Problem Observation (V3)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.4)</b><b> (CONF:1198-14898)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Encounter%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.80/Encounter%20Diagnosis%20(V3)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Encounter Diagnosis (V3) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Encounter%20Diagnosis%20(V3)_2.16.840.1.113883.10.20.22.4.80/Encounter%20Diagnosis%20(V3)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Encounter Diagnosis (V3) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Encounters"><i class="fas fa-external-link-alt"></i> Encounters</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Encounters"><i class="fas fa-external-link-alt"></i> Encounters</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.85.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.85.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,137 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Tobacco Use (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.85, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.85.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Tobacco Use (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.85, release
+        2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.85.pdf"><i class="fas fa-file-pdf"></i> view
+          pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents a patient's tobacco use.</p><p>All the types of tobacco use are represented using the codes from the tobacco use and exposure-finding hierarchy in SNOMED CT, including codes required for recording smoking status in Meaningful Use Stage 2.</p><p>The effectiveTime element is used to describe dates associated with the patient's tobacco use. Whereas the Smoking Status - Meaningful Use (V2) template (2.16.840.1.113883.10.20.22.4.78) represents a "snapshot in time" observation, simply reflecting what the patient's current smoking status is at the time of the observation, this Tobacco Use template uses effectiveTime to represent the biologically relevant time of the observation. Thus, to record a former smoker, an observation of "cigarette smoker" will have an effectiveTime/low defining the time the patient started to smoke cigarettes and an effectiveTime/high defining the time the patient ceased to smoke cigarettes. To record a current smoker, the effectiveTime/low will define the time the patient started smoking and will have no effectiveTime/high to indicated that the patient is still smoking.</p></div>
+    <div id="description">
+      <p>This template represents a patient's tobacco use.</p>
+      <p>All the types of tobacco use are represented using the codes from the tobacco use and exposure-finding
+        hierarchy in SNOMED CT, including codes required for recording smoking status in Meaningful Use Stage 2.</p>
+      <p>The effectiveTime element is used to describe dates associated with the patient's tobacco use. Whereas the
+        Smoking Status - Meaningful Use (V2) template (2.16.840.1.113883.10.20.22.4.78) represents a "snapshot in time"
+        observation, simply reflecting what the patient's current smoking status is at the time of the observation, this
+        Tobacco Use template uses effectiveTime to represent the biologically relevant time of the observation. Thus, to
+        record a former smoker, an observation of "cigarette smoker" will have an effectiveTime/low defining the time
+        the patient started to smoke cigarettes and an effectiveTime/high defining the time the patient ceased to smoke
+        cigarettes. To record a current smoker, the effectiveTime/low will define the time the patient started smoking
+        and will have no effectiveTime/high to indicated that the patient is still smoking.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.2.17.html">Social History Section (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-16558)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-16559)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16566)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.85"</b><b> (CONF:1098-16567)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32589)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32400)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19174)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11367-0"</b> History of tobacco use<b> (CONF:1098-19175)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32172)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-16561)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19118)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-16564)</b>.<br>Note: The effectiveTime represents the biologically relevant time of the observation. A "former smoker" is recorded with the proper code "current smoker" with an effectiveTime/low and effectiveTime/high  defining the time during which the patient was a smoker.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-16565)</b>.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-31431)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Tobacco Use<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.41/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.41</a></b><b> DYNAMIC</b><b> (CONF:1098-16562)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31152)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-16558)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-16559)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16566)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.85"</b><b>
+              (CONF:1098-16567)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32589)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-32400)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-19174)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11367-0"</b> History of tobacco use<b>
+              (CONF:1098-19175)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:1098-32172)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-16561)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19118)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-16564)</b>.<br>Note: The effectiveTime represents the biologically relevant time of the
+        observation. A "former smoker" is recorded with the proper code "current smoker" with an effectiveTime/low and
+        effectiveTime/high defining the time during which the patient was a smoker.<ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-16565)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-31431)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Tobacco Use<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.41/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.41</a></b><b> DYNAMIC</b><b>
+          (CONF:1098-16562)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31152)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Tobacco%20Use%20(V2)_2.16.840.1.113883.10.20.22.4.85/Tobacco%20Use%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Tobacco Use (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Tobacco%20Use%20(V2)_2.16.840.1.113883.10.20.22.4.85/Tobacco%20Use%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Tobacco Use (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.86.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.86.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,79 +24,140 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Assessment Scale Supporting Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.86, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.86.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Assessment Scale Supporting Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.22.4.86, release 2022-06-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.4.86.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>An Assessment Scale Supporting Observation represents the components of a scale used in an Assessment Scale Observation. The individual parts that make up the component may be a group of physical, cognitive, functional status, social observations or answers to questions.</p></div>
+    <div id="description">
+      <p>An Assessment Scale Supporting Observation represents the components of a scale used in an Assessment Scale
+        Observation. The individual parts that make up the component may be a group of physical, cognitive, functional
+        status, social observations or answers to questions.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-16715)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-16716)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-16722)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.86"</b><b> (CONF:4515-16723)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-33036)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-16724)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> DYNAMIC</b><b> (CONF:4515-19178)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-16720)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:4515-19089)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>value</b><b> (CONF:4515-16754)</b>.<ul><li><p>If xsi:type="CD", MAY have a translation code to further specify the source if the instrument has an applicable code system and value set for the integer (CONF:14639) (CONF:4515-16755).</p></li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:4515-16715)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4515-16716)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-16722)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.86"</b><b>
+              (CONF:4515-16723)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-33036)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-16724)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>SHALL</b> be selected
+        from CodeSystem <b>LOINC (<a href="https://terminology.hl7.org/CodeSystem-v3-loinc.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.1</a>)</b><b> DYNAMIC</b><b>
+          (CONF:4515-19178)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-16720)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:4515-19089)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>value</b><b> (CONF:4515-16754)</b>.<ul>
+          <li>
+            <p>If xsi:type="CD", MAY have a translation code to further specify the source if the instrument has an
+              applicable code system and value set for the integer (CONF:14639) (CONF:4515-16755).</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	  <ul id="guide_examples">
-      <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20Scale%20Supporting%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.86/Assessment%20Scale%20Supporting%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Assessment Scale Supporting Observation Example</a></li>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Assessment%20Scale%20Supporting%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.86/Assessment%20Scale%20Supporting%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Assessment Scale Supporting Observation Example</a></li>
     </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.4.9.html
+++ b/templates/2.16.840.1.113883.10.20.22.4.9.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,59 +52,188 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Reaction Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.9, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.9.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Reaction Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.22.4.9,
+        release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.4.9.pdf"><i class="fas fa-file-pdf"></i>
+          view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This clinical statement represents the response to an undesired symptom, finding, etc. due to administered or exposed substance. A reaction can be defined described with respect to its severity, and can have been treated by one or more interventions.</p></div>
+    <div id="description">
+      <p>This clinical statement represents the response to an undesired symptom, finding, etc. due to administered or
+        exposed substance. A reaction can be defined described with respect to its severity, and can have been treated
+        by one or more interventions.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.8.html">Severity Observation (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.13.html">Procedure Activity Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.7.html">Allergy - Intolerance Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.24.3.90.html">Substance or Device Allergy - Intolerance Observation
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.52.html">Immunization Activity (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.14.html">Procedure Activity Procedure (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.16.html">Medication Activity (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.8.html">Severity Observation (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-7325)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-7326)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7323)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.9"</b><b> (CONF:1098-10523)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32504)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7329)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-16851)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b><b> (CONF:1098-31124)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-32169)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7328)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b> STATIC</b>)<b> (CONF:1098-19114)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:1098-7332)</b>.<ul><li>The effectiveTime, if present, <b>SHOULD</b> contain zero or one [0..1] <b>low</b><b> (CONF:1098-7333)</b>.</li></ul><ul><li>The effectiveTime, if present, <b>SHOULD</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-7334)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Problem<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b> DYNAMIC</b><b> (CONF:1098-7335)</b>.</li>
-<li class="list-group-item"><p>This procedure activity is intended to contain information about procedures that were performed in response to an allergy reaction.</p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-7337)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7338)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7343)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Procedure Activity Procedure (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-15920)</b>.</li></ul></li>
-<li class="list-group-item"><p>This medication activity is intended to contain information about medications that were administered in response to an allergy reaction.</p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-7340)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7341)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7344)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Medication Activity (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15921)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-7580)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-7581)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> TRUE<b> (CONF:1098-10375)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Severity Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.8)</b><b> (CONF:1098-15922)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-7325)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-7326)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-7323)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.4.9"</b><b>
+              (CONF:1098-10523)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32504)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-7329)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-16851)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b><b>
+              (CONF:1098-31124)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:1098-32169)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-7328)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b><b>
+              STATIC</b>)<b> (CONF:1098-19114)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b>
+          (CONF:1098-7332)</b>.<ul>
+          <li>The effectiveTime, if present, <b>SHOULD</b> contain zero or one [0..1] <b>low</b><b>
+              (CONF:1098-7333)</b>.</li>
+        </ul>
+        <ul>
+          <li>The effectiveTime, if present, <b>SHOULD</b> contain zero or one [0..1] <b>high</b><b>
+              (CONF:1098-7334)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Problem<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.7.4/expansion/Latest"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.7.4</a></b><b>
+          DYNAMIC</b><b> (CONF:1098-7335)</b>.</li>
+      <li class="list-group-item">
+        <p>This procedure activity is intended to contain information about procedures that were performed in response
+          to an allergy reaction.</p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-7337)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7338)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7343)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Procedure Activity Procedure (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.14)</b><b> (CONF:1098-15920)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This medication activity is intended to contain information about medications that were administered in
+          response to an allergy reaction.</p> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-7340)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7341)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-7344)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Medication Activity (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.16)</b><b> (CONF:1098-15921)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-7580)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-7581)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> TRUE<b> (CONF:1098-10375)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Severity Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.8)</b><b> (CONF:1098-15922)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Reaction%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.9/Reaction%20Observation%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Reaction Observation (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Reaction%20Observation%20(V2)_2.16.840.1.113883.10.20.22.4.9/Reaction%20Observation%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Reaction Observation (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.5.1.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.5.1.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,47 +52,87 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">US Realm Person Name (PN.US.FIELDED) <small class="text-muted">[name, 2.16.840.1.113883.10.20.22.5.1.1, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.1.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">US Realm Person Name (PN.US.FIELDED) <small class="text-muted">[name,
+        2.16.840.1.113883.10.20.22.5.1.1, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.1.1.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The US Realm Clinical Document Person Name datatype flavor is a set of reusable constraints that can be used for Persons.</p></div>
+    <div id="description">
+      <p>The US Realm Clinical Document Person Name datatype flavor is a set of reusable constraints that can be used
+        for Persons.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.123.html">Drug Monitoring Act</a><br><a href="2.16.840.1.113883.10.20.6.2.2.html">Physician of Record Participant (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.1.html">US Realm Header (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.123.html">Drug Monitoring Act</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.2.html">Physician of Record Participant (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.15.html">Care Plan (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.1.html">US Realm Header (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:81-9368)</b>.<ul><li><p>The content of name <strong>SHALL</strong> be either a conformant Patient Name (PTN.US.FIELDED), or a string (CONF:81-9371).</p></li></ul><ul><li><p>The string <strong>SHALL NOT</strong> contain name parts (CONF:81-9372).</p></li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:81-9368)</b>.<ul>
+          <li>
+            <p>The content of name <strong>SHALL</strong> be either a conformant Patient Name (PTN.US.FIELDED), or a
+              string (CONF:81-9371).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>The string <strong>SHALL NOT</strong> contain name parts (CONF:81-9372).</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.5.1.html
+++ b/templates/2.16.840.1.113883.10.20.22.5.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,118 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">US Realm Patient Name (PTN.US.FIELDED) <small class="text-muted">[name, 2.16.840.1.113883.10.20.22.5.1, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">US Realm Patient Name (PTN.US.FIELDED) <small class="text-muted">[name,
+        2.16.840.1.113883.10.20.22.5.1, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.1.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The US Realm Patient Name datatype flavor is a set of reusable constraints that can be used for the patient or any other person. It requires a first (given) and last (family) name. If a patient or person has only one name part (e.g., patient with first name only) place the name part in the field required by the organization. Use the appropriate nullFlavor, "Not Applicable" (NA), in the other field.For information on mixed content see the Extensible Markup Language reference (<a href="http://www.w3c.org/TR/2008/REC-xml-20081126/">http://www.w3c.org/TR/2008/REC-xml-20081126/</a>).</p></div>
+    <div id="description">
+      <p>The US Realm Patient Name datatype flavor is a set of reusable constraints that can be used for the patient or
+        any other person. It requires a first (given) and last (family) name. If a patient or person has only one name
+        part (e.g., patient with first name only) place the name part in the field required by the organization. Use the
+        appropriate nullFlavor, "Not Applicable" (NA), in the other field.For information on mixed content see the
+        Extensible Markup Language reference (<a
+          href="http://www.w3c.org/TR/2008/REC-xml-20081126/">http://www.w3c.org/TR/2008/REC-xml-20081126/</a>).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.1.html">US Realm Header (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.14.html">Referral Note (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.1.html">US Realm Header (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet EntityNameUse<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15913/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15913</a></b><b> STATIC</b> 2005-05-01<b> (CONF:81-7154)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>family</b><b> (CONF:81-7159)</b>.<ul><li>This family <b>MAY</b> contain zero or one [0..1] <b>@qualifier</b>, which <b>SHALL</b> be selected from ValueSet EntityPersonNamePartQualifier<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.26/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.26</a></b><b> STATIC</b> 2011-09-30<b> (CONF:81-7160)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>given</b><b> (CONF:81-7157)</b>.<ul><li>Such givens <b>MAY</b> contain zero or one [0..1] <b>@qualifier</b>, which <b>SHALL</b> be selected from ValueSet EntityPersonNamePartQualifier<b> 2.16.840.1.113883.11.20.9.26</b><b> STATIC</b> 2011-09-30<b> (CONF:81-7158)</b>.</li></ul><ul><li><p>The second occurrence of given (given[2]) if provided, SHALL include middle name or middle initial (CONF:81-7163).</p></li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>prefix</b><b> (CONF:81-7155)</b>.<ul><li>The prefix, if present, <b>MAY</b> contain zero or one [0..1] <b>@qualifier</b>, which <b>SHALL</b> be selected from ValueSet EntityPersonNamePartQualifier<b> 2.16.840.1.113883.11.20.9.26</b><b> STATIC</b> 2011-09-30<b> (CONF:81-7156)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>suffix</b><b> (CONF:81-7161)</b>.<ul><li>The suffix, if present, <b>MAY</b> contain zero or one [0..1] <b>@qualifier</b>, which <b>SHALL</b> be selected from ValueSet EntityPersonNamePartQualifier<b> 2.16.840.1.113883.11.20.9.26</b><b> STATIC</b> 2011-09-30<b> (CONF:81-7162)</b>.</li></ul></li>
-<li class="list-group-item"> <p><strong>SHALL NOT</strong> have mixed content except for white space (CONF:81-7278).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected
+        from ValueSet EntityNameUse<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15913/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.15913</a></b><b> STATIC</b> 2005-05-01<b>
+          (CONF:81-7154)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>family</b><b> (CONF:81-7159)</b>.<ul>
+          <li>This family <b>MAY</b> contain zero or one [0..1] <b>@qualifier</b>, which <b>SHALL</b> be selected from
+            ValueSet EntityPersonNamePartQualifier<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.26/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.26</a></b><b>
+              STATIC</b> 2011-09-30<b> (CONF:81-7160)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>given</b><b> (CONF:81-7157)</b>.<ul>
+          <li>Such givens <b>MAY</b> contain zero or one [0..1] <b>@qualifier</b>, which <b>SHALL</b> be selected from
+            ValueSet EntityPersonNamePartQualifier<b> 2.16.840.1.113883.11.20.9.26</b><b> STATIC</b> 2011-09-30<b>
+              (CONF:81-7158)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>The second occurrence of given (given[2]) if provided, SHALL include middle name or middle initial
+              (CONF:81-7163).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>prefix</b><b> (CONF:81-7155)</b>.<ul>
+          <li>The prefix, if present, <b>MAY</b> contain zero or one [0..1] <b>@qualifier</b>, which <b>SHALL</b> be
+            selected from ValueSet EntityPersonNamePartQualifier<b> 2.16.840.1.113883.11.20.9.26</b><b> STATIC</b>
+            2011-09-30<b> (CONF:81-7156)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>suffix</b><b> (CONF:81-7161)</b>.<ul>
+          <li>The suffix, if present, <b>MAY</b> contain zero or one [0..1] <b>@qualifier</b>, which <b>SHALL</b> be
+            selected from ValueSet EntityPersonNamePartQualifier<b> 2.16.840.1.113883.11.20.9.26</b><b> STATIC</b>
+            2011-09-30<b> (CONF:81-7162)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p><strong>SHALL NOT</strong> have mixed content except for white space (CONF:81-7278).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Patient%20Name%20(PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/US%20Realm%20Patient%20Name%20Example.xml"><i class="fab fa-github"></i>&nbsp;US Realm Patient Name Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Patient%20Name%20(PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/US%20Realm%20Patient%20Name%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;US Realm Patient Name Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.5.2.html
+++ b/templates/2.16.840.1.113883.10.20.22.5.2.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,107 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">US Realm Address (AD.US.FIELDED) <small class="text-muted">[addr, 2.16.840.1.113883.10.20.22.5.2, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">US Realm Address (AD.US.FIELDED) <small class="text-muted">[addr, 2.16.840.1.113883.10.20.22.5.2,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>Reusable address template, for use in US Realm CDA Header.</p></div>
+    <div id="description">
+      <p>Reusable address template, for use in US Realm CDA Header.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a href="2.16.840.1.113883.10.20.22.4.61.html">Policy Activity (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.1.html">US Realm Header (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.18.html">Medication Dispense (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.48.html">Advance Directive Observation (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.61.html">Policy Activity (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.1.html">US Realm Header (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected from ValueSet PostalAddressUse<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.10637/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.10637</a></b><b> STATIC</b> 2005-05-01<b> (CONF:81-7290)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>country</b>, which <b>SHALL</b> be selected from ValueSet Country<b> 2.16.840.1.113883.3.88.12.80.63</b><b> DYNAMIC</b><b> (CONF:81-7295)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>state</b> (ValueSet: StateValueSet<b> 2.16.840.1.113883.3.88.12.80.1</b><b> DYNAMIC</b>)<b> (CONF:81-7293)</b>.<ul><li><p>If the country is US, the state element is required but SHOULD have @nullFlavor if the state is unknown. If country is not specified, it's assumed to be US. If country is something other than US, the state MAY be present but MAY be bound to different vocabularies (CONF:81-10024).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>city</b><b> (CONF:81-7292)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>postalCode</b>, which <b>SHOULD</b> be selected from ValueSet PostalCode<b> 2.16.840.1.113883.3.88.12.80.2</b><b> DYNAMIC</b><b> (CONF:81-7294)</b>.<ul><li><p>If the country is US, the postalCode element is required but SHOULD have @nullFlavor if the postalCode is unknown. If country is not specified, it's assumed to be US. If country is something other than US, the postalCode MAY be present but MAY be bound to different vocabularies (CONF:81-10025).</p></li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one and not more than 4 <b>streetAddressLine</b><b> (CONF:81-7291)</b>.</li>
-<li class="list-group-item"> <p><strong>SHALL NOT</strong> have mixed content except for white space (CONF:81-7296).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>@use</b>, which <b>SHALL</b> be selected
+        from ValueSet PostalAddressUse<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.10637/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.1.11.10637</a></b><b> STATIC</b> 2005-05-01<b>
+          (CONF:81-7290)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>country</b>, which <b>SHALL</b> be
+        selected from ValueSet Country<b> 2.16.840.1.113883.3.88.12.80.63</b><b> DYNAMIC</b><b> (CONF:81-7295)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>state</b> (ValueSet: StateValueSet<b>
+          2.16.840.1.113883.3.88.12.80.1</b><b> DYNAMIC</b>)<b> (CONF:81-7293)</b>.<ul>
+          <li>
+            <p>If the country is US, the state element is required but SHOULD have @nullFlavor if the state is unknown.
+              If country is not specified, it's assumed to be US. If country is something other than US, the state MAY
+              be present but MAY be bound to different vocabularies (CONF:81-10024).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>city</b><b> (CONF:81-7292)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>postalCode</b>, which <b>SHOULD</b> be
+        selected from ValueSet PostalCode<b> 2.16.840.1.113883.3.88.12.80.2</b><b> DYNAMIC</b><b> (CONF:81-7294)</b>.
+        <ul>
+          <li>
+            <p>If the country is US, the postalCode element is required but SHOULD have @nullFlavor if the postalCode is
+              unknown. If country is not specified, it's assumed to be US. If country is something other than US, the
+              postalCode MAY be present but MAY be bound to different vocabularies (CONF:81-10025).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one and not more than 4 <b>streetAddressLine</b><b>
+          (CONF:81-7291)</b>.</li>
+      <li class="list-group-item">
+        <p><strong>SHALL NOT</strong> have mixed content except for white space (CONF:81-7296).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Address%20(AD.US.FIELDED)_2.16.840.1.113883.10.20.22.5.2/US%20Realm%20Address%20Example.xml"><i class="fab fa-github"></i>&nbsp;US Realm Address Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Address%20(AD.US.FIELDED)_2.16.840.1.113883.10.20.22.5.2/US%20Realm%20Address%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;US Realm Address Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.5.3.html
+++ b/templates/2.16.840.1.113883.10.20.22.5.3.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,50 +52,89 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">US Realm Date and Time (DT.US.FIELDED) <small class="text-muted">[effectiveTime, 2.16.840.1.113883.10.20.22.5.3, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">US Realm Date and Time (DT.US.FIELDED) <small class="text-muted">[effectiveTime,
+        2.16.840.1.113883.10.20.22.5.3, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.3.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The US Realm Clinical Document Date and Time datatype flavor records date and time information. If no time zone offset is provided, you can make no assumption about time, unless you have made a local exchange agreement.</p><p>This data type uses the same rules as US Realm Date and Time (DTM.US.FIELDED),  but is used with elements having a datatype of IVL_TS.</p></div>
+    <div id="description">
+      <p>The US Realm Clinical Document Date and Time datatype flavor records date and time information. If no time zone
+        offset is provided, you can make no assumption about time, unless you have made a local exchange agreement.</p>
+      <p>This data type uses the same rules as US Realm Date and Time (DTM.US.FIELDED), but is used with elements having
+        a datatype of IVL_TS.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.1.html">Physician Reading Study Performer (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.1.html">Physician Reading Study Performer
+              (V2)</a><br><a href="2.16.840.1.113883.10.20.22.1.4.html">Consultation Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.3.html">History and Physical (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.9.html">Progress Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.6.html">Procedure Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <p><strong>SHALL</strong> be precise to the day (CONF:81-10078).</p></li>
-<li class="list-group-item"> <p><strong>SHOULD</strong> be precise to the minute (CONF:81-10079).</p></li>
-<li class="list-group-item"> <p><strong>MAY</strong> be precise to the second (CONF:81-10080).</p></li>
-<li class="list-group-item"> <p>If more precise than day, <strong>SHOULD</strong> include time-zone offset (CONF:81-10081).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">
+        <p><strong>SHALL</strong> be precise to the day (CONF:81-10078).</p>
+      </li>
+      <li class="list-group-item">
+        <p><strong>SHOULD</strong> be precise to the minute (CONF:81-10079).</p>
+      </li>
+      <li class="list-group-item">
+        <p><strong>MAY</strong> be precise to the second (CONF:81-10080).</p>
+      </li>
+      <li class="list-group-item">
+        <p>If more precise than day, <strong>SHOULD</strong> include time-zone offset (CONF:81-10081).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.5.4.html
+++ b/templates/2.16.840.1.113883.10.20.22.5.4.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,50 +52,87 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">US Realm Date and Time (DTM.US.FIELDED) <small class="text-muted">[effectiveTime, 2.16.840.1.113883.10.20.22.5.4, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.4.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">US Realm Date and Time (DTM.US.FIELDED) <small class="text-muted">[effectiveTime,
+        2.16.840.1.113883.10.20.22.5.4, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.4.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The US Realm Clinical Document Date and Time datatype flavor records date and time information. If no time zone offset is provided, you can make no assumption about time, unless you have made a local exchange agreement.</p><p>This data type uses the same rules as US Realm Date and Time (DT.US.FIELDED), but is used with elements having a datatype of TS.</p></div>
+    <div id="description">
+      <p>The US Realm Clinical Document Date and Time datatype flavor records date and time information. If no time zone
+        offset is provided, you can make no assumption about time, unless you have made a local exchange agreement.</p>
+      <p>This data type uses the same rules as US Realm Date and Time (DT.US.FIELDED), but is used with elements having
+        a datatype of TS.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.1.html">US Realm Header (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.1.html">US Realm Header (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <p><strong>SHALL</strong> be precise to the day (CONF:81-10127).</p></li>
-<li class="list-group-item"> <p><strong>SHOULD</strong> be precise to the minute (CONF:81-10128).</p></li>
-<li class="list-group-item"> <p><strong>MAY</strong> be precise to the second (CONF:81-10129).</p></li>
-<li class="list-group-item"> <p>If more precise than day, <strong>SHOULD</strong> include time-zone offset (CONF:81-10130).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">
+        <p><strong>SHALL</strong> be precise to the day (CONF:81-10127).</p>
+      </li>
+      <li class="list-group-item">
+        <p><strong>SHOULD</strong> be precise to the minute (CONF:81-10128).</p>
+      </li>
+      <li class="list-group-item">
+        <p><strong>MAY</strong> be precise to the second (CONF:81-10129).</p>
+      </li>
+      <li class="list-group-item">
+        <p>If more precise than day, <strong>SHOULD</strong> include time-zone offset (CONF:81-10130).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Date%20and%20Time%20(DTM.US.FIELDED)_2.16.840.1.113883.10.20.22.5.4/US%20Realm%20Date%20and%20Time%20Example.xml"><i class="fab fa-github"></i>&nbsp;US Realm Date and Time Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Date%20and%20Time%20(DTM.US.FIELDED)_2.16.840.1.113883.10.20.22.5.4/US%20Realm%20Date%20and%20Time%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;US Realm Date and Time Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.5.6.html
+++ b/templates/2.16.840.1.113883.10.20.22.5.6.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,73 +24,227 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Provenance - Author Participation (V2) <small class="text-muted">[author, 2.16.840.1.113883.10.20.22.5.6, release 2019-10-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.6.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Provenance - Author Participation (V2) <small class="text-muted">[author,
+        2.16.840.1.113883.10.20.22.5.6, release 2019-10-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.5.6.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the key information to record Provenance in an Author Participation.</p><p>This Participation is appropriate at any place CDA allows an author. For example, at the CDA Header, CDA Section, CDA Entry, or within a CDA entry (e.g. Organizer and contained Observation(s)).</p><p>This template is consistent with the C-CDA Author Participation, however, it doesn't use a formal 'conforms to' relationship. All constraints for conformance are defined in this template which specializes the Author Participation (2.16.840.1.113883.10.20.22.4.119).</p><p>This template is used to identify primary authorship for an entry. An entry may have many authors, but recipients need a single authoritative point of contact for resolving issues. This is typically the last provider to make substantive changes to the entry If two providers are simultaneously involved in that activity, the implementer must choose one, ideally in a repeatable way.</p><p>The assignedAuthor/id may be set equal to (a pointer to) an id on a participant elsewhere in the document (header or entries) or a new author participant can be described here.</p><p>Note: The Provenance template title includes a version 2 to support moving from the 'Basic Provenance' guide to the this Companion Guide, so the templateId has not changed.</p></div>
+    <div id="description">
+      <p>This template represents the key information to record Provenance in an Author Participation.</p>
+      <p>This Participation is appropriate at any place CDA allows an author. For example, at the CDA Header, CDA
+        Section, CDA Entry, or within a CDA entry (e.g. Organizer and contained Observation(s)).</p>
+      <p>This template is consistent with the C-CDA Author Participation, however, it doesn't use a formal 'conforms to'
+        relationship. All constraints for conformance are defined in this template which specializes the Author
+        Participation (2.16.840.1.113883.10.20.22.4.119).</p>
+      <p>This template is used to identify primary authorship for an entry. An entry may have many authors, but
+        recipients need a single authoritative point of contact for resolving issues. This is typically the last
+        provider to make substantive changes to the entry If two providers are simultaneously involved in that activity,
+        the implementer must choose one, ideally in a repeatable way.</p>
+      <p>The assignedAuthor/id may be set equal to (a pointer to) an id on a participant elsewhere in the document
+        (header or entries) or a new author participant can be described here.</p>
+      <p>Note: The Provenance template title includes a version 2 to support moving from the 'Basic Provenance' guide to
+        the this Companion Guide, so the templateId has not changed.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4440-6)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.5.6"</b><b> (CONF:4440-15)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-10-01"</b><b> (CONF:4440-36)</b>.</li></ul></li>
-    <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:4440-7)</b>.</li>
-    <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b> (CONF:4440-1)</b>.<ul><li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4440-2)</b>.</li><ul><li>If the assignedAuthor/id is not referencing a Provenance Author described elsewhere in the document with a representedOrganization populated, this assignedAuthor SHALL contain exactly one [1..1] representedOrganization (CONF:4440-64).</li></ul><li>This assignedAuthor <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:4440-20)</b> such that it<ul><li>If id with <b>@root</b>="2.16.840.1.113883.4.6" National Provider Identifier is unknown then <br/><b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"UNK"</b> Unknown (CodeSystem: HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a>) <b>(CONF:4440-21)</b>.</li><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider Identifier <b>(CONF:4440-22)</b>.</li><li><b>SHOULD</b> contain zero or one [0..1] <b>@extension</b> <b>(CONF:4440-23)</b>.</li></ul></li></ul><ul><li>When the author is a person who is not acting in the role of a clinician, this code encodes the personal or legal relationship between author and the patient.<br/> This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:4440-33)</b>.</li><ul><li>If the content is provider authored, the code SHOULD be selected from the ValueSet Healthcare Provider Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b> <b>DYNAMIC</b> <b>(CONF:4440-56)</b>.</li><li>If the author is a person who is not acting in the role of a clinician, the code SHOULD be selected from the ValueSet Personal And Legal Relationship Role Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b> DYNAMIC</b> <b>(CONF:4440-57)</b>.</li></ul></ul><ul><li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>assignedPerson</b><b> (CONF:4440-3)</b>.</li><ul><li>The assignedPerson, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:4440-9)</b>.</li><ul><li>Such names <b>SHALL</b> contain exactly one [1..1] <b>family</b><b> (CONF:4440-17)</b>.</li></ul><ul><li>Such names <b>SHOULD</b> contain zero or more [0..*] <b>given</b><b> (CONF:4440-18)</b>.</li></ul></ul></ul><ul><li>This assignedAuthor <b>MAY</b> contain zero or one [0..1] <b>assignedAuthoringDevice</b><b> (CONF:4440-32)</b>.</li></ul><ul><li>If the assignedAuthor/id is not referencing a Provenance Author described elsewhere in the document with a <b>representedOrganization</b> populated, this assignedAuthor <b>SHALL</b> contain exactly one [1..1] <b>representedOrganization</b> (See - CONF:4440-64). This assignedAuthor <br /><b>MAY</b> contain zero or one [0..1] <b>representedOrganization</b><b> (CONF:4440-4)</b>.</li><ul><li>A nullFlavor of "NA" is allowed If the assignedAuthor is not a clinician.<br/> This representedOrganization <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b><b> (CONF:4440-35)</b>.</li></ul><ul><li>This representedOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4440-10)</b>.</li></ul><ul><li>This representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>id </b><b> (CONF:4440-24)</b> such that it<ul><li>If id with @root="2.16.840.1.113883.4.2" Tax ID Number is unknown then <br/><b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"UNK"</b> Unknown (CodeSystem: HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a>)<b> (CONF:4440-25)</b>.</li><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>="2.16.840.1.113883.4.2" Tax ID Number<b>(CONF:4440-26)</b>.</li><li><b>SHOULD</b> contain zero or one [0..1] <b>@extension</b> <b>(CONF:4440-27)</b>.</li></ul></li><li>This representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>id</b><b>(CONF:4440-28)</b> such that it<ul><li>If id with @root="2.16.840.1.113883.4.6" National Provider Identifier is unknown then<br/> <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"UNK"</b> Unknown (CodeSystem: <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b> (CONF:4440-29)</b>.</li><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>="2.16.840.1.113883.4.6" National Provider Identifier<b> (CONF:4440-30)</b>.</li><li><b>SHOULD</b> contain zero or one [0..1] <b>@extension</b> <b>(CONF:4440-31)</b>.</li></ul></li></ul><ul><li>This representedOrganization <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:4440-11)</b>.</li></ul><ul><li>This representedOrganization <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:4440-12)</b>.</li></ul></ul></li>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4440-6)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.5.6"</b><b>
+              (CONF:4440-15)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2019-10-01"</b><b> (CONF:4440-36)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:4440-7)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b> (CONF:4440-1)</b>.
+        <ul>
+          <li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4440-2)</b>.</li>
+          <ul>
+            <li>If the assignedAuthor/id is not referencing a Provenance Author described elsewhere in the document with
+              a representedOrganization populated, this assignedAuthor SHALL contain exactly one [1..1]
+              representedOrganization (CONF:4440-64).</li>
+          </ul>
+          <li>This assignedAuthor <b>SHALL</b> contain exactly one [1..1] <b>id</b><b> (CONF:4440-20)</b> such that it
+            <ul>
+              <li>If id with <b>@root</b>="2.16.840.1.113883.4.6" National Provider Identifier is unknown then
+                <br /><b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"UNK"</b> Unknown (CodeSystem:
+                HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a>)
+                <b>(CONF:4440-21)</b>.</li>
+              <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.4.6"</b> National Provider
+                Identifier <b>(CONF:4440-22)</b>.</li>
+              <li><b>SHOULD</b> contain zero or one [0..1] <b>@extension</b> <b>(CONF:4440-23)</b>.</li>
+            </ul>
+          </li>
+        </ul>
+        <ul>
+          <li>When the author is a person who is not acting in the role of a clinician, this code encodes the personal
+            or legal relationship between author and the patient.<br /> This assignedAuthor <b>SHOULD</b> contain zero
+            or one [0..1] <b>code</b><b> (CONF:4440-33)</b>.</li>
+          <ul>
+            <li>If the content is provider authored, the code SHOULD be selected from the ValueSet Healthcare Provider
+              Taxonomy<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.114222.4.11.1066</a></b>
+              <b>DYNAMIC</b> <b>(CONF:4440-56)</b>.</li>
+            <li>If the author is a person who is not acting in the role of a clinician, the code SHOULD be selected from
+              the ValueSet Personal And Legal Relationship Role Type<b> <a
+                  href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b>
+                DYNAMIC</b> <b>(CONF:4440-57)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>assignedPerson</b><b> (CONF:4440-3)</b>.
+          </li>
+          <ul>
+            <li>The assignedPerson, if present, <b>SHALL</b> contain at least one [1..*] <b>name</b><b>
+                (CONF:4440-9)</b>.</li>
+            <ul>
+              <li>Such names <b>SHALL</b> contain exactly one [1..1] <b>family</b><b> (CONF:4440-17)</b>.</li>
+            </ul>
+            <ul>
+              <li>Such names <b>SHOULD</b> contain zero or more [0..*] <b>given</b><b> (CONF:4440-18)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+        <ul>
+          <li>This assignedAuthor <b>MAY</b> contain zero or one [0..1] <b>assignedAuthoringDevice</b><b>
+              (CONF:4440-32)</b>.</li>
+        </ul>
+        <ul>
+          <li>If the assignedAuthor/id is not referencing a Provenance Author described elsewhere in the document with a
+            <b>representedOrganization</b> populated, this assignedAuthor <b>SHALL</b> contain exactly one [1..1]
+            <b>representedOrganization</b> (See - CONF:4440-64). This assignedAuthor <br /><b>MAY</b> contain zero or
+            one [0..1] <b>representedOrganization</b><b> (CONF:4440-4)</b>.</li>
+          <ul>
+            <li>A nullFlavor of "NA" is allowed If the assignedAuthor is not a clinician.<br /> This
+              representedOrganization <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b><b> (CONF:4440-35)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This representedOrganization, if present, <b>SHALL</b> contain at least one [1..*] <b>id</b><b>
+                (CONF:4440-10)</b>.</li>
+          </ul>
+          <ul>
+            <li>This representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1] <b>id </b><b>
+                (CONF:4440-24)</b> such that it<ul>
+                <li>If id with @root="2.16.840.1.113883.4.2" Tax ID Number is unknown then <br /><b>MAY</b> contain zero
+                  or one [0..1] <b>@nullFlavor</b>=<b>"UNK"</b> Unknown (CodeSystem: HL7NullFlavor <a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a>)<b> (CONF:4440-25)</b>.</li>
+                <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>="2.16.840.1.113883.4.2" Tax ID
+                  Number<b>(CONF:4440-26)</b>.</li>
+                <li><b>SHOULD</b> contain zero or one [0..1] <b>@extension</b> <b>(CONF:4440-27)</b>.</li>
+              </ul>
+            </li>
+            <li>This representedOrganization, if present, <b>SHALL</b> contain exactly one [1..1]
+              <b>id</b><b>(CONF:4440-28)</b> such that it<ul>
+                <li>If id with @root="2.16.840.1.113883.4.6" National Provider Identifier is unknown then<br />
+                  <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>=<b>"UNK"</b> Unknown (CodeSystem:
+                  <b>HL7NullFlavor <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-NullFlavor.html"
+                      target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1008</a></b>)<b>
+                    (CONF:4440-29)</b>.</li>
+                <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>="2.16.840.1.113883.4.6" National Provider
+                  Identifier<b> (CONF:4440-30)</b>.</li>
+                <li><b>SHOULD</b> contain zero or one [0..1] <b>@extension</b> <b>(CONF:4440-31)</b>.</li>
+              </ul>
+            </li>
+          </ul>
+          <ul>
+            <li>This representedOrganization <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:4440-11)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This representedOrganization <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b>
+                (CONF:4440-12)</b>.</li>
+          </ul>
+        </ul>
+      </li>
     </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Provenance%20-%20Author%20Participation%20(V2)_2.16.840.1.113883.10.20.22.5.6-2019-10-01/Provenance%20-%20Author%20Participation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Provenance - Author Participation</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Provenance%20-%20Author%20Participation%20(V2)_2.16.840.1.113883.10.20.22.5.6-2019-10-01/Provenance%20-%20Author%20Participation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Provenance - Author Participation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.22.5.7.html
+++ b/templates/2.16.840.1.113883.10.20.22.5.7.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,77 +24,164 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Provenance - Assembler Participation (V2) <small class="text-muted">[participant, 2.16.840.1.113883.10.20.22.5.7, release 2020-05-19, open] <a href="../pdfs/2.16.840.1.113883.10.20.22.5.7.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Provenance - Assembler Participation (V2) <small class="text-muted">[participant,
+        2.16.840.1.113883.10.20.22.5.7, release 2020-05-19, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.22.5.7.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template represents the organization that supported generation of a CDA document. The Assembler Organization may be different than the Author Organization, and may be different from the Organization that developed the software used to generate the document.</p><p>This Participation is appropriate to use in the CDA Header because it applies to the entire content in the document.</p><p>This template is consistent with the prior Assembler Document Participant  (2.16.840.1.113883.3.5019.1.1) in the 2016 HL7 Data Provenance guide, however, makes no claim about representing the software organization. All constraints for conformance are defined in this template.</p><p>Note: The CDA Participant does not support a software device or the organization that created the software. The Assembler role can only be expressed at the level of organization. This is a known issue with the current CDA R2 model. </p><p>Note: The Provenance template title includes a version 2 to support moving from the 'Basic Provenance' guide to the this Companion Guide, so the templateId has not changed.</p></div>
+    <div id="description">
+      <p>This template represents the organization that supported generation of a CDA document. The Assembler
+        Organization may be different than the Author Organization, and may be different from the Organization that
+        developed the software used to generate the document.</p>
+      <p>This Participation is appropriate to use in the CDA Header because it applies to the entire content in the
+        document.</p>
+      <p>This template is consistent with the prior Assembler Document Participant (2.16.840.1.113883.3.5019.1.1) in the
+        2016 HL7 Data Provenance guide, however, makes no claim about representing the software organization. All
+        constraints for conformance are defined in this template.</p>
+      <p>Note: The CDA Participant does not support a software device or the organization that created the software. The
+        Assembler role can only be expressed at the level of organization. This is a known issue with the current CDA R2
+        model. </p>
+      <p>Note: The Provenance template title includes a version 2 to support moving from the 'Basic Provenance' guide to
+        the this Companion Guide, so the templateId has not changed.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address (AD.US.FIELDED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.2.html">US Realm Address (AD.US.FIELDED)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"DEV"</b> Device<b> (CONF:4515-55)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-40)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.5.7"</b><b> (CONF:4515-44)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2020-05-19"</b><b> (CONF:4515-32974)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>functionCode</b><b> (CONF:4515-38)</b>.<ul><li>This functionCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"assembler"</b> Assembler<b> (CONF:4515-32972)</b>.</li></ul><ul><li>This functionCode <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b> (CodeSystem: <b>ProvenanceParticipantType <a href="https://terminology.hl7.org/3.1.0/CodeSystem-provenance-participant-type.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.4.642.4.1131</a></b>)<b> (CONF:4515-41)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:4515-42)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:4515-39)</b>.<br>Note: The template does not require any elements from the associatedEntity since the information is recorded in the scopingOrganization.<ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OWN"</b> Owned Entity<b> (CONF:4515-32973)</b>.</li></ul><ul><li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>scopingOrganization</b><b> (CONF:4515-43)</b>.</li><ul><li>This scopingOrganization <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-50)</b>.</li></ul><ul><li>This scopingOrganization <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:4515-51)</b>.</li></ul><ul><li>This scopingOrganization <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:4515-52)</b>.</li></ul><ul><li>This scopingOrganization <b>SHOULD</b> contain zero or more [0..*]  US Realm Address (AD.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:4515-47)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"DEV"</b> Device<b>
+          (CONF:4515-55)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-40)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.22.5.7"</b><b>
+              (CONF:4515-44)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2020-05-19"</b><b> (CONF:4515-32974)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>functionCode</b><b> (CONF:4515-38)</b>.
+        <ul>
+          <li>This functionCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"assembler"</b> Assembler<b>
+              (CONF:4515-32972)</b>.</li>
+        </ul>
+        <ul>
+          <li>This functionCode <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b> (CodeSystem:
+            <b>ProvenanceParticipantType <a
+                href="https://terminology.hl7.org/3.1.0/CodeSystem-provenance-participant-type.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.4.642.4.1131</a></b>)<b> (CONF:4515-41)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>time</b><b> (CONF:4515-42)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b>
+          (CONF:4515-39)</b>.<br>Note: The template does not require any elements from the associatedEntity since the
+        information is recorded in the scopingOrganization.<ul>
+          <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OWN"</b> Owned
+            Entity<b> (CONF:4515-32973)</b>.</li>
+        </ul>
+        <ul>
+          <li>This associatedEntity <b>SHALL</b> contain exactly one [1..1] <b>scopingOrganization</b><b>
+              (CONF:4515-43)</b>.</li>
+          <ul>
+            <li>This scopingOrganization <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:4515-50)</b>.</li>
+          </ul>
+          <ul>
+            <li>This scopingOrganization <b>SHALL</b> contain at least one [1..*] <b>name</b><b> (CONF:4515-51)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This scopingOrganization <b>SHOULD</b> contain zero or more [0..*] <b>telecom</b><b> (CONF:4515-52)</b>.
+            </li>
+          </ul>
+          <ul>
+            <li>This scopingOrganization <b>SHOULD</b> contain zero or more [0..*] US Realm Address (AD.US.FIELDED)<b>
+                (identifier: 2.16.840.1.113883.10.20.22.5.2)</b><b> (CONF:4515-47)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Provenance%20-%20Assembler%20Participation%20(V2)_2.16.840.1.113883.10.20.22.5.7-2020-05-19/Provenance%20-%20Assembler%20Participation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Provenance - Assembler Participation</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Provenance%20-%20Assembler%20Participation%20(V2)_2.16.840.1.113883.10.20.22.5.7-2020-05-19/Provenance%20-%20Assembler%20Participation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Provenance - Assembler Participation</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.24.3.90.html
+++ b/templates/2.16.840.1.113883.10.20.24.3.90.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,62 +52,243 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Substance or Device Allergy - Intolerance Observation (V2) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.24.3.90, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.24.3.90.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Substance or Device Allergy - Intolerance Observation (V2) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.24.3.90, release 2014-06-09, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.24.3.90.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template reflects a discrete observation about a patient's allergy or intolerance to a substance or device. Because it is a discrete observation, it will have a statusCode of "completed". The effectiveTime, also referred to as the 'biologically relevant time' is the time at which the observation holds for the patient. For a provider seeing a patient in the clinic today, observing a history of penicillin allergy that developed five years ago, the effectiveTime is five years ago.</p><p>The effectiveTime of the Substance or Device Allergy - Intolerance Observation is the definitive indication of whether or not the underlying allergy/intolerance is resolved. If known to be resolved, then an effectiveTime/high would be present. If the date of resolution is not known, then effectiveTime/high will be present with a nullFlavor of "UNK".</p></div>
+    <div id="description">
+      <p>This template reflects a discrete observation about a patient's allergy or intolerance to a substance or
+        device. Because it is a discrete observation, it will have a statusCode of "completed". The effectiveTime, also
+        referred to as the 'biologically relevant time' is the time at which the observation holds for the patient. For
+        a provider seeing a patient in the clinic today, observing a history of penicillin allergy that developed five
+        years ago, the effectiveTime is five years ago.</p>
+      <p>The effectiveTime of the Substance or Device Allergy - Intolerance Observation is the definitive indication of
+        whether or not the underlying allergy/intolerance is resolved. If known to be resolved, then an
+        effectiveTime/high would be present. If the date of resolution is not known, then effectiveTime/high will be
+        present with a nullFlavor of "UNK".</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.145.html">Criticality Observation </a><br><a href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a href="2.16.840.1.113883.10.20.22.4.28.html">Allergy Status Observation</a><br><a href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a href="2.16.840.1.113883.10.20.22.4.8.html">Severity Observation (V2)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.132.html">Health Concern Act (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.136.html">Risk Concern Act (V2)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.145.html">Criticality Observation </a><br><a
+              href="2.16.840.1.113883.10.20.22.4.119.html">Author Participation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.28.html">Allergy Status Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.9.html">Reaction Observation (V2)</a><br><a
+              href="2.16.840.1.113883.10.20.22.4.8.html">Severity Observation (V2)</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-16303)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:1098-16304)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16305)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.24.3.90"</b><b> (CONF:1098-16306)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32527)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-16307)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-16345)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b> (CONF:1098-16346)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b> (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b> (CONF:1098-32171)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-16308)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:1098-26354)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:1098-16309)</b>.<br>Note: The effectiveTime/low (a.k.a. "onset date") asserts when the allergy/intolerance became biologically active. The effectiveTime/high (a.k.a. "resolution date") asserts when the allergy/intolerance became biologically resolved. If the allergy/intolerance is known to be resolved, but the date of resolution is not known, then the high element SHALL be present, and the nullFlavor attribute SHALL be set to 'UNK'. <ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-31536)</b>.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-31537)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b> (CONF:1098-16312)</b>.<ul><li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from ValueSet Allergy and Intolerance Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.6.2/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.6.2</a></b><b> DYNAMIC</b><b> (CONF:1098-16317)</b>.<br>Note: Many systems will simply assign a fixed value here (e.g., "allergy to substance"). </li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*]  Author Participation<b> (identifier: 2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31144)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-16318)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CSM"</b> Consumable (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1098-16319)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1098-16320)</b>.</li><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b> Manufactured Product (CodeSystem: <b>HL7RoleClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b> (CONF:1098-16321)</b>.</li></ul><ul><li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b> (CONF:1098-16322)</b>.</li><ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MMAT"</b> Manufactured Material (CodeSystem: <b>HL7EntityClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b><b> STATIC</b>)<b> (CONF:1098-16323)</b>.</li></ul><ul><li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>MAY</b> be selected from ValueSet Substance Reactant for Intolerance<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.1</a></b><b> DYNAMIC</b><b> (CONF:1098-16324)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-16333)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-16335)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-16334)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Allergy Status Observation<b> (identifier: 2.16.840.1.113883.10.20.22.4.28)</b><b> (CONF:1098-16336)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:1098-16337)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"MFST"</b> Is Manifestation of (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-16339)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-16338)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Reaction Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1098-16340)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD NOT</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-16341)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:1098-16342)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-16343)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Severity Observation (V2)<b> (identifier: 2.16.840.1.113883.10.20.22.4.8)</b><b> (CONF:1098-16344)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b> (CONF:1098-32935)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b> (CONF:1098-32936)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-32937)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Criticality Observation <b> (identifier: 2.16.840.1.113883.10.20.22.4.145)</b><b> (CONF:1098-32938)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-16303)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:1098-16304)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16305)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.24.3.90"</b><b>
+              (CONF:1098-16306)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32527)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-16307)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-16345)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion<b>
+              (CONF:1098-16346)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.5.4"</b>
+            (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b>)<b>
+              (CONF:1098-32171)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:1098-16308)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> Completed
+            (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b>
+              (CONF:1098-26354)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b>
+          (CONF:1098-16309)</b>.<br>Note: The effectiveTime/low (a.k.a. "onset date") asserts when the
+        allergy/intolerance became biologically active. The effectiveTime/high (a.k.a. "resolution date") asserts when
+        the allergy/intolerance became biologically resolved. If the allergy/intolerance is known to be resolved, but
+        the date of resolution is not known, then the high element SHALL be present, and the nullFlavor attribute SHALL
+        be set to 'UNK'. <ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:1098-31536)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:1098-31537)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD"<b>
+          (CONF:1098-16312)</b>.<ul>
+          <li>This value <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHALL</b> be selected from
+            ValueSet Allergy and Intolerance Type<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.88.12.3221.6.2/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.3.88.12.3221.6.2</a></b><b>
+              DYNAMIC</b><b> (CONF:1098-16317)</b>.<br>Note: Many systems will simply assign a fixed value here (e.g.,
+            "allergy to substance"). </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] Author Participation<b> (identifier:
+          2.16.840.1.113883.10.20.22.4.119)</b><b> (CONF:1098-31144)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1098-16318)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"CSM"</b> Consumable (CodeSystem:
+            <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b>
+              STATIC</b>)<b> (CONF:1098-16319)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>participantRole</b><b> (CONF:1098-16320)</b>.</li>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MANU"</b>
+              Manufactured Product (CodeSystem: <b>HL7RoleClass <a
+                  href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-RoleClass.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.110</a></b><b> STATIC</b>)<b>
+                (CONF:1098-16321)</b>.</li>
+          </ul>
+          <ul>
+            <li>This participantRole <b>SHALL</b> contain exactly one [1..1] <b>playingEntity</b><b>
+                (CONF:1098-16322)</b>.</li>
+            <ul>
+              <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"MMAT"</b>
+                Manufactured Material (CodeSystem: <b>HL7EntityClass <a
+                    href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-EntityClass.html" target="_blank"><i
+                      class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.41</a></b><b> STATIC</b>)<b>
+                  (CONF:1098-16323)</b>.</li>
+            </ul>
+            <ul>
+              <li>This playingEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b>, which <b>MAY</b> be selected
+                from ValueSet Substance Reactant for Intolerance<b> <a
+                    href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.1/expansion/Latest"
+                    target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1010.1</a></b><b>
+                  DYNAMIC</b><b> (CONF:1098-16324)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-16333)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-16335)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-16334)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Allergy Status Observation<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.28)</b><b> (CONF:1098-16336)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or more [0..*] <b>entryRelationship</b><b>
+          (CONF:1098-16337)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"MFST"</b> Is Manifestation of (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-16339)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-16338)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Reaction Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.9)</b><b> (CONF:1098-16340)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD NOT</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-16341)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:1098-16342)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-16343)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Severity Observation (V2)<b> (identifier:
+              2.16.840.1.113883.10.20.22.4.8)</b><b> (CONF:1098-16344)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>entryRelationship</b><b>
+          (CONF:1098-32935)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b>)<b>
+              (CONF:1098-32936)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@inversionInd</b>=<b>"true"</b> True<b> (CONF:1098-32937)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Criticality Observation <b> (identifier:
+              2.16.840.1.113883.10.20.22.4.145)</b><b> (CONF:1098-32938)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"></ul>
+    <ul id="guide_examples"></ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.29.1.html
+++ b/templates/2.16.840.1.113883.10.20.29.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,59 +52,381 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">US Realm Header for Patient Generated Document (V2) <small class="text-muted">[ClinicalDocument, 2.16.840.1.113883.10.20.29.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.29.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">US Realm Header for Patient Generated Document (V2) <small class="text-muted">[ClinicalDocument,
+        2.16.840.1.113883.10.20.29.1, release 2015-08-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.29.1.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This template is designed to be used in conjunction with the US Realm Header (V2). It includes additional conformances which further constrain the US Realm Header (V2).The Patient Generated Document Header template is not a separate document type. The document body may contain any structured or unstructured content from C-CDA.</p></div>
+    <div id="description">
+      <p>This template is designed to be used in conjunction with the US Realm Header (V2). It includes additional
+        conformances which further constrain the US Realm Header (V2).The Patient Generated Document Header template is
+        not a separate document type. The document body may contain any structured or unstructured content from C-CDA.
+      </p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to US Realm Header (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28458)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.29.1"</b><b> (CONF:1198-28459)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32917)</b>.</li></ul><ul><li><p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail (CONF:1198-32945).</p></li></ul></li>
-<li class="list-group-item"><p>The recordTarget records the patient whose health information is described by the clinical document; each recordTarget must contain at least one patientRole element. <br>If the document receiver is interested in setting up a translator for the encounter with the patient, the receiver of the document will have to infer the need for a translator, based upon the language skills identified for the patient, the patient's language of preference and the predominant language used by the organization receiving the CDA.<br>HL7 Vocabulary simply describes guardian as a relationship to a ward.  This need not be a formal legal relationship. When a guardian relationship exists for the patient, it can be represented, regardless of who is present at the time the document is generated. This need not be a formal legal relationship. A child's parent can be represented in the guardian role.  In this case, the guardian/code element would encode the personal relationship of "mother" for the child's mom or "father" for the child's dad. An elderly person's child can be represented in the guardian role. In this case, the guardian/code element would encode the personal relationship of "daughter" or "son", or if a legal relationship existed, the relationship of "legal guardian" could be encoded.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>recordTarget</b><b> (CONF:1198-28460)</b>.<ul><li>This recordTarget <b>SHALL</b> contain exactly one [1..1] <b>patientRole</b><b> (CONF:1198-28461)</b>.</li><ul><li>This patientRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28462)</b>.</li></ul><ul><li>This patientRole <b>SHALL</b> contain exactly one [1..1] <b>patient</b><b> (CONF:1198-28465)</b>.</li><ul><li>This patient <b>MAY</b> contain zero or more [0..*] <b>guardian</b><b> (CONF:1198-28469)</b>.</li><ul><li>The guardian, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-28470)</b>.</li></ul><ul><li>The guardian, if present, <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b> DYNAMIC</b><b> (CONF:1198-28473)</b>.</li></ul></ul><ul><li>This patient <b>SHOULD</b> contain zero or more [0..*] <b>languageCommunication</b><b> (CONF:1198-28474)</b>.</li><ul><li>The languageCommunication, if present, <b>MAY</b> contain zero or one [0..1] <b>preferenceInd</b><b> (CONF:1198-28475)</b>.<br>Note: Indicates a preference for information about care delivery and treatments be communicated (or translated if needed) into this language.If more than one languageCommunication is present, only one languageCommunication element SHALL have a preferenceInd with a value of 1.</li></ul></ul></ul><ul><li>This patientRole <b>MAY</b> contain zero or one [0..1] <b>providerOrganization</b><b> (CONF:1198-28476)</b>.<br>Note: If present, this organization represents the provider organization where the person is claiming to be a patient.</li></ul></ul></li>
-<li class="list-group-item"><p>The author element represents the creator of the clinical document.  The author may be a device, or a person. The person is the patient or the patient's advocate.<br></p> <b>SHALL</b> contain at least one [1..*] <b>author</b><b> (CONF:1198-28477)</b>.<ul><li>Such authors <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b> (CONF:1198-28478)</b>.</li><ul><li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28479)</b>.</li></ul><ul><li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-28481)</b>.</li><ul><li>The code, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b> DYNAMIC</b><b> (CONF:1198-28676)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>The dataEnterer element represents the person who transferred the content, written or dictated by someone else, into the clinical document. The guiding rule of thumb is that an author provides the content found within the header or body of the document, subject to their own interpretation, and the dataEnterer adds that information to the electronic system. In other words, a dataEnterer transfers information from one source to another (e.g., transcription from paper form to electronic system). If the dataEnterer is missing, this role is assumed to be played by the author.<br></p> <b>MAY</b> contain zero or one [0..1] <b>dataEnterer</b><b> (CONF:1198-28678)</b>.<ul><li>The dataEnterer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-28679)</b>.</li><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b> DYNAMIC</b><b> (CONF:1198-28680)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>The informant element describes the source of the information in a medical document.<br>Assigned health care providers may be a source of information when a document is created. (e.g., a nurse's aide who provides information about a recent significant health care event that occurred within an acute care facility.) In these cases, the assignedEntity element is used.<br>When the informant is a personal relation, that informant is represented in the relatedEntity element, even if the personal relation is a medical professional.  The code element of the relatedEntity describes the relationship between the informant and the patient. The relationship between the informant and the patient  needs to be described to help the receiver of the clinical document understand the information in the document. <br>Each informant can be either an assignedEntity (a clinician serving the patient) OR a relatedEntity (a person with a personal or legal relationship with the patient). The constraints here apply to relatedEntity.<br></p> <b>MAY</b> contain zero or more [0..*] <b>informant</b><b> (CONF:1198-28681)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>relatedEntity</b><b> (CONF:1198-28682)</b>.</li><ul><li>This relatedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-28683)</b>.</li><ul><li>The code, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b> DYNAMIC</b><b> (CONF:1198-28684)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>The custodian element represents the organization or person that is in charge of maintaining the document. The custodian is the steward that is entrusted with the care of the document. Every CDA document has exactly one custodian. The custodian participation satisfies the CDA definition of Stewardship. Because CDA is an exchange standard and may not represent the original form of the authenticated document (e.g., CDA could include scanned copy of original), the custodian represents the steward of the original source document. The custodian may be the document originator, a health information exchange, or other responsible party. Also, the custodian may be the patient or an organization acting on behalf of the patient, such as a PHR organization.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>custodian</b><b> (CONF:1198-28685)</b>.<ul><li>This custodian <b>SHALL</b> contain exactly one [1..1] <b>assignedCustodian</b><b> (CONF:1198-28686)</b>.</li><ul><li>This assignedCustodian <b>SHALL</b> contain exactly one [1..1] <b>representedCustodianOrganization</b><b> (CONF:1198-28687)</b>.</li><ul><li>This representedCustodianOrganization <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28688)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>The informationRecipient element records the intended recipient of the information at the time the document is created. For example, in cases where the intended recipient of the document is the patient's health chart, set the receivedOrganization to be the scoping organization for that chart.<br></p> <b>MAY</b> contain zero or more [0..*] <b>informationRecipient</b><b> (CONF:1198-28690)</b>.<ul><li>The informationRecipient, if present, <b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b> (CONF:1198-28691)</b>.</li><ul><li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-28692)</b>.</li><ul><li>The id, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@root</b><b> (CONF:1198-28693)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"><p>In a patient authored document, the legalAuthenticator identifies the single person legally responsible for the document and must be present if the document has been legally authenticated. (Note that per the following section, there may also be one or more document authenticators.) <br>Based on local practice, patient authored documents may be provided without legal authentication. This implies that a patient authored document that does not contain this element has not been legally authenticated.<br>The act of legal authentication requires a certain privilege be granted to the legal authenticator depending upon local policy. All patient documents have the potential for legal authentication, given the appropriate legal authority.<br>Local policies MAY choose to delegate the function of legal authentication to a device or system that generates the document. In these cases, the legal authenticator is the person accepting responsibility for the document, not the generating device or system.<br>Note that the legal authenticator, if present, must be a person.<br><br></p> <b>MAY</b> contain zero or one [0..1] <b>legalAuthenticator</b><b> (CONF:1198-28694)</b>.<ul><li>The legalAuthenticator, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-28695)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28696)</b>.</li></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-28697)</b>.</li><ul><li>The code, if present, <b>MAY</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b> DYNAMIC</b><b> (CONF:1198-28698)</b>.</li></ul></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>authenticator</b><b> (CONF:1198-28699)</b>.<ul><li>The authenticator, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-28700)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28701)</b>.</li></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b> DYNAMIC</b><b> (CONF:1198-28702)</b>.</li></ul></ul></li>
-<li class="list-group-item"><p>Unless otherwise specified by the document specific header constraints, when participant/@typeCode is IND, associatedEntity/@classCode SHALL be selected from ValueSet 2.16.840.1.113883.11.20.9.33 INDRoleclassCodes STATIC 2011-09-30</p><p>The participant element identifies other supporting participants, including parents, relatives, caregivers, insurance policyholders, guarantors, and other participants related in some way to the patient. <br>A supporting person or organization is an individual or an organization with a relationship to the patient. A supporting person who is playing multiple roles would be recorded in multiple participants (e.g., emergency contact and next-of-kin)<br><br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b> (CONF:1198-28703)</b>.<ul><li>The participant, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b><b> (CONF:1198-28704)</b>.</li></ul><ul><li>The participant, if present, <b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b> (CONF:1198-28705)</b>.</li><ul><li>This associatedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b> DYNAMIC</b><b> (CONF:1198-28706)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>inFulfillmentOf</b><b> (CONF:1198-28707)</b>.<ul><li>The inFulfillmentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>order</b><b> (CONF:1198-28708)</b>.</li><ul><li>This order <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28709)</b>.</li></ul></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>documentationOf</b><b> (CONF:1198-28710)</b>.<ul><li>The documentationOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b> (CONF:1198-28711)</b>.</li><ul><li>This serviceEvent <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-28712)</b>.</li></ul><ul><li>This serviceEvent <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-28713)</b>.</li><ul><li>The performer, if present, <b>MAY</b> contain zero or one [0..1] <b>functionCode</b><b> (CONF:1198-28714)</b>.</li></ul><ul><li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1198-28715)</b>.</li><ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28716)</b>.</li></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b> DYNAMIC</b><b> (CONF:1198-28718)</b>.</li></ul></ul></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to US Realm Header (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.1.1:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1198-28458)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.29.1"</b><b>
+              (CONF:1198-28459)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2015-08-01"</b><b> (CONF:1198-32917)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>When asserting this templateId, all C-CDA 2.1 section and entry templates that had a previous version in
+              C-CDA R1.1 <strong>SHALL</strong> include both the C-CDA 2.1 templateId and the C-CDA R1.1 templateId root
+              without an extension. See C-CDA R2.1 Volume 1 - Design Considerations for additional detail
+              (CONF:1198-32945).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The recordTarget records the patient whose health information is described by the clinical document; each
+          recordTarget must contain at least one patientRole element. <br>If the document receiver is interested in
+          setting up a translator for the encounter with the patient, the receiver of the document will have to infer
+          the need for a translator, based upon the language skills identified for the patient, the patient's language
+          of preference and the predominant language used by the organization receiving the CDA.<br>HL7 Vocabulary
+          simply describes guardian as a relationship to a ward. This need not be a formal legal relationship. When a
+          guardian relationship exists for the patient, it can be represented, regardless of who is present at the time
+          the document is generated. This need not be a formal legal relationship. A child's parent can be represented
+          in the guardian role. In this case, the guardian/code element would encode the personal relationship of
+          "mother" for the child's mom or "father" for the child's dad. An elderly person's child can be represented in
+          the guardian role. In this case, the guardian/code element would encode the personal relationship of
+          "daughter" or "son", or if a legal relationship existed, the relationship of "legal guardian" could be
+          encoded.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>recordTarget</b><b> (CONF:1198-28460)</b>.<ul>
+          <li>This recordTarget <b>SHALL</b> contain exactly one [1..1] <b>patientRole</b><b> (CONF:1198-28461)</b>.
+          </li>
+          <ul>
+            <li>This patientRole <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28462)</b>.</li>
+          </ul>
+          <ul>
+            <li>This patientRole <b>SHALL</b> contain exactly one [1..1] <b>patient</b><b> (CONF:1198-28465)</b>.</li>
+            <ul>
+              <li>This patient <b>MAY</b> contain zero or more [0..*] <b>guardian</b><b> (CONF:1198-28469)</b>.</li>
+              <ul>
+                <li>The guardian, if present, <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b>
+                    (CONF:1198-28470)</b>.</li>
+              </ul>
+              <ul>
+                <li>The guardian, if present, <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHALL</b>
+                  be selected from ValueSet Personal And Legal Relationship Role Type<b> <a
+                      href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.12.1/expansion/Latest"
+                      target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.12.1</a></b><b>
+                    DYNAMIC</b><b> (CONF:1198-28473)</b>.</li>
+              </ul>
+            </ul>
+            <ul>
+              <li>This patient <b>SHOULD</b> contain zero or more [0..*] <b>languageCommunication</b><b>
+                  (CONF:1198-28474)</b>.</li>
+              <ul>
+                <li>The languageCommunication, if present, <b>MAY</b> contain zero or one [0..1] <b>preferenceInd</b><b>
+                    (CONF:1198-28475)</b>.<br>Note: Indicates a preference for information about care delivery and
+                  treatments be communicated (or translated if needed) into this language.If more than one
+                  languageCommunication is present, only one languageCommunication element SHALL have a preferenceInd
+                  with a value of 1.</li>
+              </ul>
+            </ul>
+          </ul>
+          <ul>
+            <li>This patientRole <b>MAY</b> contain zero or one [0..1] <b>providerOrganization</b><b>
+                (CONF:1198-28476)</b>.<br>Note: If present, this organization represents the provider organization where
+              the person is claiming to be a patient.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The author element represents the creator of the clinical document. The author may be a device, or a person.
+          The person is the patient or the patient's advocate.<br></p> <b>SHALL</b> contain at least one [1..*]
+        <b>author</b><b> (CONF:1198-28477)</b>.<ul>
+          <li>Such authors <b>SHALL</b> contain exactly one [1..1] <b>assignedAuthor</b><b> (CONF:1198-28478)</b>.</li>
+          <ul>
+            <li>This assignedAuthor <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28479)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedAuthor <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-28481)</b>.</li>
+            <ul>
+              <li>The code, if present, <b>SHALL</b> contain exactly one [1..1] <b>@code</b>, which <b>SHOULD</b> be
+                selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b>
+                  DYNAMIC</b><b> (CONF:1198-28676)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The dataEnterer element represents the person who transferred the content, written or dictated by someone
+          else, into the clinical document. The guiding rule of thumb is that an author provides the content found
+          within the header or body of the document, subject to their own interpretation, and the dataEnterer adds that
+          information to the electronic system. In other words, a dataEnterer transfers information from one source to
+          another (e.g., transcription from paper form to electronic system). If the dataEnterer is missing, this role
+          is assumed to be played by the author.<br></p> <b>MAY</b> contain zero or one [0..1] <b>dataEnterer</b><b>
+          (CONF:1198-28678)</b>.<ul>
+          <li>The dataEnterer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+              (CONF:1198-28679)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be selected
+              from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b>
+                DYNAMIC</b><b> (CONF:1198-28680)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The informant element describes the source of the information in a medical document.<br>Assigned health care
+          providers may be a source of information when a document is created. (e.g., a nurse's aide who provides
+          information about a recent significant health care event that occurred within an acute care facility.) In
+          these cases, the assignedEntity element is used.<br>When the informant is a personal relation, that informant
+          is represented in the relatedEntity element, even if the personal relation is a medical professional. The code
+          element of the relatedEntity describes the relationship between the informant and the patient. The
+          relationship between the informant and the patient needs to be described to help the receiver of the clinical
+          document understand the information in the document. <br>Each informant can be either an assignedEntity (a
+          clinician serving the patient) OR a relatedEntity (a person with a personal or legal relationship with the
+          patient). The constraints here apply to relatedEntity.<br></p> <b>MAY</b> contain zero or more [0..*]
+        <b>informant</b><b> (CONF:1198-28681)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>relatedEntity</b><b> (CONF:1198-28682)</b>.</li>
+          <ul>
+            <li>This relatedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-28683)</b>.</li>
+            <ul>
+              <li>The code, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be
+                selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b>
+                  DYNAMIC</b><b> (CONF:1198-28684)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The custodian element represents the organization or person that is in charge of maintaining the document.
+          The custodian is the steward that is entrusted with the care of the document. Every CDA document has exactly
+          one custodian. The custodian participation satisfies the CDA definition of Stewardship. Because CDA is an
+          exchange standard and may not represent the original form of the authenticated document (e.g., CDA could
+          include scanned copy of original), the custodian represents the steward of the original source document. The
+          custodian may be the document originator, a health information exchange, or other responsible party. Also, the
+          custodian may be the patient or an organization acting on behalf of the patient, such as a PHR
+          organization.<br></p> <b>SHALL</b> contain exactly one [1..1] <b>custodian</b><b> (CONF:1198-28685)</b>.<ul>
+          <li>This custodian <b>SHALL</b> contain exactly one [1..1] <b>assignedCustodian</b><b> (CONF:1198-28686)</b>.
+          </li>
+          <ul>
+            <li>This assignedCustodian <b>SHALL</b> contain exactly one [1..1]
+              <b>representedCustodianOrganization</b><b> (CONF:1198-28687)</b>.</li>
+            <ul>
+              <li>This representedCustodianOrganization <b>SHALL</b> contain at least one [1..*] <b>id</b><b>
+                  (CONF:1198-28688)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The informationRecipient element records the intended recipient of the information at the time the document
+          is created. For example, in cases where the intended recipient of the document is the patient's health chart,
+          set the receivedOrganization to be the scoping organization for that chart.<br></p> <b>MAY</b> contain zero or
+        more [0..*] <b>informationRecipient</b><b> (CONF:1198-28690)</b>.<ul>
+          <li>The informationRecipient, if present, <b>SHALL</b> contain exactly one [1..1] <b>intendedRecipient</b><b>
+              (CONF:1198-28691)</b>.</li>
+          <ul>
+            <li>This intendedRecipient <b>SHOULD</b> contain zero or more [0..*] <b>id</b><b> (CONF:1198-28692)</b>.
+            </li>
+            <ul>
+              <li>The id, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@root</b><b> (CONF:1198-28693)</b>.
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>In a patient authored document, the legalAuthenticator identifies the single person legally responsible for
+          the document and must be present if the document has been legally authenticated. (Note that per the following
+          section, there may also be one or more document authenticators.) <br>Based on local practice, patient authored
+          documents may be provided without legal authentication. This implies that a patient authored document that
+          does not contain this element has not been legally authenticated.<br>The act of legal authentication requires
+          a certain privilege be granted to the legal authenticator depending upon local policy. All patient documents
+          have the potential for legal authentication, given the appropriate legal authority.<br>Local policies MAY
+          choose to delegate the function of legal authentication to a device or system that generates the document. In
+          these cases, the legal authenticator is the person accepting responsibility for the document, not the
+          generating device or system.<br>Note that the legal authenticator, if present, must be a person.<br><br></p>
+        <b>MAY</b> contain zero or one [0..1] <b>legalAuthenticator</b><b> (CONF:1198-28694)</b>.<ul>
+          <li>The legalAuthenticator, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+              (CONF:1198-28695)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28696)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-28697)</b>.</li>
+            <ul>
+              <li>The code, if present, <b>MAY</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be
+                selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b>
+                  DYNAMIC</b><b> (CONF:1198-28698)</b>.</li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>authenticator</b><b> (CONF:1198-28699)</b>.
+        <ul>
+          <li>The authenticator, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+              (CONF:1198-28700)</b>.</li>
+          <ul>
+            <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28701)</b>.</li>
+          </ul>
+          <ul>
+            <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be
+              selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b>
+                DYNAMIC</b><b> (CONF:1198-28702)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Unless otherwise specified by the document specific header constraints, when participant/@typeCode is IND,
+          associatedEntity/@classCode SHALL be selected from ValueSet 2.16.840.1.113883.11.20.9.33 INDRoleclassCodes
+          STATIC 2011-09-30</p>
+        <p>The participant element identifies other supporting participants, including parents, relatives, caregivers,
+          insurance policyholders, guarantors, and other participants related in some way to the patient. <br>A
+          supporting person or organization is an individual or an organization with a relationship to the patient. A
+          supporting person who is playing multiple roles would be recorded in multiple participants (e.g., emergency
+          contact and next-of-kin)<br><br></p> <b>MAY</b> contain zero or more [0..*] <b>participant</b><b>
+          (CONF:1198-28703)</b>.<ul>
+          <li>The participant, if present, <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b><b>
+              (CONF:1198-28704)</b>.</li>
+        </ul>
+        <ul>
+          <li>The participant, if present, <b>SHALL</b> contain exactly one [1..1] <b>associatedEntity</b><b>
+              (CONF:1198-28705)</b>.</li>
+          <ul>
+            <li>This associatedEntity <b>SHOULD</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be
+              selected from ValueSet Personal And Legal Relationship Role Type<b> 2.16.840.1.113883.11.20.12.1</b><b>
+                DYNAMIC</b><b> (CONF:1198-28706)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>inFulfillmentOf</b><b>
+          (CONF:1198-28707)</b>.<ul>
+          <li>The inFulfillmentOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>order</b><b>
+              (CONF:1198-28708)</b>.</li>
+          <ul>
+            <li>This order <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28709)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>documentationOf</b><b>
+          (CONF:1198-28710)</b>.<ul>
+          <li>The documentationOf, if present, <b>SHALL</b> contain exactly one [1..1] <b>serviceEvent</b><b>
+              (CONF:1198-28711)</b>.</li>
+          <ul>
+            <li>This serviceEvent <b>SHOULD</b> contain zero or one [0..1] <b>code</b><b> (CONF:1198-28712)</b>.</li>
+          </ul>
+          <ul>
+            <li>This serviceEvent <b>SHOULD</b> contain zero or more [0..*] <b>performer</b><b> (CONF:1198-28713)</b>.
+            </li>
+            <ul>
+              <li>The performer, if present, <b>MAY</b> contain zero or one [0..1] <b>functionCode</b><b>
+                  (CONF:1198-28714)</b>.</li>
+            </ul>
+            <ul>
+              <li>The performer, if present, <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+                  (CONF:1198-28715)</b>.</li>
+              <ul>
+                <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1198-28716)</b>.
+                </li>
+              </ul>
+              <ul>
+                <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>code</b>, which <b>SHOULD</b> be
+                  selected from ValueSet Personal And Legal Relationship Role Type<b>
+                    2.16.840.1.113883.11.20.12.1</b><b> DYNAMIC</b><b> (CONF:1198-28718)</b>.</li>
+              </ul>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20authenticator%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document authenticator Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20author%20device%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document author device Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20author%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document author Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20custodian%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document custodian Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20dataEnterer%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document dataEnterer Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20informant%20Example%20informant.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document informant Example informant</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20informant%20RelEnt%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document informant RelEnt Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20informationRecipient.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document informationRecipient</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20inFulfillmentOf%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document inFulfillmentOf Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20legalAuthenticator%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document legalAuthenticator Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20participant%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document participant Example</a></li><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20recordTarget%20Example.xml"><i class="fab fa-github"></i>&nbsp;Patient Generated Document recordTarget Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20authenticator%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document authenticator Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20author%20device%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document author device Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20author%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document author Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20custodian%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document custodian Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20dataEnterer%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document dataEnterer Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20informant%20Example%20informant.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document informant Example informant</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20informant%20RelEnt%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document informant RelEnt Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20informationRecipient.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document informationRecipient</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20inFulfillmentOf%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document inFulfillmentOf Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20legalAuthenticator%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document legalAuthenticator Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20participant%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document participant Example</a></li>
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/US%20Realm%20Header%20for%20Patient%20Generated%20Document%20(V2)_2.16.840.1.113883.10.20.29.1/Patient%20Generated%20Document%20recordTarget%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Patient Generated Document recordTarget Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Header"><i class="fas fa-external-link-alt"></i> Header</a></li>
+    </ul>
 
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.34.3.45.html
+++ b/templates/2.16.840.1.113883.10.20.34.3.45.html
@@ -1,9 +1,17 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
@@ -16,80 +24,172 @@
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
     <h1 class="display-3 row">
-		<div class="col-12">
-		  <img class="rounded" style="max-width:20%" src="../img/cda.png">
-		  <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-		  <div style="font-size:0.4em"> 
-			<strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
-			<br>
-		  </div>
-		</div>
-	</h1>
+      <div class="col-12">
+        <img class="rounded" style="max-width:20%" src="../img/cda.png">
+        <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
+          <br>
+        </div>
+      </div>
+    </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, 
-        or to access the Supplemental Implementation Guides, please refer to the
-	    <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-	    <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>. 
-	    </p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA,
+          or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.
+        </p>
       </div>
     </div>
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
   </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Gender Identity Observation (V3) <small class="text-muted">[observation, 2.16.840.1.113883.10.20.34.3.45, release 2022-06-01, open] <a href="../pdfs/2.16.840.1.113883.10.20.34.3.45.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Gender Identity Observation (V3) <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.34.3.45, release 2022-06-01, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.34.3.45.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This observation represents the gender identity of the patient, defined as:</p><blockquote><p>"One's basic sense of being male, female, or other gender (for example, transgender or gender queer). Gender identity can be congruent or incongruent with one's sex assigned at birth based on the appearance of external genitalia.' (Advancing Effective Communication, Cultural Competence, and Patient- and Family-Centered Care for the Lesbian, Gay, Bisexual, and Transgender (LGBT) Community'A Field Guide, The Joint Commission (2011).)</p></blockquote><p>This template follows the guidelines from the HL7 Gender Harmony project. This template is based on C-CDA Social History Observation template.</p><p>This observation is not appropriate for recording patient gender (administrativeGender) or birth sex.</p></div>
+    <div id="description">
+      <p>This observation represents the gender identity of the patient, defined as:</p>
+      <blockquote>
+        <p>"One's basic sense of being male, female, or other gender (for example, transgender or gender queer). Gender
+          identity can be congruent or incongruent with one's sex assigned at birth based on the appearance of external
+          genitalia.' (Advancing Effective Communication, Cultural Competence, and Patient- and Family-Centered Care for
+          the Lesbian, Gay, Bisexual, and Transgender (LGBT) Community'A Field Guide, The Joint Commission (2011).)</p>
+      </blockquote>
+      <p>This template follows the guidelines from the HL7 Gender Harmony project. This template is based on C-CDA
+        Social History Observation template.</p>
+      <p>This observation is not appropriate for recording patient gender (administrativeGender) or birth sex.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By">none</td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By">none</td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item">Conforms to Social History Observation (V3) template (urn:hl7ii:2.16.840.1.113883.10.20.22.4.38:2015-08-01)</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:4515-1230)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:4515-1231)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-1221)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.34.3.45"</b><b> (CONF:4515-1225)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-1226)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-1222)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"76691-5"</b> Gender identity<b> (CONF:4515-1227)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:4515-1228)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-33031)</b>.<ul><li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem: <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:4515-33032)</b>.</li></ul></li>
-<li class="list-group-item"><p>The effectiveTime represents the relevant time of the observation. A patient's "gender identity" may change and using effectiveTime/low and effectiveTime/high defines the time during which the patient had identified as specified.</p> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-33033)</b>.<ul><li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-33034)</b>.</li></ul><ul><li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-33035)</b>.</li></ul></li>
-<li class="list-group-item"><p>To represent additional Gender Identities, set nullFlavor="OTH". To represent "choose not to disclose", set nullFlavor="ASKU".</p> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the code <b>SHALL</b> be selected from ValueSet Gender Identity USCDI core<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.101/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.101</a></b><b> DYNAMIC</b><b> (CONF:4515-1223)</b>.<ul><li>This value <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>, which <b>SHOULD</b> be selected from ValueSet Asked but Unknown and Other<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.17/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1114.17</a></b><b> DYNAMIC</b><b> (CONF:4515-1232)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item">Conforms to Social History Observation (V3) template
+        (urn:hl7ii:2.16.840.1.113883.10.20.22.4.38:2015-08-01)</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:4515-1230)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:4515-1231)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:4515-1221)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.34.3.45"</b><b>
+              (CONF:4515-1225)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2022-06-01"</b><b> (CONF:4515-1226)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:4515-1222)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"76691-5"</b> Gender identity<b>
+              (CONF:4515-1227)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b><b> STATIC</b>)<b> (CONF:4515-1228)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>statusCode</b><b> (CONF:4515-33031)</b>.
+        <ul>
+          <li>This statusCode <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"completed"</b> (CodeSystem:
+            <b>HL7ActStatus <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActStatus.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.14</a></b>)<b> (CONF:4515-33032)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>The effectiveTime represents the relevant time of the observation. A patient's "gender identity" may change
+          and using effectiveTime/low and effectiveTime/high defines the time during which the patient had identified as
+          specified.</p> <b>SHALL</b> contain exactly one [1..1] <b>effectiveTime</b><b> (CONF:4515-33033)</b>.<ul>
+          <li>This effectiveTime <b>SHALL</b> contain exactly one [1..1] <b>low</b><b> (CONF:4515-33034)</b>.</li>
+        </ul>
+        <ul>
+          <li>This effectiveTime <b>MAY</b> contain zero or one [0..1] <b>high</b><b> (CONF:4515-33035)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>To represent additional Gender Identities, set nullFlavor="OTH". To represent "choose not to disclose", set
+          nullFlavor="ASKU".</p> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHALL</b> be selected from ValueSet Gender Identity USCDI core<b> <a
+            href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1021.101/expansion/Latest" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1021.101</a></b><b> DYNAMIC</b><b>
+          (CONF:4515-1223)</b>.<ul>
+          <li>This value <b>MAY</b> contain zero or one [0..1] <b>@nullFlavor</b>, which <b>SHOULD</b> be selected from
+            ValueSet Asked but Unknown and Other<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.17/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113762.1.4.1114.17</a></b><b>
+              DYNAMIC</b><b> (CONF:4515-1232)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples">
-    <li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Gender%20Identity%20Observation%20(V3)_2.16.840.1.113883.10.20.34.3.45/Gender%20Identity%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Gender Identity Observation Example</a></li>
-  </ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Gender%20Identity%20Observation%20(V3)_2.16.840.1.113883.10.20.34.3.45/Gender%20Identity%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Gender Identity Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social History</a></li></ul>
-  
-  </ul>
-  
-  <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Social%20History"><i class="fas fa-external-link-alt"></i> Social
+          History</a></li>
+    </ul>
+
+    </ul>
+
+    <hr><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br><br><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.1.1.html
+++ b/templates/2.16.840.1.113883.10.20.6.1.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,99 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">DICOM Object Catalog Section - DCM 121181 <small class="text-muted">[section, 2.16.840.1.113883.10.20.6.1.1, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.1.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">DICOM Object Catalog Section - DCM 121181 <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.6.1.1, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.1.1.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>DICOM Object Catalog lists all referenced objects and their parent Series and Studies, plus other DICOM attributes required for retrieving the objects.</p><p>DICOM Object Catalog sections are not intended for viewing and contain empty section text.</p></div>
+    <div id="description">
+      <p>DICOM Object Catalog lists all referenced objects and their parent Series and Studies, plus other DICOM
+        attributes required for retrieving the objects.</p>
+      <p>DICOM Object Catalog sections are not intended for viewing and contain empty section text.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.6.html">Study Act</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.6.html">Study Act</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8525)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.1.1"</b><b> (CONF:81-10454)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15456)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"121181"</b> Dicom Object Catalog<b> (CONF:81-15457)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b> (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26475)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:81-8530)</b>.<ul><li>Such entries <b>SHALL</b> contain exactly one [1..1]  Study Act<b> (identifier: 2.16.840.1.113883.10.20.6.2.6)</b><b> (CONF:81-15458)</b>.</li></ul></li>
-<li class="list-group-item"> <p>A DICOM Object Catalog SHALL be present if the document contains references to DICOM Images. If present, it SHALL be the first section in the document (CONF:81-8527).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8525)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.1.1"</b><b>
+              (CONF:81-10454)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15456)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"121181"</b> Dicom Object Catalog<b>
+              (CONF:81-15457)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b>
+            (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26475)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entry</b><b> (CONF:81-8530)</b>.<ul>
+          <li>Such entries <b>SHALL</b> contain exactly one [1..1] Study Act<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.6)</b><b> (CONF:81-15458)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>A DICOM Object Catalog SHALL be present if the document contains references to DICOM Images. If present, it
+          SHALL be the first section in the document (CONF:81-8527).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/DICOM%20Object%20Catalog%20Section%20-%20DCM%20121181_2.16.840.1.113883.10.20.6.1.1/DICOM%20Object%20Catalog%20Section%20-%20DCM%20121181%20Example.xml"><i class="fab fa-github"></i>&nbsp;DICOM Object Catalog Section - DCM 121181 Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/DICOM%20Object%20Catalog%20Section%20-%20DCM%20121181_2.16.840.1.113883.10.20.6.1.1/DICOM%20Object%20Catalog%20Section%20-%20DCM%20121181%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;DICOM Object Catalog Section - DCM 121181 Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.1.2.html
+++ b/templates/2.16.840.1.113883.10.20.6.1.2.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,50 +52,86 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Findings Section (DIR) <small class="text-muted">[section, 2.16.840.1.113883.10.20.6.1.2, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.1.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Findings Section (DIR) <small class="text-muted">[section, 2.16.840.1.113883.10.20.6.1.2, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.6.1.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Findings section contains the main narrative body of the report. While not an absolute requirement for transformed DICOM SR reports, it is suggested that Diagnostic Imaging Reports authored in CDA follow Term Info guidelines for the codes in the various observations and procedures recorded in this section.</p></div>
+    <div id="description">
+      <p>The Findings section contains the main narrative body of the report. While not an absolute requirement for
+        transformed DICOM SR reports, it is suggested that Diagnostic Imaging Reports authored in CDA follow Term Info
+        guidelines for the codes in the various observations and procedures recorded in this section.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br>
+          </td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8531)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.1.2"</b><b> (CONF:81-10456)</b>.</li></ul></li>
-<li class="list-group-item"> <p>This section SHOULD contain only the direct observations in the report, with topics such as Reason for Study, History, and Impression placed in separate sections.  However, in cases where the source of report content provides a single block of text not separated into these sections, that text SHALL be placed in the Findings section (CONF:81-8532).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8531)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.1.2"</b><b>
+              (CONF:81-10456)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>This section SHOULD contain only the direct observations in the report, with topics such as Reason for Study,
+          History, and Impression placed in separate sections. However, in cases where the source of report content
+          provides a single block of text not separated into these sections, that text SHALL be placed in the Findings
+          section (CONF:81-8532).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Findings%20Section%20(DIR)_2.16.840.1.113883.10.20.6.1.2/Findings%20Section%20(DIR)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Findings Section (DIR) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Findings%20Section%20(DIR)_2.16.840.1.113883.10.20.6.1.2/Findings%20Section%20(DIR)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Findings Section (DIR) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.1.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.1.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,121 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Physician Reading Study Performer (V2) <small class="text-muted">[performer, 2.16.840.1.113883.10.20.6.2.1, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.1.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Physician Reading Study Performer (V2) <small class="text-muted">[performer,
+        2.16.840.1.113883.10.20.6.2.1, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.1.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This participant is the Physician Reading Study Performer defined in documentationOf/serviceEvent. It is usually different from the attending physician. The reading physician interprets the images and evidence of the study (DICOM Definition).</p></div>
+    <div id="description">
+      <p>This participant is the Physician Reading Study Performer defined in documentationOf/serviceEvent. It is
+        usually different from the attending physician. The reading physician interprets the images and evidence of the
+        study (DICOM Definition).</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.3.html">US Realm Date and Time (DT.US.FIELDED)</a><br>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRF"</b> Performer (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:1098-8424)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30773)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.1"</b><b> (CONF:1098-30774)</b>.</li></ul><ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32564)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1]  US Realm Date and Time (DT.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1098-8425)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1098-8426)</b>.<ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-10033)</b>.</li></ul><ul><li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-8427)</b>.</li><ul><li><p><strong>SHALL</strong> contain a valid DICOM personal identification code sequence (@codeSystem is 1.2.840.10008.2.16.4) or an appropriate national health care provider coding system (e.g., NUCC in the U.S., where @codeSystem is <a href="https://terminology.hl7.org/CodeSystem-v3-nuccProviderCodes.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.101</a>) (CONF:1098-8428).</p></li></ul></ul><ul><li><p>Every assignedEntity element <strong>SHALL</strong> contain at least one [1..*] assignedPerson or representedOrganization (CONF:1098-8429).</p></li></ul><ul><li><p>The id <strong>SHOULD</strong> include zero or one [0..1] <em>id</em> where id/@root="2.16.840.1.113883.4.6" National Provider Identifier (CONF:1098-32135).</p></li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"PRF"</b> Performer
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:1098-8424)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-30773)</b>.
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.1"</b><b> (CONF:1098-30774)</b>.</li>
+        </ul>
+        <ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b>
+              (CONF:1098-32564)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] US Realm Date and Time (DT.US.FIELDED)<b>
+          (identifier: 2.16.840.1.113883.10.20.22.5.3)</b><b> (CONF:1098-8425)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+          (CONF:1098-8426)</b>.<ul>
+          <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-10033)</b>.</li>
+        </ul>
+        <ul>
+          <li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-8427)</b>.</li>
+          <ul>
+            <li>
+              <p><strong>SHALL</strong> contain a valid DICOM personal identification code sequence (@codeSystem is
+                1.2.840.10008.2.16.4) or an appropriate national health care provider coding system (e.g., NUCC in the
+                U.S., where @codeSystem is <a href="https://terminology.hl7.org/CodeSystem-v3-nuccProviderCodes.html"
+                  target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.101</a>)
+                (CONF:1098-8428).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li>
+            <p>Every assignedEntity element <strong>SHALL</strong> contain at least one [1..*] assignedPerson or
+              representedOrganization (CONF:1098-8429).</p>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <p>The id <strong>SHOULD</strong> include zero or one [0..1] <em>id</em> where
+              id/@root="2.16.840.1.113883.4.6" National Provider Identifier (CONF:1098-32135).</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Physician%20Reading%20Study%20Performer%20(V2)_2.16.840.1.113883.10.20.6.2.1/Physician%20Reading%20Study%20Performer%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Physician Reading Study Performer (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Physician%20Reading%20Study%20Performer%20(V2)_2.16.840.1.113883.10.20.6.2.1/Physician%20Reading%20Study%20Performer%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Physician Reading Study Performer (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.10.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.10.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,101 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Referenced Frames Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.10, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.10.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Referenced Frames Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.10,
+        open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.10.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small>
+    </h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Referenced Frames Observation is used if the referenced DICOM SOP instance is a multiframe image and the reference does not apply to all frames. The list of integer values for the referenced frames of a DICOM multiframe image SOP instance is contained in a Boundary Observation nested inside this class.</p></div>
+    <div id="description">
+      <p>A Referenced Frames Observation is used if the referenced DICOM SOP instance is a multiframe image and the
+        reference does not apply to all frames. The list of integer values for the referenced frames of a DICOM
+        multiframe image SOP instance is contained in a Boundary Observation nested inside this class.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.11.html">Boundary Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.11.html">Boundary Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ROIBND"</b> Bounded Region of Interest (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9276)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-9277)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19164)</b>.<ul><li>This code <b>MAY</b> contain zero or one [0..1] <b>@code</b>=<b>"121190"</b> Referenced Frames (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b><b> STATIC</b>)<b> (CONF:81-19165)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>entryRelationship</b><b> (CONF:81-9279)</b>.<ul><li>This entryRelationship <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9280)</b>.</li></ul><ul><li>This entryRelationship <b>SHALL</b> contain exactly one [1..1]  Boundary Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.11)</b><b> (CONF:81-15923)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ROIBND"</b> Bounded
+        Region of Interest (CodeSystem: <b>HL7ActClass <a
+            href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:81-9276)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-9277)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19164)</b>.<ul>
+          <li>This code <b>MAY</b> contain zero or one [0..1] <b>@code</b>=<b>"121190"</b> Referenced Frames
+            (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b><b> STATIC</b>)<b> (CONF:81-19165)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>entryRelationship</b><b>
+          (CONF:81-9279)</b>.<ul>
+          <li>This entryRelationship <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component
+            (CodeSystem: <b>HL7ActRelationshipType <a
+                href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b>
+              (CONF:81-9280)</b>.</li>
+        </ul>
+        <ul>
+          <li>This entryRelationship <b>SHALL</b> contain exactly one [1..1] Boundary Observation<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.11)</b><b> (CONF:81-15923)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Referenced%20Frames%20Observation_2.16.840.1.113883.10.20.6.2.10/Referenced%20Frames%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Referenced Frames Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Referenced%20Frames%20Observation_2.16.840.1.113883.10.20.6.2.10/Referenced%20Frames%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Referenced Frames Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.11.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.11.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,90 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Boundary Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.11, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.11.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Boundary Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.11, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.6.2.11.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Boundary Observation contains a list of integer values for the referenced frames of a DICOM multiframe image SOP instance. It identifies the frame numbers within the referenced SOP instance to which the reference applies. The CDA Boundary Observation numbers frames using the same convention as DICOM, with the first frame in the referenced object being Frame 1. A Boundary Observation must be used if a referenced DICOM SOP instance is a multiframe image and the reference does not apply to all frames.</p></div>
+    <div id="description">
+      <p>A Boundary Observation contains a list of integer values for the referenced frames of a DICOM multiframe image
+        SOP instance. It identifies the frame numbers within the referenced SOP instance to which the reference applies.
+        The CDA Boundary Observation numbers frames using the same convention as DICOM, with the first frame in the
+        referenced object being Frame 1. A Boundary Observation must be used if a referenced DICOM SOP instance is a
+        multiframe image and the reference does not apply to all frames.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.10.html">Referenced Frames Observation</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.10.html">Referenced Frames Observation</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9282)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9283)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9284)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"113036"</b> Frames for Display (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b><b> STATIC</b>)<b> (CONF:81-19157)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>value</b> with @xsi:type="INT"<b> (CONF:81-9285)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-9282)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-9283)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9284)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"113036"</b> Frames for Display
+            (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b><b> STATIC</b>)<b> (CONF:81-19157)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>value</b> with @xsi:type="INT"<b>
+          (CONF:81-9285)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Boundary%20Observation_2.16.840.1.113883.10.20.6.2.11/Boundary%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Boundary Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Boundary%20Observation_2.16.840.1.113883.10.20.6.2.11/Boundary%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Boundary Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.12.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.12.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,138 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Text Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.12, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.12.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Text Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.12, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.6.2.12.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>DICOM Template 2000 specifies that Imaging Report Elements of Value Type Text are contained in sections. The Imaging Report Elements are inferred from Basic Diagnostic Imaging Report Observations that consist of image references and measurements (linear, area, volume, and numeric). Text DICOM Imaging Report Elements in this context are mapped to CDA text observations that are section components and are related to the SOP Instance Observations (templateId 2.16.840.1.113883.10.20.6.2.8) or Quantity Measurement Observations (templateId 2.16.840.1.113883.10.20.6.2.14) by the SPRT (Support) act relationship.</p><p>A Text Observation is required if the findings in the section text are represented as inferred from SOP Instance Observations.</p></div>
+    <div id="description">
+      <p>DICOM Template 2000 specifies that Imaging Report Elements of Value Type Text are contained in sections. The
+        Imaging Report Elements are inferred from Basic Diagnostic Imaging Report Observations that consist of image
+        references and measurements (linear, area, volume, and numeric). Text DICOM Imaging Report Elements in this
+        context are mapped to CDA text observations that are section components and are related to the SOP Instance
+        Observations (templateId 2.16.840.1.113883.10.20.6.2.8) or Quantity Measurement Observations (templateId
+        2.16.840.1.113883.10.20.6.2.14) by the SPRT (Support) act relationship.</p>
+      <p>A Text Observation is required if the findings in the section text are represented as inferred from SOP
+        Instance Observations.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br><a href="2.16.840.1.113883.10.20.6.2.14.html">Quantity Measurement Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.14.html">Quantity Measurement Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9288)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-9289)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9290)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.12"</b><b> (CONF:81-10534)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9291)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>text</b><b> (CONF:81-9295)</b>.<ul><li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:81-15938)</b>.</li><ul><li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:81-15939)</b>.</li><ul><li><p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:81-15940).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9294)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b> (CONF:81-9292)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9298)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9299)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  SOP Instance Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:81-15941)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9301)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9302)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Quantity Measurement Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.14)</b><b> (CONF:81-15942)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-9288)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-9289)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9290)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.12"</b><b>
+              (CONF:81-10534)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9291)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>text</b><b> (CONF:81-9295)</b>.<ul>
+          <li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:81-15938)</b>.
+          </li>
+          <ul>
+            <li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b>
+                (CONF:81-15939)</b>.</li>
+            <ul>
+              <li>
+                <p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using
+                  the approach defined in CDA Release 2, section 4.3.5.1) (CONF:81-15940).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9294)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="ED"<b>
+          (CONF:81-9292)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9298)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9299)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] SOP Instance Observation<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:81-15941)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9301)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9302)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Quantity Measurement Observation<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.14)</b><b> (CONF:81-15942)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Text%20Observation_2.16.840.1.113883.10.20.6.2.12/Text%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Text Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Text%20Observation_2.16.840.1.113883.10.20.6.2.12/Text%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Text Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.13.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.13.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,122 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Code Observations <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.13, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.13.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Code Observations <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.13, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.6.2.13.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>DICOM Template 2000 specifies that Imaging Report Elements of Value Type Code are contained in sections. The Imaging Report Elements are inferred from Basic Diagnostic Imaging Report Observations that consist of image references and measurements (linear, area, volume, and numeric). Coded DICOM Imaging Report Elements in this context are mapped to CDA-coded observations that are section components and are related to the SOP Instance Observations (templateId 2.16.840.1.113883.10.20.6.2.8) or Quantity Measurement Observations (templateId 2.16.840.1.113883.10.20.6.2.14) by the SPRT (Support) act relationship.</p></div>
+    <div id="description">
+      <p>DICOM Template 2000 specifies that Imaging Report Elements of Value Type Code are contained in sections. The
+        Imaging Report Elements are inferred from Basic Diagnostic Imaging Report Observations that consist of image
+        references and measurements (linear, area, volume, and numeric). Coded DICOM Imaging Report Elements in this
+        context are mapped to CDA-coded observations that are section components and are related to the SOP Instance
+        Observations (templateId 2.16.840.1.113883.10.20.6.2.8) or Quantity Measurement Observations (templateId
+        2.16.840.1.113883.10.20.6.2.14) by the SPRT (Support) act relationship.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br><a href="2.16.840.1.113883.10.20.6.2.14.html">Quantity Measurement Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.14.html">Quantity Measurement Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9304)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-9305)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-15523)</b>.<ul><li>This templateId <b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.13"</b><b> (CONF:81-15524)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19181)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9309)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:81-9308)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9311)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9312)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  SOP Instance Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:81-16083)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9314)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9315)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Quantity Measurement Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.14)</b><b> (CONF:81-16084)</b>.</li></ul></li>
-<li class="list-group-item"> <p>Code Observations SHALL be rendered into section/text in separate paragraphs (CONF:81-9310).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-9304)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-9305)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-15523)</b>.<ul>
+          <li>This templateId <b>SHALL</b> contain exactly one [1..1]
+            <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.13"</b><b> (CONF:81-15524)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19181)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9309)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b><b> (CONF:81-9308)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9311)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9312)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] SOP Instance Observation<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:81-16083)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9314)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9315)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Quantity Measurement Observation<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.14)</b><b> (CONF:81-16084)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Code Observations SHALL be rendered into section/text in separate paragraphs (CONF:81-9310).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Code%20Observations_2.16.840.1.113883.10.20.6.2.13/Code%20Observations%20Example.xml"><i class="fab fa-github"></i>&nbsp;Code Observations Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Code%20Observations_2.16.840.1.113883.10.20.6.2.13/Code%20Observations%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Code Observations Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.14.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.14.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,55 +52,116 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Quantity Measurement Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.14, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.14.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Quantity Measurement Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.6.2.14, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.14.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Quantity Measurement Observation records quantity measurements based on image data such as linear, area, volume, and numeric measurements. The codes in DIRQuantityMeasurementTypeCodes (ValueSet: 2.16.840.1.113883.11.20.9.29) are from the qualifier hierarchy of SNOMED CT and are not valid for observation/code according to the Term Info guidelines. These codes can be used for backwards compatibility, but going forward, codes from the observable entity hierarchy will be requested and used.</p></div>
+    <div id="description">
+      <p>A Quantity Measurement Observation records quantity measurements based on image data such as linear, area,
+        volume, and numeric measurements. The codes in DIRQuantityMeasurementTypeCodes (ValueSet:
+        2.16.840.1.113883.11.20.9.29) are from the qualifier hierarchy of SNOMED CT and are not valid for
+        observation/code according to the Term Info guidelines. These codes can be used for backwards compatibility, but
+        going forward, codes from the observable entity hierarchy will be requested and used.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.12.html">Text Observation</a><br><a href="2.16.840.1.113883.10.20.6.2.13.html">Code Observations</a><br><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.12.html">Text Observation</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.13.html">Code Observations</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9317)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-9318)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9319)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.14"</b><b> (CONF:81-10532)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9320)</b>.<ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from ValueSet DIRQuantityMeasurementTypeCodes<b> <a href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.29/expansion/Latest" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.29</a></b><b> DYNAMIC</b><b> (CONF:81-19210)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9326)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b> (CONF:81-9324)</b>.</li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9327)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9328)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  SOP Instance Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:81-15916)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-9317)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-9318)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9319)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.14"</b><b>
+              (CONF:81-10532)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9320)</b>.<ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>, which <b>SHOULD</b> be selected from
+            ValueSet DIRQuantityMeasurementTypeCodes<b> <a
+                href="https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.29/expansion/Latest"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.11.20.9.29</a></b><b>
+              DYNAMIC</b><b> (CONF:81-19210)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9326)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>value</b> with @xsi:type="PQ"<b>
+          (CONF:81-9324)</b>.</li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9327)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SPRT"</b> Has Support (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9328)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] SOP Instance Observation<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.8)</b><b> (CONF:81-15916)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Quantity%20Measurement%20Observation_2.16.840.1.113883.10.20.6.2.14/Quantity%20Measurement%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Quantity Measurement Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Quantity%20Measurement%20Observation_2.16.840.1.113883.10.20.6.2.14/Quantity%20Measurement%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Quantity Measurement Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.2.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.2.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,131 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Physician of Record Participant (V2) <small class="text-muted">[encounterParticipant, 2.16.840.1.113883.10.20.6.2.2, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.2.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Physician of Record Participant (V2) <small class="text-muted">[encounterParticipant,
+        2.16.840.1.113883.10.20.6.2.2, release 2014-06-09, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.2.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>This encounterParticipant is the attending physician and is usually different from the Physician Reading Study Performer defined in documentationOf/serviceEvent.</p></div>
+    <div id="description">
+      <p>This encounterParticipant is the attending physician and is usually different from the Physician Reading Study
+        Performer defined in documentationOf/serviceEvent.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br>
+          </td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.5.1.1.html">US Realm Person Name (PN.US.FIELDED)</a><br>
+          </td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"ATND"</b> Attender (CodeSystem: <b>HL7ParticipationType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b> (CONF:1098-8881)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16072)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.2"</b><b> (CONF:1098-16073)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32586)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b> (CONF:1098-8886)</b>.<ul><li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8887)</b>.</li><ul><li><p><strong>SHOULD</strong> contain zero or one [0..1] <em>id</em> such that *@root="2.16.840.1.113883.4.6" National Provider Identifier (CONF:1098-31203).</p></li></ul></ul><ul><li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-8888)</b>.</li><ul><li><p><strong>SHALL</strong> contain a valid DICOM Organizational Role from DICOM CID 7452  (Value Set 1.2.840.10008.6.1.516) (@codeSystem is 1.2.840.10008.2.16.4) or an appropriate national health care provider coding system (e.g., NUCC in the U.S., where @codeSystem is <a href="https://terminology.hl7.org/CodeSystem-v3-nuccProviderCodes.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.101</a>). Footnote: DICOM Part 16 (NEMA PS3.16), page 631 in the 2011 edition. See [URL:ftp://medical.nema.org/medical/dicom/2011/11_16pu.pdf] (CONF:1098-8889).</p></li></ul></ul><ul><li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>assignedPerson</b><b> (CONF:1098-30928)</b>.</li><ul><li>The assignedPerson, if present, <b>SHALL</b> contain exactly one [1..1]  US Realm Person Name (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1098-30929)</b>.</li></ul></ul><ul><li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>representedOrganization</b><b> (CONF:1098-16074)</b>.</li><ul><li>The representedOrganization, if present, <b>SHOULD</b> contain zero or one [0..1] <b>name</b><b> (CONF:1098-16075)</b>.</li></ul></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"ATND"</b> Attender
+        (CodeSystem: <b>HL7ParticipationType <a
+            href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ParticipationType.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.90</a>)</b><b> STATIC</b>)<b>
+          (CONF:1098-8881)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:1098-16072)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.2"</b><b>
+              (CONF:1098-16073)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@extension</b>=<b>"2014-06-09"</b><b> (CONF:1098-32586)</b>.
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>assignedEntity</b><b>
+          (CONF:1098-8886)</b>.<ul>
+          <li>This assignedEntity <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:1098-8887)</b>.</li>
+          <ul>
+            <li>
+              <p><strong>SHOULD</strong> contain zero or one [0..1] <em>id</em> such that *@root="2.16.840.1.113883.4.6"
+                National Provider Identifier (CONF:1098-31203).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This assignedEntity <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:1098-8888)</b>.</li>
+          <ul>
+            <li>
+              <p><strong>SHALL</strong> contain a valid DICOM Organizational Role from DICOM CID 7452 (Value Set
+                1.2.840.10008.6.1.516) (@codeSystem is 1.2.840.10008.2.16.4) or an appropriate national health care
+                provider coding system (e.g., NUCC in the U.S., where @codeSystem is <a
+                  href="https://terminology.hl7.org/CodeSystem-v3-nuccProviderCodes.html" target="_blank"><i
+                    class="fas fa-external-link-alt"></i> 2.16.840.1.113883.6.101</a>). Footnote: DICOM Part 16 (NEMA
+                PS3.16), page 631 in the 2011 edition. See [URL:ftp://medical.nema.org/medical/dicom/2011/11_16pu.pdf]
+                (CONF:1098-8889).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This assignedEntity <b>SHOULD</b> contain zero or one [0..1] <b>assignedPerson</b><b>
+              (CONF:1098-30928)</b>.</li>
+          <ul>
+            <li>The assignedPerson, if present, <b>SHALL</b> contain exactly one [1..1] US Realm Person Name
+              (PN.US.FIELDED)<b> (identifier: 2.16.840.1.113883.10.20.22.5.1.1)</b><b> (CONF:1098-30929)</b>.</li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This assignedEntity <b>MAY</b> contain zero or one [0..1] <b>representedOrganization</b><b>
+              (CONF:1098-16074)</b>.</li>
+          <ul>
+            <li>The representedOrganization, if present, <b>SHOULD</b> contain zero or one [0..1] <b>name</b><b>
+                (CONF:1098-16075)</b>.</li>
+          </ul>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Physician%20of%20Record%20Participant%20(V2)_2.16.840.1.113883.10.20.6.2.2/Physician%20of%20Record%20Participant%20(V2)%20Example.xml"><i class="fab fa-github"></i>&nbsp;Physician of Record Participant (V2) Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Physician%20of%20Record%20Participant%20(V2)_2.16.840.1.113883.10.20.6.2.2/Physician%20of%20Record%20Participant%20(V2)%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Physician of Record Participant (V2) Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.3.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.3.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,94 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Fetus Subject Context <small class="text-muted">[relatedSubject, 2.16.840.1.113883.10.20.6.2.3, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Fetus Subject Context <small class="text-muted">[relatedSubject, 2.16.840.1.113883.10.20.6.2.3, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.6.2.3.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>For reports on mothers and their fetus(es), information on a mother is mapped to recordTarget, PatientRole, and Patient. Information on the fetus is mapped to subject, relatedSubject, and SubjectPerson at the CDA section level. Both context information on the mother and fetus must be included in the document if observations on fetus(es) are contained in the document.</p></div>
+    <div id="description">
+      <p>For reports on mothers and their fetus(es), information on a mother is mapped to recordTarget, PatientRole, and
+        Patient. Information on the fetus is mapped to subject, relatedSubject, and SubjectPerson at the CDA section
+        level. Both context information on the mother and fetus must be included in the document if observations on
+        fetus(es) are contained in the document.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br>
+          </td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9189)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.3"</b><b> (CONF:81-10535)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9190)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"121026"</b><b> (CONF:81-26455)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b> (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26476)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>subject</b><b> (CONF:81-9191)</b>.<ul><li>This subject <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:81-15347)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9189)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.3"</b><b>
+              (CONF:81-10535)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9190)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"121026"</b><b> (CONF:81-26455)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b>
+            (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26476)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>subject</b><b> (CONF:81-9191)</b>.<ul>
+          <li>This subject <b>SHALL</b> contain exactly one [1..1] <b>name</b><b> (CONF:81-15347)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Fetus%20Subject%20Context_2.16.840.1.113883.10.20.6.2.3/Fetus%20Subject%20Context%20Example.xml"><i class="fab fa-github"></i>&nbsp;Fetus Subject Context Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Fetus%20Subject%20Context_2.16.840.1.113883.10.20.6.2.3/Fetus%20Subject%20Context%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Fetus Subject Context Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.4.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.4.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,51 +52,83 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Observer Context <small class="text-muted">[assignedAuthor, 2.16.840.1.113883.10.20.6.2.4, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.4.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Observer Context <small class="text-muted">[assignedAuthor, 2.16.840.1.113883.10.20.6.2.4, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.6.2.4.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Observer Context is used to override the author specified in the CDA Header. It is valid as a direct child element of a section.</p></div>
+    <div id="description">
+      <p>The Observer Context is used to override the author specified in the CDA Header. It is valid as a direct child
+        element of a section.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br>
+          </td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9194)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.4"</b><b> (CONF:81-10536)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-9196)</b>.</li>
-<li class="list-group-item"> <p>Either assignedPerson or assignedAuthoringDevice SHALL be present (CONF:81-9198).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9194)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.4"</b><b>
+              (CONF:81-10536)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-9196)</b>.</li>
+      <li class="list-group-item">
+        <p>Either assignedPerson or assignedAuthoringDevice SHALL be present (CONF:81-9198).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Observer%20Context_2.16.840.1.113883.10.20.6.2.4/Observer%20Context%20Example.xml"><i class="fab fa-github"></i>&nbsp;Observer Context Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Observer%20Context_2.16.840.1.113883.10.20.6.2.4/Observer%20Context%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Observer Context Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.5.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.5.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,52 +52,100 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Procedure Context <small class="text-muted">[act, 2.16.840.1.113883.10.20.6.2.5, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Procedure Context <small class="text-muted">[act, 2.16.840.1.113883.10.20.6.2.5, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.6.2.5.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The ServiceEvent Procedure Context of the document header may be overridden in the CDA structured body if there is a need to refer to multiple imaging procedures or acts. The selection of the Procedure or Act entry from the clinical statement choice box depends on the nature of the imaging service that has been performed. The Procedure entry shall be used for image-guided interventions and minimally invasive imaging services, whereas the Act entry shall be used for diagnostic imaging services.</p></div>
+    <div id="description">
+      <p>The ServiceEvent Procedure Context of the document header may be overridden in the CDA structured body if there
+        is a need to refer to multiple imaging procedures or acts. The selection of the Procedure or Act entry from the
+        clinical statement choice box depends on the nature of the imaging service that has been performed. The
+        Procedure entry shall be used for image-guided interventions and minimally invasive imaging services, whereas
+        the Act entry shall be used for diagnostic imaging services.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br>
+          </td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:81-26452)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:81-26453)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9200)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.5"</b><b> (CONF:81-10530)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9201)</b>.</li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9203)</b>.<ul><li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:81-17173)</b>.</li></ul></li>
-<li class="list-group-item"> <p>Procedure Context SHALL be represented with the procedure or act elements depending on the nature of the procedure (CONF:81-9199).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b>)<b> (CONF:81-26452)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b>)<b> (CONF:81-26453)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9200)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.5"</b><b>
+              (CONF:81-10530)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9201)</b>.</li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9203)</b>.
+        <ul>
+          <li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b>
+              (CONF:81-17173)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item">
+        <p>Procedure Context SHALL be represented with the procedure or act elements depending on the nature of the
+          procedure (CONF:81-9199).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Context_2.16.840.1.113883.10.20.6.2.5/Procedure%20Context%20Example.xml"><i class="fab fa-github"></i>&nbsp;Procedure Context Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Procedure%20Context_2.16.840.1.113883.10.20.6.2.5/Procedure%20Context%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Procedure Context Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch">CDA Search Examples</h4>
-  <ul id="cdasearch_examples"><li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a></li></ul>
+    <h4 id="cdasearch">CDA Search Examples</h4>
+    <ul id="cdasearch_examples">
+      <li><a href="http://cdasearch.hl7.org/sections/Procedures"><i class="fas fa-external-link-alt"></i> Procedures</a>
+      </li>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.6.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.6.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,56 +52,137 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Study Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.6.2.6, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.6.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Study Act <small class="text-muted">[act, 2.16.840.1.113883.10.20.6.2.6, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.6.2.6.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Study Act contains the DICOM study information that defines the characteristics of a referenced medical study performed on a patient. A study is a collection of one or more series of medical images, presentation states, SR documents, overlays, and/or curves that are logically related for the purpose of diagnosing a patient. Each study is associated with exactly one patient. A study may include composite instances that are created by a single modality, multiple modalities, or by multiple devices of the same modality. The study information is modality-independent. Study Act clinical statements are only instantiated in the DICOM Object Catalog section; in other sections, the SOP Instance Observation is included directly.</p></div>
+    <div id="description">
+      <p>A Study Act contains the DICOM study information that defines the characteristics of a referenced medical study
+        performed on a patient. A study is a collection of one or more series of medical images, presentation states, SR
+        documents, overlays, and/or curves that are logically related for the purpose of diagnosing a patient. Each
+        study is associated with exactly one patient. A study may include composite instances that are created by a
+        single modality, multiple modalities, or by multiple devices of the same modality. The study information is
+        modality-independent. Study Act clinical statements are only instantiated in the DICOM Object Catalog section;
+        in other sections, the SOP Instance Observation is included directly.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.1.1.html">DICOM Object Catalog Section - DCM 121181</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.63.html">Series Act</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.1.1.html">DICOM Object Catalog Section - DCM
+              121181</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.22.4.63.html">Series Act</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9207)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-9208)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9209)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.6"</b><b> (CONF:81-10533)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-9210)</b>.<ul><li>Such ids <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:81-9213)</b>.</li></ul><ul><li>Such ids <b>SHALL NOT</b> contain [0..0] <b>@extension</b><b> (CONF:81-9211)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19172)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"113014"</b><b> (CONF:81-19173)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b> (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26506)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>text</b><b> (CONF:81-9215)</b>.<ul><li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:81-15995)</b>.</li><ul><li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b> (CONF:81-15996)</b>.</li><ul><li><p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:81-15997).</p></li></ul></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9216)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b> (CONF:81-9219)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9220)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Series Act<b> (identifier: 2.16.840.1.113883.10.20.22.4.63)</b><b> (CONF:81-15937)</b>.</li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"ACT"</b> (CodeSystem:
+        <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b>
+          (CONF:81-9207)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> (CodeSystem:
+        <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i
+              class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-9208)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9209)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.6"</b><b>
+              (CONF:81-10533)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-9210)</b>.<ul>
+          <li>Such ids <b>SHALL</b> contain exactly one [1..1] <b>@root</b><b> (CONF:81-9213)</b>.</li>
+        </ul>
+        <ul>
+          <li>Such ids <b>SHALL NOT</b> contain [0..0] <b>@extension</b><b> (CONF:81-9211)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-19172)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"113014"</b><b> (CONF:81-19173)</b>.
+          </li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.16.4"</b>
+            (CodeSystem: <b>DCM 1.2.840.10008.2.16.4</b>)<b> (CONF:81-26506)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or one [0..1] <b>text</b><b> (CONF:81-9215)</b>.<ul>
+          <li>The text, if present, <b>SHOULD</b> contain zero or one [0..1] <b>reference</b><b> (CONF:81-15995)</b>.
+          </li>
+          <ul>
+            <li>The reference, if present, <b>SHOULD</b> contain zero or one [0..1] <b>@value</b><b>
+                (CONF:81-15996)</b>.</li>
+            <ul>
+              <li>
+                <p>This reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using
+                  the approach defined in CDA Release 2, section 4.3.5.1) (CONF:81-15997).</p>
+              </li>
+            </ul>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9216)</b>.
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>entryRelationship</b><b>
+          (CONF:81-9219)</b> such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9220)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Series Act<b> (identifier: 2.16.840.1.113883.10.20.22.4.63)</b><b>
+              (CONF:81-15937)</b>.</li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Study%20Act_2.16.840.1.113883.10.20.6.2.6/Study%20Act%20Example.xml"><i class="fab fa-github"></i>&nbsp;Study Act Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Study%20Act_2.16.840.1.113883.10.20.6.2.6/Study%20Act%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Study Act Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.8.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.8.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,57 +52,163 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">SOP Instance Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.8, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.8.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">SOP Instance Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.8, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.6.2.8.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A SOP Instance Observation contains the DICOM Service Object Pair (SOP) Instance information for referenced DICOM composite objects. The SOP Instance act class is used to reference both image and non-image DICOM instances. The text attribute contains the DICOM WADO reference.</p></div>
+    <div id="description">
+      <p>A SOP Instance Observation contains the DICOM Service Object Pair (SOP) Instance information for referenced
+        DICOM composite objects. The SOP Instance act class is used to reference both image and non-image DICOM
+        instances. The text attribute contains the DICOM WADO reference.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.63.html">Series Act</a><br><a href="2.16.840.1.113883.10.20.6.2.12.html">Text Observation</a><br><a href="2.16.840.1.113883.10.20.6.2.13.html">Code Observations</a><br><a href="2.16.840.1.113883.10.20.6.2.14.html">Quantity Measurement Observation</a><br><a href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
-        <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.9.html">Purpose of Reference Observation</a><br><a href="2.16.840.1.113883.10.20.6.2.10.html">Referenced Frames Observation</a><br></td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.4.63.html">Series Act</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.12.html">Text Observation</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.13.html">Code Observations</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.14.html">Quantity Measurement Observation</a><br><a
+              href="2.16.840.1.113883.10.20.22.1.5.html">Diagnostic Imaging Report (V3)</a><br></td>
+          <td id="Contains"><a href="2.16.840.1.113883.10.20.6.2.9.html">Purpose of Reference Observation</a><br><a
+              href="2.16.840.1.113883.10.20.6.2.10.html">Referenced Frames Observation</a><br></td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"DGIMG"</b> Diagnostic Image (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9240)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-9241)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-9242)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9244)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:81-19225)</b>.</li><ul><li><p>@code is an OID for a valid SOP class name UID (CONF:81-19226).</p></li></ul></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.6.1"</b> DCMUID<b> (CONF:81-19227)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:81-9246)</b>.<ul><li>The text, if present, <b>SHALL</b> contain exactly one [1..1] <b>@mediaType</b>=<b>"application/dicom"</b><b> (CONF:81-9247)</b>.</li></ul><ul><li>The text, if present, <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:81-9248)</b>.</li><ul><li><p><strong>SHALL</strong> contain a @value that contains a WADO reference as a URI (CONF:81-9249).</p></li></ul></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9250)</b>.<ul><li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b> (CONF:81-9251)</b>.</li></ul><ul><li>The effectiveTime, if present, <b>SHALL NOT</b> contain [0..0] <b>low</b><b> (CONF:81-9252)</b>.</li></ul><ul><li>The effectiveTime, if present, <b>SHALL NOT</b> contain [0..0] <b>high</b><b> (CONF:81-9253)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9254)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9255)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9257)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9258)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Purpose of Reference Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.9)</b><b> (CONF:81-15935)</b>.</li></ul></li>
-<li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9260)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem: <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b> STATIC</b>)<b> (CONF:81-9261)</b>.</li></ul><ul><li><b>SHALL</b> contain exactly one [1..1]  Referenced Frames Observation<b> (identifier: 2.16.840.1.113883.10.20.6.2.10)</b><b> (CONF:81-15936)</b>.</li></ul><ul><li><p>This entryRelationship SHALL be present if the referenced DICOM object is a multiframe object and the reference does not apply to all frames (CONF:81-9263).</p></li></ul></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"DGIMG"</b> Diagnostic
+        Image (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-9240)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-9241)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain at least one [1..*] <b>id</b><b> (CONF:81-9242)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9244)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b><b> (CONF:81-19225)</b>.</li>
+          <ul>
+            <li>
+              <p>@code is an OID for a valid SOP class name UID (CONF:81-19226).</p>
+            </li>
+          </ul>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"1.2.840.10008.2.6.1"</b>
+            DCMUID<b> (CONF:81-19227)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>text</b><b> (CONF:81-9246)</b>.<ul>
+          <li>The text, if present, <b>SHALL</b> contain exactly one [1..1]
+            <b>@mediaType</b>=<b>"application/dicom"</b><b> (CONF:81-9247)</b>.</li>
+        </ul>
+        <ul>
+          <li>The text, if present, <b>SHALL</b> contain exactly one [1..1] <b>reference</b><b> (CONF:81-9248)</b>.</li>
+          <ul>
+            <li>
+              <p><strong>SHALL</strong> contain a @value that contains a WADO reference as a URI (CONF:81-9249).</p>
+            </li>
+          </ul>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>effectiveTime</b><b> (CONF:81-9250)</b>.
+        <ul>
+          <li>The effectiveTime, if present, <b>SHALL</b> contain exactly one [1..1] <b>@value</b><b>
+              (CONF:81-9251)</b>.</li>
+        </ul>
+        <ul>
+          <li>The effectiveTime, if present, <b>SHALL NOT</b> contain [0..0] <b>low</b><b> (CONF:81-9252)</b>.</li>
+        </ul>
+        <ul>
+          <li>The effectiveTime, if present, <b>SHALL NOT</b> contain [0..0] <b>high</b><b> (CONF:81-9253)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9254)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"SUBJ"</b> Has Subject (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9255)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9257)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"RSON"</b> Has Reason (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9258)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Purpose of Reference Observation<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.9)</b><b> (CONF:81-15935)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>MAY</b> contain zero or more [0..*] <b>entryRelationship</b><b> (CONF:81-9260)</b>
+        such that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@typeCode</b>=<b>"COMP"</b> Has Component (CodeSystem:
+            <b>HL7ActRelationshipType <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActRelationshipType.html"
+                target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1002</a></b><b>
+              STATIC</b>)<b> (CONF:81-9261)</b>.</li>
+        </ul>
+        <ul>
+          <li><b>SHALL</b> contain exactly one [1..1] Referenced Frames Observation<b> (identifier:
+              2.16.840.1.113883.10.20.6.2.10)</b><b> (CONF:81-15936)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>This entryRelationship SHALL be present if the referenced DICOM object is a multiframe object and the
+              reference does not apply to all frames (CONF:81-9263).</p>
+          </li>
+        </ul>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/SOP%20Instance%20Observation_2.16.840.1.113883.10.20.6.2.8/SOP%20Instance%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;SOP Instance Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/SOP%20Instance%20Observation_2.16.840.1.113883.10.20.6.2.8/SOP%20Instance%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;SOP Instance Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.6.2.9.html
+++ b/templates/2.16.840.1.113883.10.20.6.2.9.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,104 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Purpose of Reference Observation <small class="text-muted">[observation, 2.16.840.1.113883.10.20.6.2.9, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.9.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Purpose of Reference Observation <small class="text-muted">[observation,
+        2.16.840.1.113883.10.20.6.2.9, open] <a href="../pdfs/2.16.840.1.113883.10.20.6.2.9.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>A Purpose of Reference Observation describes the purpose of the DICOM composite object reference. Appropriate codes, such as externally defined DICOM codes, may be used to specify the semantics of the purpose of reference. When this observation is absent, it implies that the reason for the reference is unknown.</p></div>
+    <div id="description">
+      <p>A Purpose of Reference Observation describes the purpose of the DICOM composite object reference. Appropriate
+        codes, such as externally defined DICOM codes, may be used to specify the semantics of the purpose of reference.
+        When this observation is absent, it implies that the reason for the reference is unknown.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.6.2.8.html">SOP Instance Observation</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-9264)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b> (CONF:81-9265)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9266)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.9"</b><b> (CONF:81-10531)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9267)</b>.<ul><li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion (CodeSystem: <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b><b> STATIC</b>)<b> (CONF:81-19208)</b>.</li></ul><ul><li><p>For backwards compatibility with the DICOM CMET, the code MAY be drawn from ValueSet 2.16.840.1.113883.11.20.9.28 DICOMPurposeOfReference DYNAMIC (CONF:81-19209).</p></li></ul></li>
-<li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>value</b> with @xsi:type="CD", where the code <b>SHOULD</b> be selected from ValueSet DICOMPurposeOfReference<b> 2.16.840.1.113883.11.20.9.28</b><b> DYNAMIC</b><b> (CONF:81-9273)</b>.</li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@classCode</b>=<b>"OBS"</b> Observation
+        (CodeSystem: <b>HL7ActClass <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActClass.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.6</a>&nbsp;</b><b>
+          STATIC</b>)<b> (CONF:81-9264)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>@moodCode</b>=<b>"EVN"</b> Event
+        (CodeSystem: <b>HL7ActMood <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActMood.html"
+            target="_blank"><i class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.1001</a></b><b> STATIC</b>)<b>
+          (CONF:81-9265)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-9266)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.6.2.9"</b><b>
+              (CONF:81-10531)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-9267)</b>.<ul>
+          <li>This code <b>SHOULD</b> contain zero or one [0..1] <b>@code</b>=<b>"ASSERTION"</b> Assertion (CodeSystem:
+            <b>HL7ActCode <a href="https://terminology.hl7.org/1.0.0/CodeSystem-v3-ActCode.html" target="_blank"><i
+                  class="fas fa-external-link-alt"></i> 2.16.840.1.113883.5.4</a>&nbsp;</b><b> STATIC</b>)<b>
+              (CONF:81-19208)</b>.</li>
+        </ul>
+        <ul>
+          <li>
+            <p>For backwards compatibility with the DICOM CMET, the code MAY be drawn from ValueSet
+              2.16.840.1.113883.11.20.9.28 DICOMPurposeOfReference DYNAMIC (CONF:81-19209).</p>
+          </li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHOULD</b> contain zero or one [0..1] <b>value</b> with @xsi:type="CD", where the
+        code <b>SHOULD</b> be selected from ValueSet DICOMPurposeOfReference<b> 2.16.840.1.113883.11.20.9.28</b><b>
+          DYNAMIC</b><b> (CONF:81-9273)</b>.</li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Purpose%20of%20Reference%20Observation_2.16.840.1.113883.10.20.6.2.9/Purpose%20of%20Reference%20Observation%20Example.xml"><i class="fab fa-github"></i>&nbsp;Purpose of Reference Observation Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Purpose%20of%20Reference%20Observation_2.16.840.1.113883.10.20.6.2.9/Purpose%20of%20Reference%20Observation%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Purpose of Reference Observation Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.7.12.html
+++ b/templates/2.16.840.1.113883.10.20.7.12.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,92 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Operative Note Fluids Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.7.12, open] <a href="../pdfs/2.16.840.1.113883.10.20.7.12.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Operative Note Fluids Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.7.12, open]
+        <a href="../pdfs/2.16.840.1.113883.10.20.7.12.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Operative Note Fluids Section may be used to record fluids administered during the surgical procedure.</p></div>
+    <div id="description">
+      <p>The Operative Note Fluids Section may be used to record fluids administered during the surgical procedure.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8030)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.7.12"</b><b> (CONF:81-10463)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15391)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10216-0"</b> Operative Note Fluids<b> (CONF:81-15392)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26486)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8032)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8033)</b>.</li>
-<li class="list-group-item"> <p>If the Operative Note Fluids section is present, there SHALL be a statement providing details of the fluids administered or SHALL explicitly state there were no fluids administered (CONF:81-8052).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8030)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.7.12"</b><b>
+              (CONF:81-10463)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15391)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10216-0"</b> Operative Note Fluids<b>
+              (CONF:81-15392)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26486)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8032)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8033)</b>.</li>
+      <li class="list-group-item">
+        <p>If the Operative Note Fluids section is present, there SHALL be a statement providing details of the fluids
+          administered or SHALL explicitly state there were no fluids administered (CONF:81-8052).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Operative%20Note%20Fluids%20Section_2.16.840.1.113883.10.20.7.12/Operative%20Note%20Fluids%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Operative Note Fluids Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Operative%20Note%20Fluids%20Section_2.16.840.1.113883.10.20.7.12/Operative%20Note%20Fluids%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Operative Note Fluids Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.7.13.html
+++ b/templates/2.16.840.1.113883.10.20.7.13.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,93 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Surgical Drains Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.7.13, open] <a href="../pdfs/2.16.840.1.113883.10.20.7.13.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Surgical Drains Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.7.13, open] <a
+          href="../pdfs/2.16.840.1.113883.10.20.7.13.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Surgical Drains Section may be used to record drains placed during the surgical procedure. Optionally, surgical drain placement may be represented with a text element in the Procedure Description Section.</p></div>
+    <div id="description">
+      <p>The Surgical Drains Section may be used to record drains placed during the surgical procedure. Optionally,
+        surgical drain placement may be represented with a text element in the Procedure Description Section.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8038)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.7.13"</b><b> (CONF:81-10473)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15441)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11537-8"</b> Surgical Drains<b> (CONF:81-15442)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26498)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8040)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8041)</b>.</li>
-<li class="list-group-item"> <p>If the Surgical Drains section is present, there SHALL be a statement providing details of the drains placed or SHALL explicitly state there were no drains placed (CONF:81-8056).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8038)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.7.13"</b><b>
+              (CONF:81-10473)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15441)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"11537-8"</b> Surgical Drains<b>
+              (CONF:81-15442)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26498)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8040)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8041)</b>.</li>
+      <li class="list-group-item">
+        <p>If the Surgical Drains section is present, there SHALL be a statement providing details of the drains placed
+          or SHALL explicitly state there were no drains placed (CONF:81-8056).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Surgical%20Drains%20Section_2.16.840.1.113883.10.20.7.13/Surgical%20Drains%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Surgical Drains Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Surgical%20Drains%20Section_2.16.840.1.113883.10.20.7.13/Surgical%20Drains%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Surgical Drains Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>

--- a/templates/2.16.840.1.113883.10.20.7.14.html
+++ b/templates/2.16.840.1.113883.10.20.7.14.html
@@ -1,16 +1,25 @@
-<!DOCTYPE html><html lang="en"><head>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
   <title>C-CDA Online</title>
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+    crossorigin="anonymous"></script>
   <!-- Font awesome icons -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" crossorigin="anonymous">
   <!-- jQuery library -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  <link rel="icon" href="../img/favicon.ico" type="image/x-icon"></head>
+  <link rel="icon" href="../img/favicon.ico" type="image/x-icon">
+</head>
 
 <body>
   <div class="jumbotron container-fluid" style="padding-bottom:24px; padding-top:24px;">
@@ -18,18 +27,24 @@
       <div class="col-12">
         <img class="rounded" style="max-width:20%" src="../img/cda.png">
         <!-- <i class="fas fa-book-medical"></i>&nbsp;<strong>C-CDA Online</strong> -->
-        <div style="font-size:0.4em"> 
-          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website for C-CDA 2.1</span>
+        <div style="font-size:0.4em">
+          <strong style="font-weight:500"><a href="../index.html">C-CDA Online</a></strong><span>: A navigation website
+            for C-CDA 2.1</span>
           <br>
         </div>
       </div>
     </h1>
     <div class="row">
       <div class="col-10">
-        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the Consolidated Clinical Document Architecture (C-CDA)
-        2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
-        <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.</p>
-        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
+        <p style="margin-bottom: 0.25rem">This beta navigation tool is generated from the published PDF of the
+          Consolidated Clinical Document Architecture (C-CDA)
+          2.1 (June 2019 Errata) and the C-CDA 2.1 Companion Guide R3 (May 2022 Publication). For the latest information
+          on C-CDA, or to access the Supplemental Implementation Guides, please refer to the
+          <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 C-CDA Page</a>.
+        </p>
+        <p style="margin-bottom: 0.25rem">CDA and C-CDA are copyright property of <a
+            href="https://www.hl7.org/index.cfm"> Health Level Seven (HL7)</a> and subject to the terms of <a
+            href="http://www.HL7.org/legal/ippolicy.cfm">HL7's IP policy</a>.</p>
       </div>
     </div>
     <div>
@@ -37,53 +52,95 @@
     <hr>
     <div id="user-sign-up" style="font-size: 1rem;">
       <p>HL7 encourages users to sign up for an account, which is free!</p>
-      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up 
-        <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated: August 2022.
+      Please <u><a class="btn btn-primary" href="https://qcommerce.hl7.org/qcommercenet/NewUser/Index.aspx">sign up
+          <i class="fas fa-user-plus"></i></a></u> if you do not have an account. C-CDA Online Navigator last updated:
+      August 2022.
     </div>
-	</div>
+  </div>
 
   <div class="container-fluid">
 
-    <h2 id="title">Operative Note Surgical Procedure Section <small class="text-muted">[section, 2.16.840.1.113883.10.20.7.14, open] <a href="../pdfs/2.16.840.1.113883.10.20.7.14.pdf"><i class="fas fa-file-pdf"></i> view pdf</a></small></h2>
+    <h2 id="title">Operative Note Surgical Procedure Section <small class="text-muted">[section,
+        2.16.840.1.113883.10.20.7.14, open] <a href="../pdfs/2.16.840.1.113883.10.20.7.14.pdf"><i
+            class="fas fa-file-pdf"></i> view pdf</a></small></h2>
     <hr>
     <h4>
       Description:
     </h4>
 
-    <div id="description"><p>The Operative Note Surgical Procedure Section can be used to restate the procedures performed if appropriate for an enterprise workflow. The procedure(s) performed associated with the Operative Note are formally modeled in the header using serviceEvent.</p></div>
+    <div id="description">
+      <p>The Operative Note Surgical Procedure Section can be used to restate the procedures performed if appropriate
+        for an enterprise workflow. The procedure(s) performed associated with the Operative Note are formally modeled
+        in the header using serviceEvent.</p>
+    </div>
 
     <table class="table">
       <thead>
-        <tr><th>Contained By:</th>
-        <th>Contains:</th>
-      </tr></thead>
+        <tr>
+          <th>Contained By:</th>
+          <th>Contains:</th>
+        </tr>
+      </thead>
       <tbody>
-        <tr><td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
-        <td id="Contains">none</td>
-      </tr></tbody>
+        <tr>
+          <td id="Contained_By"><a href="2.16.840.1.113883.10.20.22.1.7.html">Operative Note (V3)</a><br></td>
+          <td id="Contains">none</td>
+        </tr>
+      </tbody>
     </table>
     <h4>
       Conformance Statements:
     </h4>
-    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html" target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html" target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS login</a></i>
-    <ul id="conformance" class="list-group"><li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8034)</b> such that it<ul><li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.7.14"</b><b> (CONF:81-10464)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15393)</b>.<ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10223-6"</b> Operative Note Surgical Procedure<b> (CONF:81-15394)</b>.</li></ul><ul><li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b> (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26487)</b>.</li></ul></li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8036)</b>.</li>
-<li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8037)</b>.</li>
-<li class="list-group-item"> <p>If the surgical procedure section is present there SHALL be text indicating the procedure performed (CONF:81-8054).</p></li>
-</ul>
+    <i>HL7 Code Systems are available <a href="https://terminology.hl7.org/codesystems-cda.html"
+        target="_blank">here</a>. HL7 Value Sets are available <a href="https://terminology.hl7.org/valuesets-cda.html"
+        target="_blank">here</a>. Links to Value Set Authority Center (VSAC) are shown as hyperlinks <i
+        class="fas fa-external-link-alt"></i> and require <a href="https://uts.nlm.nih.gov/uts/" target="_blank">UMLS
+        login</a></i>
+    <ul id="conformance" class="list-group">
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>templateId</b><b> (CONF:81-8034)</b> such
+        that it<ul>
+          <li><b>SHALL</b> contain exactly one [1..1] <b>@root</b>=<b>"2.16.840.1.113883.10.20.7.14"</b><b>
+              (CONF:81-10464)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>code</b><b> (CONF:81-15393)</b>.<ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@code</b>=<b>"10223-6"</b> Operative Note Surgical
+            Procedure<b> (CONF:81-15394)</b>.</li>
+        </ul>
+        <ul>
+          <li>This code <b>SHALL</b> contain exactly one [1..1] <b>@codeSystem</b>=<b>"2.16.840.1.113883.6.1"</b>
+            (CodeSystem: <b>LOINC 2.16.840.1.113883.6.1</b>)<b> (CONF:81-26487)</b>.</li>
+        </ul>
+      </li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>title</b><b> (CONF:81-8036)</b>.</li>
+      <li class="list-group-item"> <b>SHALL</b> contain exactly one [1..1] <b>text</b><b> (CONF:81-8037)</b>.</li>
+      <li class="list-group-item">
+        <p>If the surgical procedure section is present there SHALL be text indicating the procedure performed
+          (CONF:81-8054).</p>
+      </li>
+    </ul>
     <br>
 
     <h4>
       Guide Examples:
     </h4>
-	<ul id="guide_examples"><li><a href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Operative%20Note%20Surgical%20Procedure%20Section_2.16.840.1.113883.10.20.7.14/Operative%20Note%20Surgical%20Procedure%20Section%20Example.xml"><i class="fab fa-github"></i>&nbsp;Operative Note Surgical Procedure Section Example</a></li></ul>
+    <ul id="guide_examples">
+      <li><a
+          href="https://github.com/HL7/C-CDA-Examples/blob/master/Guide%20Examples/Operative%20Note%20Surgical%20Procedure%20Section_2.16.840.1.113883.10.20.7.14/Operative%20Note%20Surgical%20Procedure%20Section%20Example.xml"><i
+            class="fab fa-github"></i>&nbsp;Operative Note Surgical Procedure Section Example</a></li>
+    </ul>
     <br>
 
-  <h4 id="cdasearch"></h4>
-  <ul id="cdasearch_examples">
+    <h4 id="cdasearch"></h4>
+    <ul id="cdasearch_examples">
 
-  </ul>
+    </ul>
 
-  <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png"></div>
-</body></html>
+    <hr /><br>To log an issue on C-CDA Standard, go to <a href="https://jira.hl7.org/projects/CDA/issues/">HL7 JIRA
+      Tracker</a> To report an issue with this webpage (but not underlying standard) please log in <a
+      href="https://github.com/jddamore/ccda-search/issues">C-CDA Search Github Repository</a><br /><br /><img
+      class="rounded float-left" style="max-width:10%" src="../img/hl7-logo.png">
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
This branch includes no content changes. 

Since the insertion of above text notes required significant custom code for extraction and insertion, the automatic process of generation from source is unlikely to be performed again for all templates (in addition, HL7 does not anticipate a main C-CDA update in PDF, just the Companion Guide). 

Consequently, formatting the HTML into a standard format (i.e. normalize line breaks and whitespace) makes for easier editing. This branch does just that and no content changes. 

